### PR TITLE
feat(dispatch): Make CommandContext optional in handler signatures

### DIFF
--- a/crates/standout-dispatch/src/lib.rs
+++ b/crates/standout-dispatch/src/lib.rs
@@ -134,7 +134,7 @@ pub use dispatch::{
 // Re-export handler types
 pub use handler::{
     CommandContext, Extensions, FnHandler, Handler, HandlerResult, IntoHandlerResult,
-    LocalFnHandler, LocalHandler, Output, RunResult,
+    LocalFnHandler, LocalHandler, LocalSimpleFnHandler, Output, RunResult, SimpleFnHandler,
 };
 
 // Re-export hook types


### PR DESCRIPTION
## Summary

- Adds `SimpleFnHandler` and `LocalSimpleFnHandler` for handlers that don't need `CommandContext`
- Adds `simple` attribute to the Dispatch derive macro
- Handlers using these types can return `Result<T, E>` directly (via `IntoHandlerResult` from #63)

## Before

```rust
fn list(_m: &ArgMatches, _ctx: &CommandContext) -> Result<Vec<Item>, Error> {
    //                   ^^^^
    // Unused but required
    storage::list()
}
```

## After

```rust
fn list(m: &ArgMatches) -> Result<Vec<Item>, Error> {
    storage::list()
}
```

## With Derive Macro

```rust
#[derive(Subcommand, Dispatch)]
#[dispatch(handlers = handlers)]
enum Commands {
    #[dispatch(simple)]  // Handler only takes &ArgMatches
    List,
}
```

## Test plan

- [x] Unit tests for `SimpleFnHandler` basic usage
- [x] Unit tests for `SimpleFnHandler` with explicit `Output` (Silent/Binary)
- [x] Unit tests for `LocalSimpleFnHandler` with mutation
- [x] Tests for auto-wrap via `IntoHandlerResult`
- [x] Full workspace test suite passes
- [x] Dispatch derive macro updated with `simple` attribute

## Dependencies

- Depends on #63 (feat/auto-wrap-result) for `IntoHandlerResult` trait

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)