### PR TITLE
feat(dispatch): Auto-wrap Result<T> returns in Output::Render

### DIFF
--- a/crates/standout-dispatch/src/handler.rs
+++ b/crates/standout-dispatch/src/handler.rs
@@ -373,6 +373,60 @@ impl<T: Serialize> Output<T> {
 /// Enables use of the `?` operator for error propagation.
 pub type HandlerResult<T> = Result<Output<T>, anyhow::Error>;
 
+/// Trait for types that can be converted into a [`HandlerResult`].
+///
+/// This enables handlers to return either `Result<T, E>` directly (auto-wrapped
+/// in [`Output::Render`]) or the explicit [`HandlerResult<T>`] when fine-grained
+/// control is needed (for [`Output::Silent`] or [`Output::Binary`]).
+///
+/// # Example
+///
+/// ```rust
+/// use standout_dispatch::{HandlerResult, Output, IntoHandlerResult};
+///
+/// // Direct Result<T, E> is auto-wrapped in Output::Render
+/// fn simple() -> Result<String, anyhow::Error> {
+///     Ok("hello".to_string())
+/// }
+/// let result: HandlerResult<String> = simple().into_handler_result();
+/// assert!(matches!(result, Ok(Output::Render(_))));
+///
+/// // HandlerResult<T> passes through unchanged
+/// fn explicit() -> HandlerResult<String> {
+///     Ok(Output::Silent)
+/// }
+/// let result: HandlerResult<String> = explicit().into_handler_result();
+/// assert!(matches!(result, Ok(Output::Silent)));
+/// ```
+pub trait IntoHandlerResult<T: Serialize> {
+    /// Convert this type into a [`HandlerResult<T>`].
+    fn into_handler_result(self) -> HandlerResult<T>;
+}
+
+/// Implementation for `Result<T, E>` - auto-wraps successful values in [`Output::Render`].
+///
+/// This is the ergonomic path: handlers can return `Result<T, E>` directly
+/// and the framework wraps it appropriately.
+impl<T, E> IntoHandlerResult<T> for Result<T, E>
+where
+    T: Serialize,
+    E: Into<anyhow::Error>,
+{
+    fn into_handler_result(self) -> HandlerResult<T> {
+        self.map(Output::Render).map_err(Into::into)
+    }
+}
+
+/// Implementation for `HandlerResult<T>` - passes through unchanged.
+///
+/// This is the explicit path: handlers that need [`Output::Silent`] or
+/// [`Output::Binary`] can return `HandlerResult<T>` directly.
+impl<T: Serialize> IntoHandlerResult<T> for HandlerResult<T> {
+    fn into_handler_result(self) -> HandlerResult<T> {
+        self
+    }
+}
+
 /// Result of running the CLI dispatcher.
 ///
 /// After processing arguments, the dispatcher either handles a command
@@ -442,18 +496,39 @@ pub trait Handler: Send + Sync {
 }
 
 /// A wrapper that implements Handler for closures.
-pub struct FnHandler<F, T>
+///
+/// The closure can return either:
+/// - `Result<T, E>` - automatically wrapped in [`Output::Render`]
+/// - `HandlerResult<T>` - passed through unchanged (for [`Output::Silent`] or [`Output::Binary`])
+///
+/// # Example
+///
+/// ```rust
+/// use standout_dispatch::{FnHandler, Handler, CommandContext, Output};
+/// use clap::ArgMatches;
+///
+/// // Returning Result<T, E> directly (auto-wrapped)
+/// let handler = FnHandler::new(|_m: &ArgMatches, _ctx: &CommandContext| {
+///     Ok::<_, anyhow::Error>("hello".to_string())
+/// });
+///
+/// // Returning HandlerResult<T> explicitly (for Silent/Binary)
+/// let silent_handler = FnHandler::new(|_m: &ArgMatches, _ctx: &CommandContext| {
+///     Ok(Output::<()>::Silent)
+/// });
+/// ```
+pub struct FnHandler<F, T, R = HandlerResult<T>>
 where
-    F: Fn(&ArgMatches, &CommandContext) -> HandlerResult<T> + Send + Sync,
     T: Serialize + Send + Sync,
 {
     f: F,
-    _phantom: std::marker::PhantomData<fn() -> T>,
+    _phantom: std::marker::PhantomData<fn() -> (T, R)>,
 }
 
-impl<F, T> FnHandler<F, T>
+impl<F, T, R> FnHandler<F, T, R>
 where
-    F: Fn(&ArgMatches, &CommandContext) -> HandlerResult<T> + Send + Sync,
+    F: Fn(&ArgMatches, &CommandContext) -> R + Send + Sync,
+    R: IntoHandlerResult<T>,
     T: Serialize + Send + Sync,
 {
     /// Creates a new FnHandler wrapping the given closure.
@@ -465,15 +540,16 @@ where
     }
 }
 
-impl<F, T> Handler for FnHandler<F, T>
+impl<F, T, R> Handler for FnHandler<F, T, R>
 where
