### PR TITLE
Add subcommand group support in HelpConfig

### DIFF
--- a/crates/standout/src/cli/app.rs
+++ b/crates/standout/src/cli/app.rs
@@ -16,7 +16,7 @@ use super::dispatch::{
     dispatch, extract_command_path, get_deepest_matches, has_subcommand, insert_default_command,
     DispatchFn, DispatchOutput,
 };
-use super::help::{render_help, render_help_with_topics, HelpConfig};
+use super::help::{render_help, render_help_with_topics, CommandGroup, HelpConfig};
 use super::hooks::Hooks;
 use super::result::HelpResult;
 use crate::cli::handler::{CommandContext, HandlerResult, Output as HandlerOutput, RunResult};
@@ -65,6 +65,8 @@ pub struct App {
     pub(crate) commands: HashMap<String, DispatchFn>,
     /// Expected arguments for each command (for verification).
     pub(crate) expected_args: HashMap<String, Vec<ExpectedArg>>,
+    /// Command groups for organized help display.
+    pub(crate) help_command_groups: Option<Vec<CommandGroup>>,
 }
 
 impl App {
@@ -88,6 +90,7 @@ impl App {
             registry: TopicRegistry::new(),
             commands: HashMap::new(),
             expected_args: HashMap::new(),
+            help_command_groups: None,
         }
     }
 
@@ -98,6 +101,7 @@ impl App {
             registry,
             commands: HashMap::new(),
             expected_args: HashMap::new(),
+            help_command_groups: None,
         }
     }
 
@@ -549,6 +553,7 @@ impl App {
         let config = HelpConfig {
             output_mode: Some(output_mode),
             theme: self.core.theme().cloned(),
+            command_groups: self.help_command_groups.clone(),
             ..Default::default()
         };
 

--- a/crates/standout/src/cli/builder/config.rs
+++ b/crates/standout/src/cli/builder/config.rs
@@ -387,6 +387,40 @@ impl AppBuilder {
         self.include_framework_styles = include;
         self
     }
+
+    /// Sets command groups for organized help display.
+    ///
+    /// When set, subcommands in help output are organized into the specified
+    /// groups instead of a single "Commands" section. Commands not listed in
+    /// any group are auto-appended to an "Other" group.
+    ///
+    /// Use [`validate_command_groups`](crate::cli::validate_command_groups) in
+    /// a `#[test]` to catch typos and stale configs.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use standout::cli::{App, CommandGroup};
+    ///
+    /// App::builder()
+    ///     .command_groups(vec![
+    ///         CommandGroup {
+    ///             title: "Commands".into(),
+    ///             help: None,
+    ///             commands: vec![Some("init".into()), Some("list".into())],
+    ///         },
+    ///         CommandGroup {
+    ///             title: "Danger Zone".into(),
+    ///             help: Some("These commands are destructive.".into()),
+    ///             commands: vec![Some("delete".into()), Some("purge".into())],
+    ///         },
+    ///     ])
+    ///     .build()?;
+    /// ```
+    pub fn command_groups(mut self, groups: Vec<super::super::help::CommandGroup>) -> Self {
+        self.help_command_groups = Some(groups);
+        self
+    }
 }
 
 #[cfg(test)]

--- a/crates/standout/src/cli/builder/mod.rs
+++ b/crates/standout/src/cli/builder/mod.rs
@@ -43,6 +43,7 @@ use super::app::App;
 use super::dispatch::DispatchFn;
 use super::group::CommandRecipe;
 use super::handler::Extensions;
+use super::help::CommandGroup;
 use super::hooks::Hooks;
 
 /// Stores a pending command recipe along with its resolved template.
@@ -123,6 +124,9 @@ pub struct AppBuilder {
     ///
     /// If not provided, a default MiniJinja engine will be created.
     pub(crate) template_engine: Rc<Box<dyn standout_render::template::TemplateEngine>>,
+
+    /// Command groups for organized help display.
+    pub(crate) help_command_groups: Option<Vec<CommandGroup>>,
 }
 
 impl Default for AppBuilder {
@@ -156,6 +160,7 @@ impl AppBuilder {
             include_framework_styles: true,
             app_state: Rc::new(Extensions::new()),
             template_engine: Rc::new(Box::new(standout_render::template::MiniJinjaEngine::new())),
+            help_command_groups: None,
         }
     }
 
@@ -400,6 +405,7 @@ impl AppBuilder {
             registry: self.registry,
             commands,
             expected_args,
+            help_command_groups: self.help_command_groups,
         })
     }
 

--- a/crates/standout/src/cli/help/config.rs
+++ b/crates/standout/src/cli/help/config.rs
@@ -1,7 +1,28 @@
 //! Help rendering configuration.
 
+use crate::setup::SetupError;
 use crate::{OutputMode, Theme};
+use clap::Command;
 use console::Style;
+use std::collections::HashSet;
+
+/// Defines a group of subcommands for help display.
+///
+/// When provided via [`HelpConfig::command_groups`], subcommands are organized
+/// into named sections instead of appearing in a single "Commands" group.
+///
+/// Use `None` entries in [`commands`](CommandGroup::commands) to insert blank
+/// line separators for visual sub-grouping within a section.
+#[derive(Debug, Clone, Default)]
+pub struct CommandGroup {
+    /// Section header (e.g., "Commands", "Per Pad(s)").
+    pub title: String,
+    /// Optional help text displayed below the title, before the command list.
+    pub help: Option<String>,
+    /// Command names in display order.
+    /// Use `None` to insert a blank line separator between commands.
+    pub commands: Vec<Option<String>>,
+}
 
 /// Configuration for clap help rendering.
 #[derive(Debug, Clone, Default)]
