### PR TITLE
Fix LocalApp template includes support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **LocalApp now supports `{% include %}` directives** - Template includes now work correctly in LocalApp when a template registry is configured via `.templates()`. Previously, inline templates in LocalApp could not resolve `{% include %}` directives because the MiniJinja environment was created with only the single inline template. Now, when a template registry is provided, all templates from the registry are loaded into the environment, enabling full template composition.
+
+  **Example:**
+  ```rust
+  use standout::cli::{LocalApp, Output};
+  use standout::embed_templates;
+
+  LocalApp::builder()
+      .templates(embed_templates!("src/templates"))  // Contains _header.jinja
+      .command("show", |_m, _ctx| {
+          Ok(Output::Render(json!({"title": "Hello"})))
+      }, "{% include '_header' %}\n{{ content }}")  // Now works!
+      .build()?
+      .run(cmd, args);
+  ```
+
+### Added
+
+- **`render_auto_with_registry` function** - New rendering function that accepts an optional `TemplateRegistry` parameter for include support. This is the most complete rendering function, supporting auto-dispatch, context injection, and template includes.
+
 ## [1.1.0] - 2026-01-18
 
 ### Added

--- a/crates/standout/src/lib.rs
+++ b/crates/standout/src/lib.rs
@@ -252,6 +252,7 @@ pub use rendering::template::{
     render,
     render_auto,
     render_auto_with_context,
+    render_auto_with_registry,
     render_auto_with_spec,
     render_with_context,
     render_with_mode,

--- a/crates/standout/src/rendering/template/mod.rs
+++ b/crates/standout/src/rendering/template/mod.rs
@@ -80,8 +80,9 @@ pub mod registry;
 mod renderer;
 
 pub use functions::{
-    render, render_auto, render_auto_with_context, render_auto_with_spec, render_with_context,
-    render_with_mode, render_with_output, render_with_vars, validate_template,
+    render, render_auto, render_auto_with_context, render_auto_with_registry,
+    render_auto_with_spec, render_with_context, render_with_mode, render_with_output,
+    render_with_vars, validate_template,
 };
 pub use registry::{
     walk_template_dir, RegistryError, ResolvedTemplate, TemplateFile, TemplateRegistry,


### PR DESCRIPTION
## Summary

- Fix `{% include %}` directives not working in LocalApp inline templates
- Add new `render_auto_with_registry()` function that accepts an optional template registry
- LocalApp now properly loads all templates from the registry into the MiniJinja environment

## Problem

LocalApp inline templates could not use `{% include %}` directives because the MiniJinja environment was created with only the single inline template. When a user tried to use includes, they would fail to resolve.

## Solution

- Added `render_auto_with_registry()` function that accepts an optional `TemplateRegistry`
- Updated `LocalCommandRecipe::create_dispatch()` to accept and use the template registry
- Used `Arc<TemplateRegistry>` to share the registry efficiently across commands
- When rendering, all templates from the registry are now loaded into the MiniJinja environment, enabling `{% include "partial" %}` directives to resolve correctly

## Test plan

- [x] Added `test_local_app_template_includes` - verifies `{% include %}` works with registry
- [x] Added `test_local_app_without_registry_still_works` - verifies backward compatibility
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)