### PR TITLE
feat(hooks): add post-dispatch hooks for data manipulation before rendering

### DIFF
--- a/crates/outstanding-clap/Cargo.toml
+++ b/crates/outstanding-clap/Cargo.toml
@@ -18,8 +18,8 @@ anyhow = "1"
 clap = { version = "4", features = ["derive", "help"] }
 console = "0.15"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "2.0.17"
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive"] }
-serde_json = "1"

--- a/crates/outstanding-clap/docs/hooks.md
+++ b/crates/outstanding-clap/docs/hooks.md
@@ -5,12 +5,13 @@ Hooks allow you to run custom code before and after command handlers execute. Th
 - **Logging and metrics**: Record command execution times, log command invocations
 - **Clipboard operations**: Copy output to clipboard after command completes
 - **Output transformation**: Modify, filter, or enhance output before it's displayed
+- **Data validation and enrichment**: Validate or modify handler data before rendering
 - **Validation and access control**: Block commands based on conditions
 - **Side effects**: Write to files, send notifications, update state
 
 ## Hook Points
 
-There are two hook points in the command execution lifecycle:
+There are three hook points in the command execution lifecycle:
 
 ### Pre-dispatch
 
@@ -20,7 +21,7 @@ Runs **before** the command handler is invoked. Pre-dispatch hooks receive the `
 - Abort execution by returning an error
 - Log or record the command being executed
 
-```
+```rust
 Hooks::new().pre_dispatch(|_m, ctx| {
     println!("Running command: {:?}", ctx.command_path);
 
@@ -33,6 +34,34 @@ Hooks::new().pre_dispatch(|_m, ctx| {
 })
 ```
 
+### Post-dispatch
+
+Runs **after** the command handler has executed but **before** the output is rendered. Post-dispatch hooks receive the raw handler result as a `serde_json::Value`, and can:
+
+- Inspect or validate the data
+- Add or modify fields before rendering
+- Abort with an error if data is invalid
+
+```rust
+use serde_json::json;
+
+Hooks::new().post_dispatch(|_m, _ctx, mut data| {
+    // Add metadata before rendering
+    if let Some(obj) = data.as_object_mut() {
+        obj.insert("timestamp".into(), json!(chrono::Utc::now().to_rfc3339()));
+        obj.insert("processed".into(), json!(true));
+    }
+    Ok(data)
+})
+```
+
+Post-dispatch hooks are ideal for:
+
+- **Data enrichment**: Add computed fields, timestamps, metadata
+- **Validation**: Check data meets requirements before rendering
+- **Filtering**: Remove or redact sensitive fields
+- **Normalization**: Ensure consistent data structure
+
 ### Post-output
 
 Runs **after** the command handler has executed and output has been rendered. Post-output hooks receive the `CommandContext` and `Output`, and can:
@@ -42,7 +71,7 @@ Runs **after** the command handler has executed and output has been rendered. Po
 - Perform side effects (copy to clipboard, write to file)
 - Abort with an error if needed
 
