### PR TITLE
feat: Strip ANSI codes from piped content for shell semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Piped content is now automatically plain text** - When using `pipe_to()`, `pipe_through()`, `pipe_to_clipboard()`, or custom `PipeTarget` implementations, ANSI escape codes are automatically stripped from the piped content. This matches standard shell semantics where `command | other_command` receives unformatted output.
+
+  ```rust
+  // Template with styled output
+  cfg.template("[bold]{{ title }}[/bold]: [green]{{ count }}[/green]")
+     .pipe_through("jq .")
+
+  // Terminal sees formatted output with colors
+  // jq receives plain text: "Report: 42"
+  ```
+
+  **Implementation details:**
+  - `TextOutput` struct now has both `formatted` (ANSI codes for terminal) and `raw` (plain text for piping) fields
+  - All piping methods use `raw` for external commands while returning `formatted` for terminal display
+  - Uses existing `OutputMode::Text` rendering path to strip style tags cleanly
+
 ## [3.7.0] - 2026-01-31
 
 ## [3.6.1] - 2026-01-31

--- a/crates/standout-dispatch/src/lib.rs
+++ b/crates/standout-dispatch/src/lib.rs
@@ -140,6 +140,7 @@ pub use handler::{
 // Re-export hook types
 pub use hooks::{
     HookError, HookPhase, Hooks, PostDispatchFn, PostOutputFn, PreDispatchFn, RenderedOutput,
+    TextOutput,
 };
 
 // Re-export render abstraction

--- a/crates/standout-render/src/template/mod.rs
+++ b/crates/standout-render/src/template/mod.rs
@@ -114,8 +114,9 @@ mod simple;
 
 pub use engine::{register_filters, MiniJinjaEngine, TemplateEngine};
 pub use functions::{
-    render, render_auto, render_auto_with_context, render_auto_with_engine, render_auto_with_spec,
-    render_with_context, render_with_mode, render_with_output, render_with_vars, validate_template,
+    apply_style_tags, render, render_auto, render_auto_with_context, render_auto_with_engine,
+    render_auto_with_engine_split, render_auto_with_spec, render_with_context, render_with_mode,
+    render_with_output, render_with_vars, validate_template, RenderResult,
 };
 pub use registry::{
     walk_template_dir, RegistryError, ResolvedTemplate, TemplateFile, TemplateRegistry,

--- a/crates/standout/src/cli/hooks.rs
+++ b/crates/standout/src/cli/hooks.rs
@@ -32,8 +32,9 @@
 //!         })
 //!         .post_output(|_m, _ctx, output| {
 //!             // Copy to clipboard (pseudo-code)
-//!             if let RenderedOutput::Text(ref text) = output {
-//!                 // clipboard::copy(text)?;
+//!             if let RenderedOutput::Text(ref text_output) = output {
+//!                 // Use text_output.raw for piping (no ANSI codes)
+//!                 // clipboard::copy(&text_output.raw)?;
 //!             }
 //!             Ok(output)
 //!         }))
@@ -48,6 +49,7 @@
 // These types are render-agnostic and focus on hook execution.
 pub use standout_dispatch::{
     HookError, HookPhase, Hooks, PostDispatchFn, PostOutputFn, PreDispatchFn, RenderedOutput,
+    TextOutput,
 };
 
 // Tests for these types are in the standout-dispatch crate.


### PR DESCRIPTION
## Summary

- Piped content now automatically has ANSI escape codes stripped, matching standard shell behavior
- When using `pipe_to()`, `pipe_through()`, `pipe_to_clipboard()`, or custom `PipeTarget`, the piped content is plain text
- Terminal display still shows rich formatting with colors

## Implementation

- Added `TextOutput` struct with `formatted` (ANSI codes) and `raw` (plain text) fields
- Added `render_auto_with_engine_split()` for two-output rendering  
- All piping methods now use `text_output.raw` for external commands
- Uses existing `OutputMode::Text` rendering path to strip style tags cleanly

## Test plan

- [x] Added 3 new tests verifying ANSI stripping behavior
- [x] Tests use `force_styling(true)` to ensure ANSI codes are generated even in test environment
- [x] All 10 piping integration tests pass
- [x] Full workspace test suite passes (1000+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)