-    F: Fn(&ArgMatches, &CommandContext) -> HandlerResult<T> + Send + Sync,
+    F: Fn(&ArgMatches, &CommandContext) -> R + Send + Sync,
+    R: IntoHandlerResult<T>,
     T: Serialize + Send + Sync,
 {
     type Output = T;
 
     fn handle(&self, matches: &ArgMatches, ctx: &CommandContext) -> HandlerResult<T> {
-        (self.f)(matches, ctx)
+        (self.f)(matches, ctx).into_handler_result()
     }
 }
 
@@ -493,18 +569,38 @@ pub trait LocalHandler {
 }
 
 /// A wrapper that implements LocalHandler for FnMut closures.
-pub struct LocalFnHandler<F, T>
+///
+/// Similar to [`FnHandler`], but:
+/// - Does NOT require `Send + Sync`
+/// - Takes `FnMut` instead of `Fn` (allows mutation)
+///
+/// The closure can return either:
+/// - `Result<T, E>` - automatically wrapped in [`Output::Render`]
+/// - `HandlerResult<T>` - passed through unchanged (for [`Output::Silent`] or [`Output::Binary`])
+///
+/// # Example
+///
+/// ```rust
+/// use standout_dispatch::{LocalFnHandler, LocalHandler, CommandContext, Output};
+/// use clap::ArgMatches;
+///
+/// // Returning Result<T, E> directly (auto-wrapped)
+/// let mut handler = LocalFnHandler::new(|_m: &ArgMatches, _ctx: &CommandContext| {
+///     Ok::<_, anyhow::Error>("hello".to_string())
+/// });
+/// ```
+pub struct LocalFnHandler<F, T, R = HandlerResult<T>>
 where
-    F: FnMut(&ArgMatches, &CommandContext) -> HandlerResult<T>,
     T: Serialize,
 {
     f: F,
-    _phantom: std::marker::PhantomData<fn() -> T>,
+    _phantom: std::marker::PhantomData<fn() -> (T, R)>,
 }
 
-impl<F, T> LocalFnHandler<F, T>
+impl<F, T, R> LocalFnHandler<F, T, R>
 where
-    F: FnMut(&ArgMatches, &CommandContext) -> HandlerResult<T>,
+    F: FnMut(&ArgMatches, &CommandContext) -> R,
+    R: IntoHandlerResult<T>,
     T: Serialize,
 {
     /// Creates a new LocalFnHandler wrapping the given FnMut closure.
@@ -516,15 +612,16 @@ where
     }
 }
 
-impl<F, T> LocalHandler for LocalFnHandler<F, T>
+impl<F, T, R> LocalHandler for LocalFnHandler<F, T, R>
 where
-    F: FnMut(&ArgMatches, &CommandContext) -> HandlerResult<T>,
+    F: FnMut(&ArgMatches, &CommandContext) -> R,
+    R: IntoHandlerResult<T>,
     T: Serialize,
 {
     type Output = T;
 
     fn handle(&mut self, matches: &ArgMatches, ctx: &CommandContext) -> HandlerResult<T> {
-        (self.f)(matches, ctx)
+        (self.f)(matches, ctx).into_handler_result()
     }
 }
 