@@ -12,6 +33,9 @@ pub struct HelpConfig {
     pub theme: Option<Theme>,
     /// Output mode. If None, uses Auto (auto-detects).
     pub output_mode: Option<OutputMode>,
+    /// Subcommand grouping for help display. If None, all subcommands
+    /// appear in a single "Commands" group (default behavior).
+    pub command_groups: Option<Vec<CommandGroup>>,
 }
 
 /// Returns the default theme for help rendering.
@@ -23,4 +47,135 @@ pub fn default_help_theme() -> Theme {
         .add("usage", Style::new())
         .add("example", Style::new())
         .add("about", Style::new())
+}
+
+/// Validates command groups against the actual clap Command tree.
+///
+/// Checks for phantom references: command names in groups that don't exist
+/// as subcommands in the Command. Ungrouped commands are OK — they will be
+/// auto-appended to an "Other" group at render time.
+///
+/// Call this from a `#[test]` to catch misconfigurations in CI.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// #[test]
+/// fn test_help_groups_match_commands() {
+///     let cmd = Cli::command();
+///     let groups = my_command_groups();
+///     validate_command_groups(&cmd, &groups).unwrap();
+/// }
+/// ```
+pub fn validate_command_groups(cmd: &Command, groups: &[CommandGroup]) -> Result<(), SetupError> {
+    let known: HashSet<&str> = cmd
+        .get_subcommands()
+        .filter(|s| !s.is_hide_set())
+        .map(|s| s.get_name())
+        .collect();
+
+    let mut phantoms = Vec::new();
+    for group in groups {
+        for name in group.commands.iter().flatten() {
+            if !known.contains(name.as_str()) {
+                phantoms.push(format!(
+                    "group \"{}\": command \"{}\" does not exist",
+                    group.title, name
+                ));
+            }
+        }
+    }
+
+    if phantoms.is_empty() {
+        Ok(())
+    } else {
+        Err(SetupError::Config(format!(
+            "command group validation failed:\n  {}",
+            phantoms.join("\n  ")
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_ok() {
+        let cmd = Command::new("root")
+            .subcommand(Command::new("init"))
+            .subcommand(Command::new("list"));
+
+        let groups = vec![CommandGroup {
+            title: "Main".into(),
+            help: None,
+            commands: vec![Some("init".into()), Some("list".into())],
+        }];
+
+        assert!(validate_command_groups(&cmd, &groups).is_ok());
+    }
+
+    #[test]
+    fn test_validate_phantom_reference() {
+        let cmd = Command::new("root").subcommand(Command::new("init"));
+
+        let groups = vec![CommandGroup {
+            title: "Main".into(),
+            help: None,
+            commands: vec![Some("init".into()), Some("nonexistent".into())],
+        }];
+
+        let err = validate_command_groups(&cmd, &groups).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("nonexistent"));
+        assert!(msg.contains("does not exist"));
+    }
+
+    #[test]
+    fn test_validate_ungrouped_commands_ok() {
+        let cmd = Command::new("root")
+            .subcommand(Command::new("init"))
+            .subcommand(Command::new("list"))
+            .subcommand(Command::new("extra"));
+
+        let groups = vec![CommandGroup {
+            title: "Main".into(),
+            help: None,
+            commands: vec![Some("init".into())],
+        }];
+
+        assert!(validate_command_groups(&cmd, &groups).is_ok());
+    }
+
+    #[test]
+    fn test_validate_with_separators() {
+        let cmd = Command::new("root")
+            .subcommand(Command::new("a"))
+            .subcommand(Command::new("b"));
+
+        let groups = vec![CommandGroup {
+            title: "Main".into(),
+            help: None,
+            commands: vec![Some("a".into()), None, Some("b".into())],
+        }];
+
+        assert!(validate_command_groups(&cmd, &groups).is_ok());
+    }
+
+    #[test]
+    fn test_validate_hidden_commands_not_checked() {
+        let cmd = Command::new("root")
+            .subcommand(Command::new("visible"))
+            .subcommand(Command::new("hidden").hide(true));
+
+        let groups = vec![CommandGroup {
+            title: "Main".into(),
+            help: None,
+            commands: vec![Some("visible".into()), Some("hidden".into())],
+        }];
+
+        let err = validate_command_groups(&cmd, &groups).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("hidden"));
+    }
 }

--- a/crates/standout/src/cli/help/data.rs
+++ b/crates/standout/src/cli/help/data.rs
@@ -5,6 +5,8 @@ use clap::Command;
 use serde::Serialize;
 use std::collections::BTreeMap;
 
+use super::config::CommandGroup;
+
 /// Fixed width for the name column in help output (commands, options, topics).
 pub(crate) const NAME_COLUMN_WIDTH: usize = 14;
 
@@ -22,6 +24,7 @@ pub(crate) struct HelpData {
 #[derive(Serialize)]
 pub(crate) struct Group<T> {
     pub title: Option<String>,
+    pub help: Option<String>,
     pub commands: Vec<T>,
     pub options: Vec<T>,
 }
@@ -31,6 +34,7 @@ pub(crate) struct Subcommand {
     pub name: String,
     pub about: String,
     pub padding: String,
+    pub separator: bool,
 }
 
 #[derive(Serialize)]
@@ -49,7 +53,10 @@ pub(crate) struct TopicListItem {
     pub padding: String,
 }
 
-pub(crate) fn extract_help_data(cmd: &Command) -> HelpData {
+pub(crate) fn extract_help_data(
+    cmd: &Command,
+    command_groups: Option<&[CommandGroup]>,
+) -> HelpData {
     let name = cmd.get_name().to_string();
     let about = cmd.get_about().map(|s| s.to_string()).unwrap_or_default();
     let usage = cmd
@@ -60,31 +67,14 @@ pub(crate) fn extract_help_data(cmd: &Command) -> HelpData {
         .unwrap_or(&cmd.clone().render_usage().to_string())
         .to_string();
 
-    // Group Subcommands
-    let mut sub_cmds = Vec::new();
+    // Collect visible subcommands
     let mut subs: Vec<_> = cmd.get_subcommands().filter(|s| !s.is_hide_set()).collect();
     subs.sort_by_key(|s| s.get_display_order());
 
-    for sub in subs {
-        let name = sub.get_name().to_string();
-        let pad = NAME_COLUMN_WIDTH.saturating_sub(name.len() + 1);
-
-        let sub_data = Subcommand {
-            name,
-            about: sub.get_about().map(|s| s.to_string()).unwrap_or_default(),
-            padding: " ".repeat(pad),
-        };
-        sub_cmds.push(sub_data);
-    }
-
-    let subcommands = if sub_cmds.is_empty() {
-        vec![]
+    let subcommands = if let Some(groups) = command_groups {
+        extract_grouped_subcommands(&subs, groups)
     } else {
-        vec![Group {
-            title: Some("Commands".to_string()),
-            commands: sub_cmds,
-            options: vec![],
-        }]
+        extract_default_subcommands(&subs)
     };
 
     // Group Options
@@ -124,6 +114,7 @@ pub(crate) fn extract_help_data(cmd: &Command) -> HelpData {
         .into_iter()
         .map(|(title, opts)| Group {
             title,
+            help: None,
             commands: vec![],
             options: opts,
         })
@@ -140,8 +131,115 @@ pub(crate) fn extract_help_data(cmd: &Command) -> HelpData {
     }
 }
 
-pub(crate) fn extract_help_data_with_topics(cmd: &Command, registry: &TopicRegistry) -> HelpData {
-    let mut data = extract_help_data(cmd);
+fn extract_default_subcommands(subs: &[&Command]) -> Vec<Group<Subcommand>> {
+    let sub_cmds: Vec<Subcommand> = subs
+        .iter()
+        .map(|sub| {
+            let name = sub.get_name().to_string();
+            let pad = NAME_COLUMN_WIDTH.saturating_sub(name.len() + 1);
+            Subcommand {
+                name,
+                about: sub.get_about().map(|s| s.to_string()).unwrap_or_default(),
+                padding: " ".repeat(pad),
+                separator: false,
+            }
+        })
+        .collect();
+
+    if sub_cmds.is_empty() {
+        vec![]
+    } else {
+        vec![Group {
+            title: Some("Commands".to_string()),
+            help: None,
+            commands: sub_cmds,
+            options: vec![],
+        }]
+    }
+}
+
+fn extract_grouped_subcommands(
+    subs: &[&Command],
+    groups: &[CommandGroup],
+) -> Vec<Group<Subcommand>> {
+    use std::collections::HashMap;
+
+    let mut sub_map: HashMap<&str, &Command> = subs.iter().map(|s| (s.get_name(), *s)).collect();
+    let mut result_groups: Vec<Group<Subcommand>> = Vec::new();
+
+    for group in groups {
+        let mut group_cmds = Vec::new();
+        for entry in &group.commands {
+            match entry {
+                None => {
+                    group_cmds.push(Subcommand {
+                        name: String::new(),
+                        about: String::new(),
+                        padding: String::new(),
+                        separator: true,
+                    });
+                }
+                Some(cmd_name) => {
+                    if let Some(sub) = sub_map.remove(cmd_name.as_str()) {
+                        let name = sub.get_name().to_string();
+                        let pad = NAME_COLUMN_WIDTH.saturating_sub(name.len() + 1);
+                        group_cmds.push(Subcommand {
+                            name,
+                            about: sub.get_about().map(|s| s.to_string()).unwrap_or_default(),
+                            padding: " ".repeat(pad),
+                            separator: false,
+                        });
+                    }
+                    // Unknown names silently skipped here.
+                    // validate_command_groups catches phantom references at test time.
+                }
+            }
+        }
+        if !group_cmds.is_empty() {
+            result_groups.push(Group {
+                title: Some(group.title.clone()),
+                help: group.help.clone(),
+                commands: group_cmds,
+                options: vec![],
+            });
+        }
+    }
+
+    // Ungrouped commands go to auto "Other" group
+    if !sub_map.is_empty() {
+        // Preserve display_order for remaining commands
+        let mut remaining: Vec<_> = sub_map.into_values().collect();
+        remaining.sort_by_key(|s| s.get_display_order());
+        let other_cmds: Vec<Subcommand> = remaining
+            .iter()
+            .map(|sub| {
+                let name = sub.get_name().to_string();
+                let pad = NAME_COLUMN_WIDTH.saturating_sub(name.len() + 1);
+                Subcommand {
+                    name,
+                    about: sub.get_about().map(|s| s.to_string()).unwrap_or_default(),
+                    padding: " ".repeat(pad),
+                    separator: false,
+                }
+            })
+            .collect();
+        result_groups.push(Group {
+            title: Some("Other".to_string()),
+            help: None,
+            commands: other_cmds,
+            options: vec![],
+        });
+    }
+
+    result_groups
+}
+
+pub(crate) fn extract_help_data_with_topics(
+    cmd: &Command,
+    registry: &TopicRegistry,
+    command_groups: Option<&[CommandGroup]>,
+) -> HelpData {
+    let mut data = extract_help_data(cmd, command_groups);
 
     let topics = registry.list_topics();
     if !topics.is_empty() {
@@ -169,7 +267,7 @@ mod tests {
     #[test]
     fn test_extract_basic() {
         let cmd = Command::new("test").about("A test command");
-        let data = extract_help_data(&cmd);
+        let data = extract_help_data(&cmd, None);
         assert_eq!(data.name, "test");
         assert_eq!(data.about, "A test command");
     }
@@ -180,7 +278,7 @@ mod tests {
             .subcommand(Command::new("sub1").about("Sub 1"))
             .subcommand(Command::new("sub2").about("Sub 2"));
 
-        let data = extract_help_data(&cmd);
+        let data = extract_help_data(&cmd, None);
         assert_eq!(data.subcommands.len(), 1);
         assert_eq!(data.subcommands[0].commands.len(), 2);
     }
@@ -191,7 +289,7 @@ mod tests {
             .subcommand(Command::new("Zoo"))
             .subcommand(Command::new("Air"));
 
-        let data = extract_help_data(&cmd);
+        let data = extract_help_data(&cmd, None);
         assert_eq!(data.subcommands[0].commands[0].name, "Zoo");
         assert_eq!(data.subcommands[0].commands[1].name, "Air");
     }
@@ -202,7 +300,7 @@ mod tests {
             .arg(Arg::new("opt1").long("opt1"))
             .arg(Arg::new("custom").long("custom").help_heading("Custom"));
 
-        let data = extract_help_data(&cmd);
+        let data = extract_help_data(&cmd, None);
         assert_eq!(data.options.len(), 2);
 
         let group1 = &data.options[0];
@@ -234,9 +332,108 @@ mod tests {
         }
 
         let cmd = Cli::command();
-        let data = extract_help_data(&cmd);
+        let data = extract_help_data(&cmd, None);
 
         assert_eq!(data.subcommands[0].commands[0].name, "second");
         assert_eq!(data.subcommands[0].commands[1].name, "first");
+    }
+
+    #[test]
+    fn test_extract_with_command_groups() {
+        let cmd = Command::new("root")
+            .disable_help_subcommand(true)
+            .subcommand(Command::new("init").about("Initialize"))
+            .subcommand(Command::new("list").about("List items"))
+            .subcommand(Command::new("delete").about("Delete items"))
+            .subcommand(Command::new("config").about("Configuration"));
+
+        let groups = vec![
+            CommandGroup {
+                title: "Main".into(),
+                help: None,
+                commands: vec![Some("init".into()), Some("list".into())],
+            },
+            CommandGroup {
+                title: "Danger".into(),
+                help: Some("Be careful with these.".into()),
+                commands: vec![Some("delete".into())],
+            },
+        ];
+
+        let data = extract_help_data(&cmd, Some(&groups));
+        assert_eq!(data.subcommands.len(), 3); // Main, Danger, Other (config is ungrouped)
+        assert_eq!(data.subcommands[0].title.as_deref(), Some("Main"));
+        assert_eq!(data.subcommands[0].commands.len(), 2);
+        assert_eq!(data.subcommands[0].commands[0].name, "init");
+        assert_eq!(data.subcommands[0].commands[1].name, "list");
+        assert_eq!(data.subcommands[1].title.as_deref(), Some("Danger"));
+        assert_eq!(
+            data.subcommands[1].help.as_deref(),
+            Some("Be careful with these.")
+        );
+        assert_eq!(data.subcommands[1].commands[0].name, "delete");
+        assert_eq!(data.subcommands[2].title.as_deref(), Some("Other"));
+        assert_eq!(data.subcommands[2].commands[0].name, "config");
+    }
+
+    #[test]
+    fn test_extract_with_separators() {
+        let cmd = Command::new("root")
+            .subcommand(Command::new("a").about("A"))
+            .subcommand(Command::new("b").about("B"))
+            .subcommand(Command::new("c").about("C"));
+
+        let groups = vec![CommandGroup {
+            title: "All".into(),
+            help: None,
+            commands: vec![
+                Some("a".into()),
+                None, // separator
+                Some("b".into()),
+                Some("c".into()),
+            ],
+        }];
+
+        let data = extract_help_data(&cmd, Some(&groups));
+        assert_eq!(data.subcommands.len(), 1);
+        let cmds = &data.subcommands[0].commands;
+        assert_eq!(cmds.len(), 4); // a, separator, b, c
+        assert!(!cmds[0].separator);
+        assert_eq!(cmds[0].name, "a");
+        assert!(cmds[1].separator);
+        assert!(!cmds[2].separator);
+        assert_eq!(cmds[2].name, "b");
+    }
+
+    #[test]
+    fn test_extract_all_grouped_no_other() {
+        let cmd = Command::new("root")
+            .subcommand(Command::new("a").about("A"))
+            .subcommand(Command::new("b").about("B"));
+
+        let groups = vec![CommandGroup {
+            title: "All".into(),
+            help: None,
+            commands: vec![Some("a".into()), Some("b".into())],
+        }];
+
+        let data = extract_help_data(&cmd, Some(&groups));
+        assert_eq!(data.subcommands.len(), 1); // No "Other" group
+        assert_eq!(data.subcommands[0].title.as_deref(), Some("All"));
+    }
+
+    #[test]
+    fn test_default_group_title_is_commands() {
+        let cmd = Command::new("root").subcommand(Command::new("foo").about("Foo"));
+
+        let data = extract_help_data(&cmd, None);
+        assert_eq!(data.subcommands[0].title.as_deref(), Some("Commands"));
+    }
+
+    #[test]
+    fn test_no_subcommands_empty_vec() {
+        let cmd = Command::new("root");
+        let data = extract_help_data(&cmd, None);
+        assert!(data.subcommands.is_empty());
     }
 }

--- a/crates/standout/src/cli/help/mod.rs
+++ b/crates/standout/src/cli/help/mod.rs
@@ -5,11 +5,13 @@
 //! - [`render_help`]: Render help for a command
 //! - [`render_help_with_topics`]: Render help with a "Learn More" section listing topics
 //! - [`HelpConfig`]: Configuration for help rendering
+//! - [`CommandGroup`]: Define subcommand groups for organized help display
+//! - [`validate_command_groups`]: Validate group config against a clap Command tree
 //! - [`default_help_theme`]: Returns the default theme for help
 
 mod config;
 pub(crate) mod data;
 mod render;
 
-pub use config::{default_help_theme, HelpConfig};
+pub use config::{default_help_theme, validate_command_groups, CommandGroup, HelpConfig};
 pub use render::{render_help, render_help_with_topics};

--- a/crates/standout/src/cli/help/render.rs
+++ b/crates/standout/src/cli/help/render.rs
@@ -18,7 +18,7 @@ pub fn render_help(cmd: &Command, config: Option<HelpConfig>) -> Result<String, 
     let theme = config.theme.unwrap_or_else(default_help_theme);
     let mode = config.output_mode.unwrap_or(OutputMode::Auto);
 
-    let data = extract_help_data(cmd);
+    let data = extract_help_data(cmd, config.command_groups.as_deref());
 
     render_with_output(template, &data, &theme, mode)
 }
@@ -38,7 +38,7 @@ pub fn render_help_with_topics(
     let theme = config.theme.unwrap_or_else(default_help_theme);
     let mode = config.output_mode.unwrap_or(OutputMode::Auto);
 
-    let data = extract_help_data_with_topics(cmd, registry);
+    let data = extract_help_data_with_topics(cmd, registry, config.command_groups.as_deref());
 
     render_with_output(template, &data, &theme, mode)
 }

--- a/crates/standout/src/cli/help/template.txt
+++ b/crates/standout/src/cli/help/template.txt
@@ -2,15 +2,20 @@
 
 [header]USAGE[/header]
   [usage]{{ usage }}[/usage]
-{%- if subcommands %}
-
-[header]COMMANDS[/header]
 {%- for group in subcommands %}
+
+[header]{{ group.title | upper }}[/header]
+{%- if group.help %}
+  [desc]{{ group.help }}[/desc]
+{% endif %}
 {%- for cmd in group.commands %}
+{%- if cmd.separator %}
+{{ "" }}
+{%- else %}
   [item]{{ cmd.name }}[/item]:{{ cmd.padding }}[desc]{{ cmd.about }}[/desc]
-{%- endfor %}
-{%- endfor %}
 {%- endif %}
+{%- endfor %}
+{%- endfor %}
 {%- if options %}
 
 [header]OPTIONS[/header]

--- a/crates/standout/src/cli/mod.rs
+++ b/crates/standout/src/cli/mod.rs
@@ -143,7 +143,10 @@ pub use group::{CommandConfig, GroupBuilder};
 pub use result::HelpResult;
 
 // Re-export help types
-pub use help::{default_help_theme, render_help, render_help_with_topics, HelpConfig};
+pub use help::{
+    default_help_theme, render_help, render_help_with_topics, validate_command_groups,
+    CommandGroup, HelpConfig,
+};
 
 // Re-export handler types
 pub use handler::{CommandContext, FnHandler, Handler, HandlerResult, Output, RunResult};

--- a/crates/standout/tests/help_command_groups.rs
+++ b/crates/standout/tests/help_command_groups.rs
@@ -1,0 +1,247 @@
+use clap::Command;
+use standout::cli::{render_help, validate_command_groups, CommandGroup, HelpConfig};
+use standout::OutputMode;
+
+#[test]
+fn test_grouped_help_renders_titles() {
+    let cmd = Command::new("myapp")
+        .about("My application")
+        .subcommand(Command::new("init").about("Initialize"))
+        .subcommand(Command::new("list").about("List items"))
+        .subcommand(Command::new("delete").about("Delete items"))
+        .subcommand(Command::new("config").about("Configuration"));
+
+    let config = HelpConfig {
+        output_mode: Some(OutputMode::Text),
+        command_groups: Some(vec![
+            CommandGroup {
+                title: "Commands".into(),
+                help: None,
+                commands: vec![Some("init".into()), Some("list".into())],
+            },
+            CommandGroup {
+                title: "Danger Zone".into(),
+                help: Some("These commands are destructive.".into()),
+                commands: vec![Some("delete".into())],
+            },
+        ]),
+        ..Default::default()
+    };
+
+    let output = render_help(&cmd, Some(config)).unwrap();
+
+    // Group titles appear uppercased
+    assert!(output.contains("COMMANDS"), "output:\n{output}");
+    assert!(output.contains("DANGER ZONE"), "output:\n{output}");
+
+    // Group help text renders
+    assert!(
+        output.contains("These commands are destructive."),
+        "output:\n{output}"
+    );
+
+    // Ungrouped command auto-appended to "Other"
+    assert!(output.contains("OTHER"), "output:\n{output}");
+    assert!(output.contains("config"), "output:\n{output}");
+
+    // Commands appear in the right order
+    assert!(output.contains("init"), "output:\n{output}");
+    assert!(output.contains("list"), "output:\n{output}");
+    assert!(output.contains("delete"), "output:\n{output}");
+}
+
+#[test]
+fn test_separators_produce_blank_lines() {
+    let cmd = Command::new("myapp")
+        .subcommand(Command::new("open").about("Open a pad"))
+        .subcommand(Command::new("view").about("View pads"))
+        .subcommand(Command::new("pin").about("Pin pads"))
+        .subcommand(Command::new("unpin").about("Unpin pads"));
+
+    let config = HelpConfig {
+        output_mode: Some(OutputMode::Text),
+        command_groups: Some(vec![CommandGroup {
+            title: "Per Pad".into(),
+            help: None,
+            commands: vec![
+                Some("open".into()),
+                Some("view".into()),
+                None, // separator
+                Some("pin".into()),
+                Some("unpin".into()),
+            ],
+        }]),
+        ..Default::default()
+    };
+
+    let output = render_help(&cmd, Some(config)).unwrap();
+
+    // All commands appear
+    assert!(output.contains("open"), "output:\n{output}");
+    assert!(output.contains("view"), "output:\n{output}");
+    assert!(output.contains("pin"), "output:\n{output}");
+    assert!(output.contains("unpin"), "output:\n{output}");
+
+    // The separator produces a blank line between "view" line and "pin" line
+    let lines: Vec<&str> = output.lines().collect();
+    let view_idx = lines.iter().position(|l| l.contains("view:")).unwrap();
+    let pin_idx = lines.iter().position(|l| l.contains("pin:")).unwrap();
+    // There should be a blank line between them
+    assert!(
+        pin_idx > view_idx + 1,
+        "Expected blank line separator between view and pin, lines:\n{}",
+        lines[view_idx..=pin_idx].join("\n")
+    );
+    let between_line = lines[view_idx + 1];
+    assert!(
+        between_line.trim().is_empty(),
+        "Expected empty line between view and pin, got: {:?}",
+        between_line
+    );
+}
+
+#[test]
+fn test_no_groups_backward_compat() {
+    let cmd = Command::new("myapp")
+        .about("My app")
+        .subcommand(Command::new("foo").about("Foo cmd"))
+        .subcommand(Command::new("bar").about("Bar cmd"));
+
+    let config = HelpConfig {
+        output_mode: Some(OutputMode::Text),
+        ..Default::default()
+    };
+
+    let output = render_help(&cmd, Some(config)).unwrap();
+
+    // Default "COMMANDS" header
+    assert!(output.contains("COMMANDS"), "output:\n{output}");
+    assert!(output.contains("foo"), "output:\n{output}");
+    assert!(output.contains("bar"), "output:\n{output}");
+
+    // No "OTHER" group when no groups are configured
+    assert!(!output.contains("OTHER"), "output:\n{output}");
+}
+
+#[test]
+fn test_all_grouped_no_other_section() {
+    let cmd = Command::new("myapp")
+        .subcommand(Command::new("a").about("A cmd"))
+        .subcommand(Command::new("b").about("B cmd"));
+
+    let config = HelpConfig {
+        output_mode: Some(OutputMode::Text),
+        command_groups: Some(vec![CommandGroup {
+            title: "Everything".into(),
+            help: None,
+            commands: vec![Some("a".into()), Some("b".into())],
+        }]),
+        ..Default::default()
+    };
+
+    let output = render_help(&cmd, Some(config)).unwrap();
+
+    assert!(output.contains("EVERYTHING"), "output:\n{output}");
+    assert!(!output.contains("OTHER"), "output:\n{output}");
+}
+
+#[test]
+fn test_validate_command_groups_passes_for_valid() {
+    let cmd = Command::new("myapp")
+        .subcommand(Command::new("init"))
+        .subcommand(Command::new("list"));
+
+    let groups = vec![CommandGroup {
+        title: "Main".into(),
+        help: None,
+        commands: vec![Some("init".into()), Some("list".into())],
+    }];
+
+    assert!(validate_command_groups(&cmd, &groups).is_ok());
+}
+
+#[test]
+fn test_validate_command_groups_fails_for_phantom() {
+    let cmd = Command::new("myapp")
+        .subcommand(Command::new("init"))
+        .subcommand(Command::new("list"));
+
+    let groups = vec![CommandGroup {
+        title: "Main".into(),
+        help: None,
+        commands: vec![Some("init".into()), Some("typo".into())],
+    }];
+
+    let err = validate_command_groups(&cmd, &groups).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("typo"), "error: {msg}");
+    assert!(msg.contains("does not exist"), "error: {msg}");
+}
+
+#[test]
+fn test_multiple_groups_preserve_order() {
+    let cmd = Command::new("myapp")
+        .subcommand(Command::new("z_last").about("Last"))
+        .subcommand(Command::new("a_first").about("First"))
+        .subcommand(Command::new("m_middle").about("Middle"));
+
+    let config = HelpConfig {
+        output_mode: Some(OutputMode::Text),
+        command_groups: Some(vec![
+            CommandGroup {
+                title: "Alpha".into(),
+                help: None,
+                commands: vec![Some("a_first".into())],
+            },
+            CommandGroup {
+                title: "Zeta".into(),
+                help: None,
+                commands: vec![Some("z_last".into())],
+            },
+        ]),
+        ..Default::default()
+    };
+
+    let output = render_help(&cmd, Some(config)).unwrap();
+
+    // Alpha group appears before Zeta group
+    let alpha_pos = output.find("ALPHA").unwrap();
+    let zeta_pos = output.find("ZETA").unwrap();
+    assert!(alpha_pos < zeta_pos, "output:\n{output}");
+
+    // Ungrouped m_middle goes to Other
+    let other_pos = output.find("OTHER").unwrap();
+    assert!(zeta_pos < other_pos, "output:\n{output}");
+    assert!(output.contains("m_middle"), "output:\n{output}");
+}
+
+#[test]
+fn test_group_help_text_renders_below_title() {
+    let cmd = Command::new("myapp")
+        .subcommand(Command::new("view").about("View pads"))
+        .subcommand(Command::new("edit").about("Edit pads"));
+
+    let config = HelpConfig {
+        output_mode: Some(OutputMode::Text),
+        command_groups: Some(vec![CommandGroup {
+            title: "Per Pad".into(),
+            help: Some(
+                "These commands accept one or more pad ids: <id> or ranges <id>-<id>".into(),
+            ),
+            commands: vec![Some("view".into()), Some("edit".into())],
+        }]),
+        ..Default::default()
+    };
+
+    let output = render_help(&cmd, Some(config)).unwrap();
+
+    // Help text appears between title and first command
+    let title_pos = output.find("PER PAD").unwrap();
+    let help_pos = output.find("These commands accept").unwrap();
+    let first_cmd_pos = output.find("  view").unwrap();
+
+    assert!(
+        title_pos < help_pos && help_pos < first_cmd_pos,
+        "output:\n{output}"
+    );
+}

--- a/docs/topics/standout-help.md
+++ b/docs/topics/standout-help.md
@@ -1,0 +1,289 @@
+# Styled Help
+
+Standout replaces clap's built-in help with themed, template-driven output. Instead of clap's fixed format, your `--help` renders through the same MiniJinja + style-tag pipeline as the rest of your CLI.
+
+Out of the box, this gives you bold headers, consistent alignment, and a "Learn More" section linking to help topics. For CLIs with many commands, you can organize subcommands into named groups with section headers, help text, and visual separators.
+
+## How It Works
+
+When you use `App`, standout:
+
+1. Disables clap's default help subcommand
+2. Registers its own `help` subcommand (with `--page` for pager support)
+3. Intercepts `help` requests and renders them through a MiniJinja template with style tags
+
+No configuration is required for basic use. `App::builder().build()` gives you styled help automatically.
+
+## Default Behavior
+
+Without any group configuration, all subcommands appear in a single "Commands" section:
+
+```text
+My application
+
+USAGE
+  myapp <COMMAND>
+
+COMMANDS
+  init:         Initialize the project
+  list:         List all items
+  delete:       Delete an item
+  config:       Manage configuration
+
+OPTIONS
+  --output      Output format
+```
+
+## Command Groups
+
+CLIs with many commands (20+) benefit from organized help. The `CommandGroup` struct lets you split subcommands into named sections:
+
+```rust
+use standout::cli::{App, CommandGroup};
+
+App::builder()
+    .command_groups(vec![
+        CommandGroup {
+            title: "Commands".into(),
+            help: None,
+            commands: vec![
+                Some("init".into()),
+                Some("create".into()),
+                Some("list".into()),
+                Some("search".into()),
+            ],
+        },
+        CommandGroup {
+            title: "Per Pad(s)".into(),
+            help: Some(
+                "These commands accept one or more pad ids: <id> or ranges <id>-<id>\n\
+                 ex: $ padz view 3 5 7-9  # views pads 3, 5, 7, 8 and 9".into()
+            ),
+            commands: vec![
+                Some("open".into()), Some("view".into()), Some("peek".into()),
+                None, // blank line separator
+                Some("pin".into()), Some("unpin".into()),
+                None,
+                Some("complete".into()), Some("reopen".into()),
+            ],
+        },
+        CommandGroup {
+            title: "Misc".into(),
+            help: None,
+            commands: vec![
+                Some("completions".into()),
+                Some("help".into()),
+                Some("config".into()),
+            ],
+        },
+    ])
+    .build()?;
+```
+
+This produces:
+
+```text
+COMMANDS
+  init:         Initialize the store
+  create:       Create a new pad
+  list:         List pads
+  search:       Search pads
+
+PER PAD(S)
+  These commands accept one or more pad ids: <id> or ranges <id>-<id>
+  ex: $ padz view 3 5 7-9  # views pads 3, 5, 7, 8 and 9
+
+  open:         Open a pad in the editor
+  view:         View one or more pads
+  peek:         Peek at pad content previews
+
+  pin:          Pin one or more pads
+  unpin:        Unpin one or more pads
+
+  complete:     Mark pads as done
+  reopen:       Reopen pads
+
+MISC
+  completions:  Generate shell completions
+  help:         Print this message
+  config:       Get or set configuration
+```
+
+### Blank Line Separators
+
+Use `None` entries in the `commands` vec to insert blank lines within a group. This creates visual sub-clusters without introducing nested group hierarchy:
+
+```rust
+commands: vec![
+    Some("open".into()),
+    Some("view".into()),
+    None,               // blank line
+    Some("pin".into()),
+    Some("unpin".into()),
+],
+```
+
+### Ungrouped Commands
+
+Commands that exist in your clap definition but don't appear in any `CommandGroup` are automatically appended to an "Other" section. This is a safety net: if you add a new subcommand but forget to add it to the group config, it still shows up in help. Silently hiding commands would be worse than slightly messy help.
+
+### Group Help Text
+
+Each group can include optional help text displayed between the section header and the command list. Use this to explain shared arguments, conventions, or usage patterns that apply to all commands in the group.
+
+## Standalone Rendering
+
+You can render help without `App` using `render_help` directly:
+
+```rust
+use standout::cli::{render_help, CommandGroup, HelpConfig};
+use standout::OutputMode;
+
+let config = HelpConfig {
+    output_mode: Some(OutputMode::Text),
+    command_groups: Some(vec![
+        CommandGroup {
+            title: "Main".into(),
+            help: None,
+            commands: vec![Some("init".into()), Some("list".into())],
+        },
+    ]),
+    ..Default::default()
+};
+
+let output = render_help(&cmd, Some(config))?;
+println!("{}", output);
+```
+
+## Validation
+
+The group config is static — it should be validated at test time, not when a user runs `--help`. Use `validate_command_groups` in a `#[test]`:
+
+```rust
+use standout::cli::{validate_command_groups, CommandGroup};
+use clap::CommandFactory;
+
+#[test]
+fn test_help_groups_match_commands() {
+    let cmd = Cli::command();
+    let groups = my_command_groups();
+    validate_command_groups(&cmd, &groups).unwrap();
+}
+```
+
+**What it checks:**
+
+- **Phantom reference** — a group names a command that doesn't exist in the clap definition (catches typos and stale configs)
+
+**What it allows:**
+
+- **Ungrouped commands** — commands not in any group are OK; they auto-append to "Other" at render time
+
+This follows the same pattern as `app.verify_command(&cmd)` for handler/argument validation.
+
+## Themes
+
+Help rendering uses a theme to style output. The default theme applies bold to headers and command names:
+
+```rust
+pub fn default_help_theme() -> Theme {
+    Theme::new()
+        .add("header", Style::new().bold())   // COMMANDS, OPTIONS, etc.
+        .add("item", Style::new().bold())     // Command/option names
+        .add("desc", Style::new())            // Descriptions
+        .add("usage", Style::new())           // Usage line
+        .add("example", Style::new())         // Examples section
+        .add("about", Style::new())           // About text
+}
+```
+
+Override via `HelpConfig`:
+
+```rust
+let config = HelpConfig {
+    theme: Some(
+        Theme::new()
+            .add("header", Style::new().bold().cyan())
+            .add("item", Style::new().green())
+            .add("desc", Style::new())
+            .add("usage", Style::new())
+            .add("example", Style::new().dim())
+            .add("about", Style::new())
+    ),
+    ..Default::default()
+};
+```
+
+Or when using `AppBuilder`, set the theme with `.theme()` — it applies to both help and command output.
+
+## Custom Templates
+
+The default template renders about, usage, grouped commands, options, examples, and learn-more topics. Override it via `HelpConfig::template`:
+
+```rust
+let config = HelpConfig {
+    template: Some(my_custom_template.into()),
+    ..Default::default()
+};
+```
+
+### Template Variables
+
+The template receives a `HelpData` struct with these fields:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `about` | String | Command's about text |
+| `usage` | String | Usage line (without "Usage: " prefix) |
+| `subcommands` | Vec | Command groups (each with `title`, `help`, `commands`) |
+| `options` | Vec | Option groups (each with `title`, `options`) |
+| `examples` | String | Examples text |
+| `learn_more` | Vec | Topic list items (each with `name`, `title`, `padding`) |
+
+### Group Fields in Templates
+
+Each subcommand group has:
+
+- `group.title` — section header (rendered as `group.title | upper` in the default template)
+- `group.help` — optional help text for the group
+- `group.commands` — list of command entries
+
+Each command entry has:
+
+- `cmd.name` — command name
+- `cmd.about` — command description
+- `cmd.padding` — alignment spaces
+- `cmd.separator` — true for blank-line separator entries
+
+### Example Custom Template
+
+```jinja
+[about]{{ about }}[/about]
+
+[header]USAGE[/header]
+  [usage]{{ usage }}[/usage]
+{%- for group in subcommands %}
+
+[header]{{ group.title | upper }}[/header]
+{%- if group.help %}
+  [desc]{{ group.help }}[/desc]
+{% endif %}
+{%- for cmd in group.commands %}
+{%- if cmd.separator %}
+
+{%- else %}
+  [item]{{ cmd.name }}[/item]:{{ cmd.padding }}[desc]{{ cmd.about }}[/desc]
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
+```
+
+Style tags like `[header]...[/header]` are resolved against the theme. Unknown tags pass through or show a `?` indicator depending on the output mode.
+
+## Output Modes
+
+Help respects the `--output` flag. In `Text` mode, style tags are stripped. In `Json` mode, the `HelpData` struct is serialized directly. This means help output is machine-readable when needed:
+
+```bash
+myapp help --output json
+```


### PR DESCRIPTION
## Summary

- Implements #102: subcommand group support for organized help display
- Adds `CommandGroup` struct with `title`, `help` text, and `commands` (with `None` for blank-line separators)
- Adds `command_groups` field to `HelpConfig` and `AppBuilder::command_groups()` builder method
- Adds `validate_command_groups()` for CI-time validation of group configs against clap Command trees
- Updates default template to render per-group titles, help text, and separators
- Ungrouped commands auto-append to an "Other" section (never silently hidden)
- Fully backward-compatible: no groups configured = identical output to before

## Test plan

- [x] 5 unit tests for `validate_command_groups` (valid, phantom, ungrouped, separators, hidden)
- [x] 3 unit tests for grouped extraction (groups, separators, all-grouped)
- [x] 8 integration tests verifying rendered output (titles, help text, separators, backward compat, ordering, validation)
- [x] All 157 existing unit tests pass
- [x] All existing integration tests pass
- [x] `cargo fmt` and `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)