-```
+```rust
 Hooks::new().post_output(|_m, _ctx, output| {
     // Copy text to clipboard (pseudo-code)
     if let Output::Text(ref text) = output {
@@ -52,6 +81,28 @@ Hooks::new().post_output(|_m, _ctx, output| {
     // Pass through unchanged (or return a modified Output)
     Ok(output)
 })
+```
+
+## Execution Flow
+
+The hooks execute in a specific order during command dispatch:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Command Dispatch                          │
+├─────────────────────────────────────────────────────────────┤
+│  1. Pre-dispatch hooks                                       │
+│     ↓ (can abort)                                           │
+│  2. Handler executes → returns data                         │
+│     ↓                                                        │
+│  3. Post-dispatch hooks (receive raw serde_json::Value)     │
+│     ↓ (can modify data or abort)                            │
+│  4. Render data using template                              │
+│     ↓                                                        │
+│  5. Post-output hooks (receive rendered Output)             │
+│     ↓ (can modify output or abort)                          │
+│  6. Return final output                                      │
+└─────────────────────────────────────────────────────────────┘
 ```
 
 ## Output Types
@@ -73,11 +124,26 @@ Post-output hooks can inspect and transform any output type.
 Multiple hooks at the same phase are chained and run in registration order:
 
 - **Pre-dispatch**: All hooks run sequentially. If any returns an error, execution stops.
+- **Post-dispatch**: Each hook receives the data from the previous hook. Transformations chain together.
 - **Post-output**: Each hook receives the output from the previous hook. Transformations chain together.
 
 ```rust
+use serde_json::json;
+
 Hooks::new()
-    // First: add a prefix
+    // Pre-dispatch: validate before running
+    .pre_dispatch(|_m, ctx| {
+        println!("Running: {:?}", ctx.command_path);
+        Ok(())
+    })
+    // Post-dispatch: enrich data before rendering
+    .post_dispatch(|_m, _ctx, mut data| {
+        if let Some(obj) = data.as_object_mut() {
+            obj.insert("enriched".into(), json!(true));
+        }
+        Ok(data)
+    })
+    // Post-output: transform rendered text
     .post_output(|_m, _ctx, output| {
         if let Output::Text(text) = output {
             Ok(Output::Text(format!("[INFO] {}", text)))
@@ -85,15 +151,7 @@ Hooks::new()
             Ok(output)
         }
     })
-    // Second: convert to uppercase
-    .post_output(|_m, _ctx, output| {
-        if let Output::Text(text) = output {
-            Ok(Output::Text(text.to_uppercase()))
-        } else {
-            Ok(output)
-        }
-    })
-    // Third: copy to clipboard
+    // Post-output: copy to clipboard
     .post_output(|_m, _ctx, output| {
         if let Output::Text(ref text) = output {
             // clipboard::copy(text)?;
@@ -102,8 +160,6 @@ Hooks::new()
     })
 ```
 
-With input "hello", this produces: `[INFO] HELLO`
-
 ## Usage with Declarative API
 
 Register hooks per-command using the `.hooks()` builder method:
@@ -111,6 +167,7 @@ Register hooks per-command using the `.hooks()` builder method:
 ```rust
 use outstanding_clap::{Outstanding, CommandResult, Hooks, Output, HookError};
 use serde::Serialize;
+use serde_json::json;
 
 #[derive(Serialize)]
 struct ListOutput {
@@ -129,6 +186,15 @@ Outstanding::builder()
         .pre_dispatch(|_m, _ctx| {
             println!("Listing items...");
             Ok(())
+        })
+        .post_dispatch(|_m, _ctx, mut data| {
+            // Add item count before rendering
+            if let Some(items) = data.get("items").and_then(|v| v.as_array()) {
+                if let Some(obj) = data.as_object_mut() {
+                    obj.insert("count".into(), json!(items.len()));
+                }
+            }
+            Ok(data)
         })
         .post_output(copy_to_clipboard))
     .command("export", export_handler, "")
@@ -151,13 +217,14 @@ Use dot notation for nested command paths:
 Outstanding::builder()
     .command("config.get", config_get_handler, "{{ value }}")
     .hooks("config.get", Hooks::new()
-        .post_output(|_m, _ctx, output| {
-            // Mask sensitive values
-            if let Output::Text(_) = output {
-                Ok(Output::Text("***".into()))
-            } else {
-                Ok(output)
+        .post_dispatch(|_m, _ctx, mut data| {
+            // Redact sensitive values in the data
+            if let Some(obj) = data.as_object_mut() {
+                if let Some(v) = obj.get_mut("value") {
+                    *v = json!("***");
+                }
             }
+            Ok(data)
         }))
 ```
 
@@ -171,6 +238,10 @@ use outstanding_clap::{Outstanding, Hooks, CommandResult, Output};
 // Build Outstanding with hooks
 let outstanding = Outstanding::builder()
     .hooks("list", Hooks::new()
+        .post_dispatch(|_m, _ctx, data| {
+            // Validate data before rendering
+            Ok(data)
+        })
         .post_output(copy_to_clipboard))
     .build();
 
@@ -209,6 +280,14 @@ Hooks::new().pre_dispatch(|_m, _ctx| {
     Err(HookError::pre_dispatch("access denied"))
 })
 
+// Post-dispatch error
+Hooks::new().post_dispatch(|_m, _ctx, data| {
+    if data.get("items").and_then(|v| v.as_array()).map(|a| a.is_empty()) == Some(true) {
+        return Err(HookError::post_dispatch("no items to display"));
+    }
+    Ok(data)
+})
+
 // Post-output error
 Hooks::new().post_output(|_m, _ctx, _output| {
     Err(HookError::post_output("clipboard operation failed"))
@@ -218,17 +297,19 @@ Hooks::new().post_output(|_m, _ctx, _output| {
 The error message includes the phase where the error occurred:
 ```
 Hook error (pre-dispatch): access denied
+Hook error (post-dispatch): no items to display
 Hook error (post-output): clipboard operation failed
 ```
 
 ## Best Practices
 
 1. **Keep hooks focused**: Each hook should do one thing well
-2. **Handle all output types**: Check for `Text`, `Binary`, and `Silent` variants
-3. **Preserve output when possible**: Return `Ok(output)` unchanged if not transforming
+2. **Handle all output types**: Check for `Text`, `Binary`, and `Silent` variants in post-output hooks
+3. **Preserve data/output when possible**: Return `Ok(data)` or `Ok(output)` unchanged if not transforming
 4. **Use pre-dispatch for validation**: Fail fast before the handler runs
-5. **Use post-output for side effects**: Logging, clipboard, file writes, etc.
-6. **Chain transformations logically**: Order matters for post-output hooks
+5. **Use post-dispatch for data manipulation**: Enrich, validate, or filter data before rendering
+6. **Use post-output for side effects**: Logging, clipboard, file writes, etc.
+7. **Chain transformations logically**: Order matters for all hook types
 
 ## API Reference
 

--- a/crates/outstanding-clap/src/dispatch.rs
+++ b/crates/outstanding-clap/src/dispatch.rs
@@ -6,6 +6,7 @@ use clap::ArgMatches;
 use std::sync::Arc;
 
 use crate::handler::CommandContext;
+use crate::hooks::Hooks;
 
 /// Internal result type for dispatch functions.
 pub(crate) enum DispatchOutput {
@@ -19,9 +20,13 @@ pub(crate) enum DispatchOutput {
 
 /// Type-erased dispatch function.
 ///
-/// Takes ArgMatches and CommandContext, returns the dispatch output or an error.
-pub(crate) type DispatchFn =
-    Arc<dyn Fn(&ArgMatches, &CommandContext) -> Result<DispatchOutput, String> + Send + Sync>;
+/// Takes ArgMatches, CommandContext, and optional Hooks. The hooks parameter
+/// allows post-dispatch hooks to run between handler execution and rendering.
+pub(crate) type DispatchFn = Arc<
+    dyn Fn(&ArgMatches, &CommandContext, Option<&Hooks>) -> Result<DispatchOutput, String>
+        + Send
+        + Sync,
+>;
 
 /// Extracts the command path from ArgMatches by following subcommand chain.
 pub(crate) fn extract_command_path(matches: &ArgMatches) -> Vec<String> {


### PR DESCRIPTION
## Summary

- Adds a new **post-dispatch** hook phase that runs after command handler execution but before output rendering
- Post-dispatch hooks receive the raw handler result as `serde_json::Value`, enabling inspection, modification, or replacement of data before rendering
- Completes the planned hook system from PR #12 (pre-dispatch ✓, post-dispatch ✓, post-output ✓)

## Changes

### Core Implementation
- `HookPhase::PostDispatch` variant for error tracking
- `PostDispatchFn` type alias: `Fn(&ArgMatches, &CommandContext, serde_json::Value) -> Result<serde_json::Value, HookError>`
- `Hooks::post_dispatch()` builder method for registering hooks
- `run_post_dispatch()` execution method on `Hooks`
- `HookError::post_dispatch()` factory method

### Integration
- Updated `DispatchFn` signature to accept optional `&Hooks` parameter
- Integrated post-dispatch hooks in `OutstandingBuilder::dispatch()` flow
- Integrated post-dispatch hooks in `Outstanding::run_command()` flow
- Added `serde_json` as a regular dependency (was dev-only)

### Documentation
- Updated module-level docs in `hooks.rs`
- Updated `docs/hooks.md` with comprehensive post-dispatch documentation
- Updated `README.md` with post-dispatch example
- Updated `CHANGELOG.md` with feature description and example

## Use Cases

- **Data enrichment**: Add computed fields, timestamps, metadata
- **Validation**: Check data meets requirements before rendering  
- **Filtering**: Remove or redact sensitive fields
- **Normalization**: Ensure consistent data structure

## Execution Flow

```
1. Pre-dispatch hooks (can abort)
2. Handler executes → returns data
3. Post-dispatch hooks (receive serde_json::Value, can modify or abort)
4. Render data using template
5. Post-output hooks (receive Output, can modify or abort)
6. Return final output
```

## Test plan

- [x] Unit tests for `post_dispatch` builder method
- [x] Unit tests for `run_post_dispatch` execution
- [x] Unit tests for chained post-dispatch hooks
- [x] Unit tests for post-dispatch error handling
- [x] Integration tests in `outstanding.rs` for dispatch flow
- [x] Integration tests for `run_command` with post-dispatch
- [x] Test for all three hooks executing in correct order
- [x] All 308 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)