@@ -886,5 +983,157 @@ mod tests {
         if let Ok(Output::Render(count)) = result {
             assert_eq!(count, 3);
         }
+    }
+
+    // IntoHandlerResult tests
+    #[test]
+    fn test_into_handler_result_from_result_ok() {
+        use super::IntoHandlerResult;
+
+        let result: Result<String, anyhow::Error> = Ok("hello".to_string());
+        let handler_result = result.into_handler_result();
+
+        assert!(handler_result.is_ok());
+        match handler_result.unwrap() {
+            Output::Render(s) => assert_eq!(s, "hello"),
+            _ => panic!("Expected Output::Render"),
+        }
+    }
+
+    #[test]
+    fn test_into_handler_result_from_result_err() {
+        use super::IntoHandlerResult;
+
+        let result: Result<String, anyhow::Error> = Err(anyhow::anyhow!("test error"));
+        let handler_result = result.into_handler_result();
+
+        assert!(handler_result.is_err());
+        assert!(handler_result
+            .unwrap_err()
+            .to_string()
+            .contains("test error"));
+    }
+
+    #[test]
+    fn test_into_handler_result_passthrough_render() {
+        use super::IntoHandlerResult;
+
+        let handler_result: HandlerResult<String> = Ok(Output::Render("hello".to_string()));
+        let result = handler_result.into_handler_result();
+
+        assert!(result.is_ok());
+        match result.unwrap() {
+            Output::Render(s) => assert_eq!(s, "hello"),
+            _ => panic!("Expected Output::Render"),
+        }
+    }
+
+    #[test]
+    fn test_into_handler_result_passthrough_silent() {
+        use super::IntoHandlerResult;
+
+        let handler_result: HandlerResult<String> = Ok(Output::Silent);
+        let result = handler_result.into_handler_result();
+
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), Output::Silent));
+    }
+
+    #[test]
+    fn test_into_handler_result_passthrough_binary() {
+        use super::IntoHandlerResult;
+
+        let handler_result: HandlerResult<String> = Ok(Output::Binary {
+            data: vec![1, 2, 3],
+            filename: "test.bin".to_string(),
+        });
+        let result = handler_result.into_handler_result();
+
+        assert!(result.is_ok());
+        match result.unwrap() {
+            Output::Binary { data, filename } => {
+                assert_eq!(data, vec![1, 2, 3]);
+                assert_eq!(filename, "test.bin");
+            }
+            _ => panic!("Expected Output::Binary"),
+        }
+    }
+
+    #[test]
+    fn test_fn_handler_with_auto_wrap() {
+        // Handler that returns Result<T, E> directly (not HandlerResult)
+        let handler = FnHandler::new(|_m: &ArgMatches, _ctx: &CommandContext| {
+            Ok::<_, anyhow::Error>("auto-wrapped".to_string())
+        });
+
+        let ctx = CommandContext::default();
+        let matches = clap::Command::new("test").get_matches_from(vec!["test"]);
+
+        let result = handler.handle(&matches, &ctx);
+        assert!(result.is_ok());
+        match result.unwrap() {
+            Output::Render(s) => assert_eq!(s, "auto-wrapped"),
+            _ => panic!("Expected Output::Render"),
+        }
+    }
+
+    #[test]
+    fn test_fn_handler_with_explicit_output() {
+        // Handler that returns HandlerResult directly (for Silent/Binary)
+        let handler =
+            FnHandler::new(|_m: &ArgMatches, _ctx: &CommandContext| Ok(Output::<()>::Silent));
+
+        let ctx = CommandContext::default();
+        let matches = clap::Command::new("test").get_matches_from(vec!["test"]);
+
+        let result = handler.handle(&matches, &ctx);
+        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), Output::Silent));
+    }
+
+    #[test]
+    fn test_local_fn_handler_with_auto_wrap() {
+        let mut handler = LocalFnHandler::new(|_m: &ArgMatches, _ctx: &CommandContext| {
+            Ok::<_, anyhow::Error>(42i32)
+        });
+
+        let ctx = CommandContext::default();
+        let matches = clap::Command::new("test").get_matches_from(vec!["test"]);
+
+        let result = handler.handle(&matches, &ctx);
+        assert!(result.is_ok());
+        match result.unwrap() {
+            Output::Render(n) => assert_eq!(n, 42),
+            _ => panic!("Expected Output::Render"),
+        }
+    }
+
+    #[test]
+    fn test_fn_handler_with_custom_error_type() {
+        // Custom error type that implements Into<anyhow::Error>
+        #[derive(Debug)]
+        struct CustomError(String);
+
+        impl std::fmt::Display for CustomError {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "CustomError: {}", self.0)
+            }
+        }
+
+        impl std::error::Error for CustomError {}
+
+        let handler = FnHandler::new(|_m: &ArgMatches, _ctx: &CommandContext| {
+            Err::<String, CustomError>(CustomError("oops".to_string()))
+        });
+
+        let ctx = CommandContext::default();
+        let matches = clap::Command::new("test").get_matches_from(vec!["test"]);
+
+        let result = handler.handle(&matches, &ctx);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("CustomError: oops"));
     }
 }

--- a/crates/standout-dispatch/src/lib.rs
+++ b/crates/standout-dispatch/src/lib.rs
@@ -133,8 +133,8 @@ pub use dispatch::{
 
 // Re-export handler types
 pub use handler::{
-    CommandContext, Extensions, FnHandler, Handler, HandlerResult, LocalFnHandler, LocalHandler,
-    Output, RunResult,
+    CommandContext, Extensions, FnHandler, Handler, HandlerResult, IntoHandlerResult,
+    LocalFnHandler, LocalHandler, Output, RunResult,
 };
 
 // Re-export hook types


### PR DESCRIPTION
## Summary

- Adds `IntoHandlerResult<T>` trait that enables handlers to return `Result<T, E>` directly
- Auto-wraps successful results in `Output::Render`, reducing boilerplate
- Existing `HandlerResult<T>` returns pass through unchanged (for `Output::Silent` or `Output::Binary`)
- Updates `FnHandler` and `LocalFnHandler` to use the new trait

## Before

```rust
fn list(m: &ArgMatches, ctx: &CommandContext) -> HandlerResult<Vec<Item>> {
    let items = storage::list()?;
    Ok(Output::Render(items))  // Framework ceremony
}
```

## After

```rust
fn list(m: &ArgMatches, ctx: &CommandContext) -> Result<Vec<Item>, Error> {
    storage::list()  // Clean and natural
}
```

## Test plan

- [x] Unit tests for `IntoHandlerResult` trait conversions
- [x] Tests for `FnHandler` with auto-wrap
- [x] Tests for `FnHandler` with explicit `HandlerResult` (passthrough)
- [x] Tests for `LocalFnHandler` with auto-wrap
- [x] Tests for custom error types that implement `Into<anyhow::Error>`
- [x] Full workspace test suite passes

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)