### PR TITLE
User experience improvements from feedback review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       .command_passthrough("init-sh", |_m, _ctx| {
           print!("export PATH=\"$HOME/.myapp/bin:$PATH\"");
           Ok(())
-      })
+      })?
+      .build()?;
   ```
+
+- **`Theme::from_css()` and `Theme::from_css_file()`** — New constructors for loading themes directly from CSS content or CSS files, matching the existing `from_yaml()` / `from_file()` pattern.
+
+- **CSS stylesheet support in `embed_styles!`** — The `embed_styles!` macro and `StylesheetRegistry` now recognize `.css` files in addition to `.yaml` / `.yml`. CSS files are auto-detected and parsed with the CSS parser. `.css` has highest priority when multiple formats exist with the same base name.
 
 - **Complete working example** — New `docs/guides/complete-example.md` with a self-contained, copy-paste project (Cargo.toml, main.rs, template, CSS stylesheet).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Passthrough commands** — Commands that bypass the rendering pipeline but still participate in help, completions, and dispatch. Use `command_passthrough` on `App` or `passthrough` on `GroupBuilder` for commands that manage their own output (e.g., shell init scripts, config delegation).
+
+  ```rust
+  App::builder()
+      .command_passthrough("init-sh", |_m, _ctx| {
+          print!("export PATH=\"$HOME/.myapp/bin:$PATH\"");
+          Ok(())
+      })
+  ```
+
+- **Complete working example** — New `docs/guides/complete-example.md` with a self-contained, copy-paste project (Cargo.toml, main.rs, template, CSS stylesheet).
+
+### Changed
+
+- **`console` crate bumped to 0.16** — The `console` dependency has been updated from 0.15 to 0.16 across all crates (`standout`, `standout-render`, `standout-bbparser`). Users who construct `console::Style` values programmatically must ensure they depend on `console = "0.16"`. No API changes were needed — all existing console APIs remain compatible.
+
+- **CSS is now the primary styling format** — All documentation now presents CSS as the recommended and primary format for defining styles. YAML themes are still supported but are documented as a legacy alternative. Specific changes:
+  - `docs/index.md`, `docs/intro.md`: References to "CSS or YAML" replaced with "CSS"
+  - `docs/guides/intro-to-standout.md`: Removed YAML styling alternative section
+  - `docs/guides/tldr-intro-to-standout.md`: Updated comments to reference CSS only
+  - `docs/topics/app-configuration.md`: Examples and file listings now show `.css` files
+  - `crates/standout-render/docs/topics/styling-system.md`: Restructured to lead with CSS, YAML moved to legacy note
+  - `crates/standout-render/docs/guides/intro-to-rendering.md`: Complete example now uses `Theme::from_css()`
+  - `crates/standout-render/src/lib.rs`: Rustdoc example changed from `Theme::from_yaml()` to `Theme::from_css()`
+
 ## [7.0.0] - 2026-02-17
 
 ## [6.2.0] - 2026-02-15

--- a/crates/standout-bbparser/Cargo.toml
+++ b/crates/standout-bbparser/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["command-line-interface", "parser-implementations"]
 repository = "https://github.com/arthur-debert/standout"
 
 [dependencies]
-console = "0.15"
+console = "0.16"
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/standout-macros/src/embed.rs
+++ b/crates/standout-macros/src/embed.rs
@@ -33,7 +33,7 @@ use syn::LitStr;
 pub const TEMPLATE_EXTENSIONS: &[&str] = &[".jinja", ".jinja2", ".j2", ".txt"];
 
 /// Stylesheet file extensions (must match standout::style::STYLESHEET_EXTENSIONS).
-pub const STYLESHEET_EXTENSIONS: &[&str] = &[".yaml", ".yml"];
+pub const STYLESHEET_EXTENSIONS: &[&str] = &[".css", ".yaml", ".yml"];
 
 /// Generates code to create an EmbeddedTemplates source.
 ///

--- a/crates/standout-macros/src/lib.rs
+++ b/crates/standout-macros/src/lib.rs
@@ -8,7 +8,7 @@
 //! ## Embedding Macros
 //!
 //! - [`embed_templates!`] - Embed template files (`.jinja`, `.jinja2`, `.j2`, `.txt`)
-//! - [`embed_styles!`] - Embed stylesheet files (`.yaml`, `.yml`)
+//! - [`embed_styles!`] - Embed stylesheet files (`.css`, `.yaml`, `.yml`)
 //!
 //! ## Derive Macros
 //!

--- a/crates/standout-render/Cargo.toml
+++ b/crates/standout-render/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/arthur-debert/standout"
 readme = "README.md"
 
 [dependencies]
-console = "0.15"
+console = "0.16"
 dark-light = "0.2"
 deunicode = "1.6.2"
 minijinja = { version = "2", features = ["loader"] }

--- a/crates/standout-render/docs/guides/intro-to-rendering.md
+++ b/crates/standout-render/docs/guides/intro-to-rendering.md
@@ -220,7 +220,7 @@ Features:
 - **True color**: RGB values for precise colors (`#ff6b35` or `[255, 107, 53]`)
 - **Aliases**: semantic names resolve to visual styles (`commit-message: title`)
 
-YAML syntax is also supported as an alternative. See [Styling System](../topics/styling-system.md) for complete style options.
+See [Styling System](../topics/styling-system.md) for complete style options.
 
 ---
 
@@ -368,11 +368,11 @@ pub struct Report {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let theme = Theme::from_yaml(r#"
-        title: { fg: cyan, bold: true }
-        done: green
-        pending: yellow
-        muted: { dim: true }
+    let theme = Theme::from_css(r#"
+        .title { color: cyan; font-weight: bold; }
+        .done { color: green; }
+        .pending { color: yellow; }
+        .muted { opacity: 0.5; }
     "#)?;
 
     let tasks = vec![

--- a/crates/standout-render/docs/topics/styling-system.md
+++ b/crates/standout-render/docs/topics/styling-system.md
@@ -15,61 +15,9 @@ This separation provides several benefits:
 
 A `Theme` is a named collection of styles. Each style maps a name (like `title` or `error`) to visual attributes (bold cyan, dim red, etc.).
 
-### Programmatic Themes
-
-Build themes in code using the builder pattern:
-
-```rust
-use standout_render::Theme;
-use console::Style;
-
-let theme = Theme::new()
-    .add("title", Style::new().bold().cyan())
-    .add("error", Style::new().red().bold())
-    .add("muted", Style::new().dim())
-    .add("success", Style::new().green());
-```
-
-### YAML Themes
-
-For file-based configuration, YAML provides a concise syntax:
-
-```yaml
-# theme.yaml
-title:
-  fg: cyan
-  bold: true
-
-error:
-  fg: red
-  bold: true
-
-muted:
-  dim: true
-
-success:
-  fg: green
-
-# Shorthand: single attribute or space-separated
-warning: yellow
-emphasis: "bold italic"
-```
-
-Load YAML themes:
-
-```rust
-use standout_render::Theme;
-
-// From string
-let theme = Theme::from_yaml(yaml_content)?;
-
-// From file (with hot reload in debug builds)
-let theme = Theme::from_yaml_file("styles/theme.yaml")?;
-```
-
 ### CSS Themes
 
-For developers who prefer standard CSS syntax, `standout-render` supports a subset of CSS Level 3 tailored for terminals:
+Define styles in standard CSS syntax — a subset of CSS Level 3 tailored for terminals:
 
 ```css
 /* theme.css */
@@ -104,7 +52,24 @@ let theme = Theme::from_css(css_content)?;
 let theme = Theme::from_css_file("styles/theme.css")?;
 ```
 
-> CSS is the recommended format for new projects. It enables syntax highlighting in editors, linting tools, and familiarity for web developers.
+CSS gives you syntax highlighting in editors, linting tools, and familiarity for web developers.
+
+### Programmatic Themes
+
+Build themes in code using the builder pattern:
+
+```rust
+use standout_render::Theme;
+use console::Style;
+
+let theme = Theme::new()
+    .add("title", Style::new().bold().cyan())
+    .add("error", Style::new().red().bold())
+    .add("muted", Style::new().dim())
+    .add("success", Style::new().green());
+```
+
+> **Legacy format:** YAML themes are still supported via `Theme::from_yaml()` and `Theme::from_yaml_file()`. CSS is the recommended format for all new projects.
 
 ---
 
@@ -119,44 +84,39 @@ let theme = Theme::from_css_file("styles/theme.css")?;
 
 ### Color Formats
 
-```yaml
-# Named colors (16 ANSI colors)
-fg: red
-fg: green
-fg: blue
-fg: cyan
-fg: magenta
-fg: yellow
-fg: white
-fg: black
+```css
+/* Named colors (16 ANSI colors) */
+.example { color: red; }
+.example { color: green; }
+.example { color: cyan; }
+.example { color: magenta; }
+.example { color: yellow; }
+.example { color: white; }
+.example { color: black; }
 
-# Bright variants
-fg: bright_red
-fg: bright_green
+/* Bright variants */
+.example { color: bright_red; }
+.example { color: bright_green; }
 
-# 256-color palette (0-255)
-fg: 208
+/* 256-color palette (0-255) */
+.example { color: 208; }
 
-# RGB hex
-fg: "#ff6b35"
-fg: "#f63"      # shorthand
-
-# RGB array
-fg: [255, 107, 53]
+/* RGB hex */
+.example { color: #ff6b35; }
+.example { color: #f63; }     /* shorthand */
 ```
 
 ### Text Attributes
 
-| YAML | CSS | Effect |
-|------|-----|--------|
-| `bold: true` | `font-weight: bold` | Bold text |
-| `dim: true` | `opacity: 0.5` | Dimmed/faint text |
-| `italic: true` | `font-style: italic` | Italic text |
-| `underline: true` | `text-decoration: underline` | Underlined text |
-| `blink: true` | `text-decoration: blink` | Blinking text |
-| `reverse: true` | — | Swap fg/bg colors |
-| `hidden: true` | `visibility: hidden` | Hidden text |
-| `strikethrough: true` | `text-decoration: line-through` | Strikethrough |
+| CSS Property | Effect |
+|-------------|--------|
+| `font-weight: bold` | Bold text |
+| `opacity: 0.5` | Dimmed/faint text |
+| `font-style: italic` | Italic text |
+| `text-decoration: underline` | Underlined text |
+| `text-decoration: blink` | Blinking text |
+| `text-decoration: line-through` | Strikethrough |
+| `visibility: hidden` | Hidden text |
 
 ---
 
@@ -168,39 +128,27 @@ Terminal applications run in both light and dark environments. A color that look
 
 Instead of defining separate "light theme" and "dark theme" files, you define mode-specific overrides at the style level:
 
-```yaml
-panel:
-  bold: true          # Shared across all modes
-  fg: gray            # Default/fallback
-  light:
-    fg: black         # Override for light mode
-  dark:
-    fg: white         # Override for dark mode
-```
-
-When resolving `panel` in dark mode:
-1. Start with base attributes (`bold: true`, `fg: gray`)
-2. Merge dark overrides (`fg: white` replaces `fg: gray`)
-3. Result: bold white text
-
-This is efficient: most styles (bold, italic, semantic colors like green/red) look fine in both modes. Only a handful need adjustment—typically foreground colors for contrast.
-
-### CSS Syntax
-
 ```css
 .panel {
     font-weight: bold;
-    color: gray;
+    color: gray;        /* Default/fallback */
 }
 
 @media (prefers-color-scheme: light) {
-    .panel { color: black; }
+    .panel { color: black; }   /* Override for light mode */
 }
 
 @media (prefers-color-scheme: dark) {
-    .panel { color: white; }
+    .panel { color: white; }   /* Override for dark mode */
 }
 ```
+
+When resolving `panel` in dark mode:
+1. Start with base attributes (`bold`, `gray`)
+2. Merge dark overrides (`white` replaces `gray`)
+3. Result: bold white text
+
+This is efficient: most styles (bold, italic, semantic colors like green/red) look fine in both modes. Only a handful need adjustment—typically foreground colors for contrast.
 
 ### Programmatic API
 
@@ -245,16 +193,14 @@ set_theme_detector(|| ColorMode::Dark);  // Force dark mode
 
 Aliases let semantic names resolve to visual styles. This is useful when multiple concepts share the same appearance:
 
-```yaml
-# Define the visual style once
-title:
-  fg: cyan
-  bold: true
-
-# Aliases
-commit-message: title
-section-header: title
-heading: title
+```rust
+let theme = Theme::new()
+    // Define the visual style once
+    .add("title", Style::new().bold().cyan())
+    // Aliases — pass a string to reference another style by name
+    .add("commit-message", "title")
+    .add("section-header", "title")
+    .add("heading", "title");
 ```
 
 Now `[commit-message]`, `[section-header]`, and `[heading]` all render identically to `[title]`.
@@ -306,33 +252,26 @@ if !errors.is_empty() {
 Organize your styles in three conceptual layers:
 
 **1. Visual primitives** (low-level appearance):
-```yaml
-_cyan-bold:
-  fg: cyan
-  bold: true
-
-_dim:
-  dim: true
-
-_red-bold:
-  fg: red
-  bold: true
+```css
+._cyan-bold { color: cyan; font-weight: bold; }
+._dim { opacity: 0.5; }
+._red-bold { color: red; font-weight: bold; }
 ```
 
-**2. Presentation roles** (UI concepts):
-```yaml
-heading: _cyan-bold
-secondary: _dim
-danger: _red-bold
+**2. Presentation roles** (UI concepts — use aliases in code):
+```rust
+theme.add("heading", "_cyan-bold")
+     .add("secondary", "_dim")
+     .add("danger", "_red-bold");
 ```
 
-**3. Semantic names** (domain concepts):
-```yaml
-# In templates, use these
-task-title: heading
-task-status-done: success
-task-status-pending: warning
-error-message: danger
+**3. Semantic names** (domain concepts — aliases to presentation):
+```rust
+// In templates, use these
+theme.add("task-title", "heading")
+     .add("task-status-done", "success")
+     .add("task-status-pending", "warning")
+     .add("error-message", "danger");
 ```
 
 Templates use semantic names (`task-title`), which resolve to presentation roles (`heading`), which resolve to visual primitives (`_cyan-bold`).
@@ -344,25 +283,26 @@ This layering lets you:
 
 ### Naming Conventions
 
-```yaml
-# Good: descriptive, semantic
-error-message: ...
-file-path: ...
-command-name: ...
+```css
+/* Good: descriptive, semantic */
+.error-message { ... }
+.file-path { ... }
+.command-name { ... }
 
-# Avoid: visual descriptions
-red-text: ...
-bold-cyan: ...
+/* Avoid: visual descriptions */
+.red-text { ... }
+.bold-cyan { ... }
 ```
 
 ### Keep Themes Focused
 
 One theme per "look". Don't mix concerns:
 
-```yaml
-# theme-default.yaml - your app's default look
-# theme-colorblind.yaml - accessibility variant
-# theme-monochrome.yaml - for piped output
+```text
+styles/
+├── default.css          # your app's default look
+├── colorblind.css       # accessibility variant
+└── monochrome.css       # for piped output
 ```
 
 ---
@@ -372,18 +312,18 @@ One theme per "look". Don't mix concerns:
 ### Theme Creation
 
 ```rust
-// Empty theme
-let theme = Theme::new();
-
-// From YAML string
-let theme = Theme::from_yaml(yaml_str)?;
-
 // From CSS string
 let theme = Theme::from_css(css_str)?;
 
-// From files (hot reload in debug)
-let theme = Theme::from_yaml_file(path)?;
+// From CSS file (hot reload in debug)
 let theme = Theme::from_css_file(path)?;
+
+// Empty theme (for programmatic building)
+let theme = Theme::new();
+
+// Legacy: YAML is still supported
+let theme = Theme::from_yaml(yaml_str)?;
+let theme = Theme::from_yaml_file(path)?;
 ```
 
 ### Adding Styles

--- a/crates/standout-render/src/lib.rs
+++ b/crates/standout-render/src/lib.rs
@@ -99,26 +99,24 @@
 //!     );
 //! ```
 //!
-//! ## YAML-Based Themes
+//! ## CSS-Based Themes
 //!
 //! Ship themes alongside your application or allow users to bring their own. The
-//! [`Theme::from_yaml`] helper loads named styles (and adaptive overrides) directly
-//! from a YAML definition:
+//! [`Theme::from_css`] helper loads named styles (and adaptive overrides) directly
+//! from a CSS definition:
 //!
 //! ```rust
 //! use standout_render::Theme;
 //!
-//! let theme = Theme::from_yaml(r#"
-//! header:
-//!   fg: cyan
-//!   bold: true
-//! panel:
-//!   fg: gray
-//!   light:
-//!     fg: black
-//!   dark:
-//!     fg: white
-//! title: header
+//! let theme = Theme::from_css(r#"
+//! .header { color: cyan; font-weight: bold; }
+//! .panel { color: gray; }
+//! @media (prefers-color-scheme: light) {
+//!     .panel { color: black; }
+//! }
+//! @media (prefers-color-scheme: dark) {
+//!     .panel { color: white; }
+//! }
 //! "#).unwrap();
 //! ```
 //!

--- a/crates/standout-render/src/style/file_registry.rs
+++ b/crates/standout-render/src/style/file_registry.rs
@@ -71,18 +71,32 @@ use super::error::StylesheetError;
 ///
 /// When multiple files exist with the same base name but different extensions,
 /// the extension appearing earlier in this list takes precedence.
-pub const STYLESHEET_EXTENSIONS: &[&str] = &[".yaml", ".yml"];
+pub const STYLESHEET_EXTENSIONS: &[&str] = &[".css", ".yaml", ".yml"];
 
 /// Creates the file registry configuration for stylesheets.
 fn stylesheet_config() -> FileRegistryConfig<Theme> {
     FileRegistryConfig {
         extensions: STYLESHEET_EXTENSIONS,
         transform: |content| {
-            Theme::from_yaml(content).map_err(|e| LoadError::Transform {
+            parse_theme_content(content).map_err(|e| LoadError::Transform {
                 name: String::new(), // FileRegistry fills in the actual name
                 message: e.to_string(),
             })
         },
+    }
+}
+
+/// Parses theme content, auto-detecting CSS vs YAML format.
+///
+/// CSS is detected by the presence of a CSS class selector (`.name {`),
+/// which distinguishes it from YAML inline maps that also use `{`.
+fn parse_theme_content(content: &str) -> Result<Theme, StylesheetError> {
+    let trimmed = content.trim_start();
+    // CSS files start with class selectors (.name), comments (/*), or @media queries
+    if trimmed.starts_with('.') || trimmed.starts_with("/*") || trimmed.starts_with("@media") {
+        Theme::from_css(content)
+    } else {
+        Theme::from_yaml(content)
     }
 }
 
@@ -291,11 +305,10 @@ impl StylesheetRegistry {
     pub fn from_embedded_entries(entries: &[(&str, &str)]) -> Result<Self, StylesheetError> {
         let mut registry = Self::new();
 
-        // Use shared helper with YAML parsing transform
-        registry.inline =
-            build_embedded_registry(entries, STYLESHEET_EXTENSIONS, |yaml_content| {
-                Theme::from_yaml(yaml_content)
-            })?;
+        // Use shared helper with auto-detecting CSS/YAML parsing
+        registry.inline = build_embedded_registry(entries, STYLESHEET_EXTENSIONS, |content| {
+            parse_theme_content(content)
+        })?;
 
         Ok(registry)
     }

--- a/crates/standout-render/src/theme/theme.rs
+++ b/crates/standout-render/src/theme/theme.rs
@@ -250,6 +250,79 @@ impl Theme {
         })
     }
 
+    /// Creates a theme from CSS content.
+    ///
+    /// The CSS format supports a subset of CSS Level 3 tailored for terminals.
+    /// Class selectors map to style names (`.title { ... }` defines the `title` style).
+    /// Adaptive styles use `@media (prefers-color-scheme: light|dark)` queries.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`StylesheetError`] if parsing fails.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use standout_render::Theme;
+    ///
+    /// let theme = Theme::from_css(r#"
+    /// .header { color: cyan; font-weight: bold; }
+    /// .muted { opacity: 0.5; }
+    /// "#).unwrap();
+    /// ```
+    pub fn from_css(css: &str) -> Result<Self, StylesheetError> {
+        let variants = crate::parse_css(css)?;
+        Ok(Self {
+            name: None,
+            source_path: None,
+            base: variants.base().clone(),
+            light: variants.light().clone(),
+            dark: variants.dark().clone(),
+            aliases: variants.aliases().clone(),
+            icons: IconSet::new(),
+        })
+    }
+
+    /// Loads a theme from a CSS file.
+    ///
+    /// The theme name is derived from the filename (without extension).
+    /// The source path is stored for [`refresh`](Theme::refresh) support.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`StylesheetError`] if the file cannot be read or parsed.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use standout_render::Theme;
+    ///
+    /// let theme = Theme::from_css_file("./themes/default.css")?;
+    /// assert_eq!(theme.name(), Some("default"));
+    /// ```
+    pub fn from_css_file<P: AsRef<Path>>(path: P) -> Result<Self, StylesheetError> {
+        let path = path.as_ref();
+        let content = std::fs::read_to_string(path).map_err(|e| StylesheetError::Load {
+            message: format!("Failed to read {}: {}", path.display(), e),
+        })?;
+
+        let name = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_string());
+
+        let variants = crate::parse_css(&content)?;
+        Ok(Self {
+            name,
+            source_path: Some(path.to_path_buf()),
+            base: variants.base().clone(),
+            light: variants.light().clone(),
+            dark: variants.dark().clone(),
+            aliases: variants.aliases().clone(),
+            icons: IconSet::new(),
+        })
+    }
+
     /// Creates a theme from pre-parsed theme variants.
     pub fn from_variants(variants: ThemeVariants) -> Self {
         Self {

--- a/crates/standout/Cargo.toml
+++ b/crates/standout/Cargo.toml
@@ -19,7 +19,7 @@ standout-dispatch = { version = "7.0.0", path = "../standout-dispatch" }
 standout-seeker = { version = "7.0.0", path = "../standout-seeker" }
 
 # Direct dependencies (also used by standout-render, but needed here for cli module)
-console = "0.15"
+console = "0.16"
 deunicode = "1.6.2"
 minijinja = { version = "2", features = ["loader"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/standout/src/cli/builder/commands.rs
+++ b/crates/standout/src/cli/builder/commands.rs
@@ -11,7 +11,8 @@ use serde::Serialize;
 
 use super::{AppBuilder, PendingCommand};
 use crate::cli::group::{
-    ClosureRecipe, CommandConfig, ErasedConfigRecipe, GroupBuilder, GroupEntry, StructRecipe,
+    ClosureRecipe, CommandConfig, ErasedConfigRecipe, GroupBuilder, GroupEntry, PassthroughRecipe,
+    StructRecipe,
 };
 use crate::cli::handler::{CommandContext, FnHandler, Handler, HandlerResult};
 use crate::cli::hooks::Hooks;
@@ -267,6 +268,50 @@ impl AppBuilder {
             PendingCommand {
                 recipe: Box::new(recipe),
                 template,
+            },
+        );
+
+        Ok(self)
+    }
+
+    /// Registers a passthrough command that bypasses the rendering pipeline.
+    ///
+    /// The handler receives `&ArgMatches` and `&CommandContext`, writes directly to
+    /// stdout (or does whatever it needs), and the framework marks the command as
+    /// handled with no rendered output. The command still participates in
+    /// help/completions and dispatch.
+    ///
+    /// Use this for commands that manage their own output (e.g., shell init scripts
+    /// that output `eval`-able code, or commands that delegate to another tool).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use standout::cli::App;
+    ///
+    /// App::builder()
+    ///     .command_passthrough("init-sh", |_m, _ctx| {
+    ///         print!("export PATH=\"$HOME/.myapp/bin:$PATH\"");
+    ///         Ok(())
+    ///     })
+    ///     .build()?
+    ///     .run(cmd, args);
+    /// ```
+    pub fn command_passthrough<F>(self, path: &str, handler: F) -> Result<Self, SetupError>
+    where
+        F: FnMut(&ArgMatches, &CommandContext) -> Result<(), anyhow::Error> + 'static,
+    {
+        let recipe = PassthroughRecipe::new(handler);
+
+        if self.pending_commands.borrow().contains_key(path) {
+            return Err(SetupError::DuplicateCommand(path.to_string()));
+        }
+
+        self.pending_commands.borrow_mut().insert(
+            path.to_string(),
+            PendingCommand {
+                recipe: Box::new(recipe),
+                template: String::new(),
             },
         );
 
@@ -558,5 +603,60 @@ mod tests {
 
         assert!(builder.has_command("version"));
         assert!(builder.has_command("db.migrate"));
+    }
+
+    #[test]
+    fn test_command_passthrough() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+
+        let builder = AppBuilder::new()
+            .command_passthrough("init-sh", move |_m, _ctx| {
+                called_clone.store(true, Ordering::SeqCst);
+                Ok(())
+            })
+            .unwrap();
+
+        assert!(builder.has_command("init-sh"));
+
+        let cmd = Command::new("app").subcommand(Command::new("init-sh"));
+        let matches = cmd.try_get_matches_from(["app", "init-sh"]).unwrap();
+        let result = builder.dispatch(matches, OutputMode::Text);
+
+        assert!(called.load(Ordering::SeqCst));
+        // Passthrough commands produce empty handled output (silent)
+        assert!(result.is_handled());
+        assert_eq!(result.output(), Some(""));
+    }
+
+    #[test]
+    fn test_group_passthrough() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+
+        let builder = AppBuilder::new()
+            .group("shell", |g| {
+                g.passthrough("init", move |_m, _ctx| {
+                    called_clone.store(true, Ordering::SeqCst);
+                    Ok(())
+                })
+            })
+            .unwrap();
+
+        assert!(builder.has_command("shell.init"));
+
+        let cmd =
+            Command::new("app").subcommand(Command::new("shell").subcommand(Command::new("init")));
+        let matches = cmd.try_get_matches_from(["app", "shell", "init"]).unwrap();
+        let result = builder.dispatch(matches, OutputMode::Text);
+
+        assert!(called.load(Ordering::SeqCst));
+        assert!(result.is_handled());
     }
 }

--- a/crates/standout/src/cli/group.rs
+++ b/crates/standout/src/cli/group.rs
@@ -332,6 +332,73 @@ impl CommandRecipe for ErasedConfigRecipe {
     }
 }
 
+/// Recipe for passthrough commands that bypass the rendering pipeline.
+///
+/// The handler receives `&ArgMatches` and `&CommandContext`, writes directly to
+/// stdout (or does whatever it needs), and the framework marks the command as
+/// handled with no output.
+pub(crate) struct PassthroughRecipe<F>
+where
+    F: FnMut(&ArgMatches, &CommandContext) -> Result<(), anyhow::Error> + 'static,
+{
+    handler: Rc<RefCell<F>>,
+}
+
+impl<F> PassthroughRecipe<F>
+where
+    F: FnMut(&ArgMatches, &CommandContext) -> Result<(), anyhow::Error> + 'static,
+{
+    pub fn new(handler: F) -> Self {
+        Self {
+            handler: Rc::new(RefCell::new(handler)),
+        }
+    }
+}
+
+impl<F> CommandRecipe for PassthroughRecipe<F>
+where
+    F: FnMut(&ArgMatches, &CommandContext) -> Result<(), anyhow::Error> + 'static,
+{
+    fn template(&self) -> Option<&str> {
+        None
+    }
+
+    fn hooks(&self) -> Option<&Hooks> {
+        None
+    }
+
+    fn take_hooks(&mut self) -> Option<Hooks> {
+        None
+    }
+
+    fn create_dispatch(
+        &self,
+        _template: &str,
+        _context_registry: &ContextRegistry,
+        _template_engine: Rc<Box<dyn standout_render::template::TemplateEngine>>,
+    ) -> DispatchFn {
+        let handler = self.handler.clone();
+
+        Rc::new(RefCell::new(
+            move |matches: &ArgMatches,
+                  ctx: &CommandContext,
+                  _hooks: Option<&Hooks>,
+                  _output_mode: crate::OutputMode,
+                  _theme: &crate::Theme| {
+                let result = (handler.borrow_mut())(matches, ctx);
+                match result {
+                    Ok(()) => Ok(super::dispatch::DispatchOutput::Silent),
+                    Err(e) => Err(format!("Error: {}", e)),
+                }
+            },
+        ))
+    }
+
+    fn expected_args(&self) -> Vec<ExpectedArg> {
+        Vec::new()
+    }
+}
+
 /// Configuration for a single command.
 ///
 /// Used internally to collect handler, template, and hooks before
@@ -730,6 +797,40 @@ impl GroupBuilder {
         self
     }
 
+    /// Registers a passthrough command that bypasses the rendering pipeline.
+    ///
+    /// The handler receives `&ArgMatches` and `&CommandContext`, writes directly to
+    /// stdout (or does whatever it needs), and the framework marks the command as
+    /// handled with no rendered output. The command still participates in
+    /// help/completions.
+    ///
+    /// Use this for commands that manage their own output (e.g., shell init scripts
+    /// that output `eval`-able code, or commands that delegate to another tool).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// .group("app", |g| g
+    ///     .passthrough("init-sh", |_m, _ctx| {
+    ///         print!("export PATH=\"$HOME/.myapp/bin:$PATH\"");
+    ///         Ok(())
+    ///     }))
+    /// ```
+    pub fn passthrough<F>(mut self, name: &str, handler: F) -> Self
+    where
+        F: FnMut(&ArgMatches, &CommandContext) -> Result<(), anyhow::Error> + 'static,
+    {
+        self.entries.insert(
+            name.to_string(),
+            GroupEntry::Command {
+                handler: Box::new(PassthroughCommandConfig {
+                    handler: Rc::new(RefCell::new(handler)),
+                }),
+            },
+        );
+        self
+    }
+
     /// Creates a nested group within this group.
     ///
     /// # Example
@@ -911,6 +1012,59 @@ where
 
     fn expected_args(&self) -> Vec<ExpectedArg> {
         self.handler.borrow().expected_args()
+    }
+}
+
+/// Internal: passthrough command config that bypasses rendering.
+struct PassthroughCommandConfig<F>
+where
+    F: FnMut(&ArgMatches, &CommandContext) -> Result<(), anyhow::Error> + 'static,
+{
+    handler: Rc<RefCell<F>>,
+}
+
+impl<F> ErasedCommandConfig for PassthroughCommandConfig<F>
+where
+    F: FnMut(&ArgMatches, &CommandContext) -> Result<(), anyhow::Error> + 'static,
+{
+    fn template(&self) -> Option<&str> {
+        None
+    }
+
+    fn hooks(&self) -> Option<&Hooks> {
+        None
+    }
+
+    fn take_hooks(&mut self) -> Option<Hooks> {
+        None
+    }
+
+    fn register(
+        self: Box<Self>,
+        _path: &str,
+        _template: String,
+        _context_registry: ContextRegistry,
+        _template_engine: Rc<Box<dyn standout_render::template::TemplateEngine>>,
+    ) -> DispatchFn {
+        let handler = self.handler;
+
+        Rc::new(RefCell::new(
+            move |matches: &ArgMatches,
+                  ctx: &CommandContext,
+                  _hooks: Option<&Hooks>,
+                  _output_mode: crate::OutputMode,
+                  _theme: &crate::Theme| {
+                let result = (handler.borrow_mut())(matches, ctx);
+                match result {
+                    Ok(()) => Ok(super::dispatch::DispatchOutput::Silent),
+                    Err(e) => Err(format!("Error: {}", e)),
+                }
+            },
+        ))
+    }
+
+    fn expected_args(&self) -> Vec<ExpectedArg> {
+        Vec::new()
     }
 }
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,6 +6,7 @@
 
 # Getting Started
 
+- [Complete Working Example](./guides/complete-example.md)
 - [Quick Start](./guides/tldr-intro-to-standout.md)
 - [Introduction to Standout](./guides/intro-to-standout.md)
 

--- a/docs/guides/complete-example.md
+++ b/docs/guides/complete-example.md
@@ -1,0 +1,148 @@
+# Complete Working Example
+
+A self-contained project you can copy, build, and run. This creates a simple todo list CLI with styled terminal output.
+
+## File Structure
+
+```text
+my-todo/
+├── Cargo.toml
+├── src/
+│   ├── main.rs
+│   ├── templates/
+│   │   └── list.jinja
+│   └── styles/
+│       └── default.css
+```
+
+## Cargo.toml
+
+```toml
+[package]
+name = "my-todo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+standout = "7"
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+```
+
+## src/main.rs
+
+```rust
+use clap::{ArgMatches, Parser, Subcommand};
+use serde::Serialize;
+use standout::cli::{App, CommandContext, Dispatch, HandlerResult, Output};
+use standout::{embed_styles, embed_templates};
+
+#[derive(Parser)]
+#[command(name = "my-todo")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Dispatch)]
+#[dispatch(handlers = handlers)]
+enum Commands {
+    /// List all todos
+    List,
+}
+
+#[derive(Serialize)]
+struct TodoResult {
+    todos: Vec<Todo>,
+}
+
+#[derive(Serialize)]
+struct Todo {
+    title: String,
+    status: String,
+}
+
+mod handlers {
+    use super::*;
+
+    pub fn list(_m: &ArgMatches, _ctx: &CommandContext) -> HandlerResult<TodoResult> {
+        // Your real logic goes here — database queries, API calls, etc.
+        let todos = vec![
+            Todo { title: "Write documentation".into(), status: "done".into() },
+            Todo { title: "Ship v1.0".into(), status: "pending".into() },
+            Todo { title: "Add tests".into(), status: "pending".into() },
+        ];
+        Ok(Output::Render(TodoResult { todos }))
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let app = App::builder()
+        .templates(embed_templates!("src/templates"))
+        .styles(embed_styles!("src/styles"))
+        .default_theme("default")
+        .commands(Commands::dispatch_config())
+        .build()?;
+
+    app.run(Cli::command(), std::env::args());
+    Ok(())
+}
+```
+
+## src/templates/list.jinja
+
+```jinja
+[title]My Todos[/title]
+{% for todo in todos %}
+[index]{{ loop.index }}.[/index] [{{ todo.status }}]{{ todo.title }}[/{{ todo.status }}]
+{% endfor %}
+```
+
+## src/styles/default.css
+
+```css
+.title {
+    color: cyan;
+    font-weight: bold;
+}
+
+.index {
+    color: yellow;
+}
+
+.done {
+    text-decoration: line-through;
+    color: gray;
+}
+
+.pending {
+    font-weight: bold;
+    color: white;
+}
+
+/* Adaptive: adjust for light terminals */
+@media (prefers-color-scheme: light) {
+    .pending { color: black; }
+}
+```
+
+## Run It
+
+```bash
+cargo run -- list              # Rich terminal output with colors
+cargo run -- list --output json    # JSON for scripting
+cargo run -- list --output text    # Plain text, no ANSI codes
+```
+
+## What You Get
+
+- **Testable logic**: `handlers::list` is a pure function — test it by asserting on the returned `TodoResult`
+- **Free output modes**: JSON, YAML, CSV, and plain text output from the same handler
+- **Hot reload**: Edit `list.jinja` or `default.css` during development — changes apply without recompiling (debug builds)
+- **Adaptive styles**: The `@media` query adjusts colors for light/dark terminals automatically
+
+## Next Steps
+
+- [Introduction to Standout](intro-to-standout.md) — Full walkthrough with incremental steps
+- [Styling System](../crates/render/topics/styling-system.md) — All CSS properties and adaptive styles
+- [Tabular Layout](../crates/render/guides/intro-to-tabular.md) — Column alignment for table output

--- a/docs/guides/intro-to-standout.md
+++ b/docs/guides/intro-to-standout.md
@@ -558,22 +558,7 @@ Create `src/styles/default.css`:
 }
 ```
 
-Or if you prefer YAML (`src/styles/default.yaml`):
-
-```yaml
-done: strikethrough, gray
-index: yellow
-pending:
-  bold: true
-  fg: white
-  light:
-    fg: black
-  dark:
-    fg: white
-message: cyan
-```
-
-> **Verify:** The file exists at `src/styles/default.css` or `src/styles/default.yaml`.
+> **Verify:** The file exists at `src/styles/default.css`.
 
 ### 8.2 Add style tags to your template
 
@@ -601,7 +586,7 @@ Add the styles to your app builder:
 let app = App::builder()
     .templates(embed_templates!("src/templates"))
     .styles(embed_styles!("src/styles"))       // Load stylesheets
-    .default_theme("default")                  // Use styles/default.css or default.yaml
+    .default_theme("default")                  // Use styles/default.css
     .commands(Commands::dispatch_config())
     .build()?;
 ```
@@ -639,7 +624,7 @@ src/
 │   ├── list.jinja       # with [style] tags
 │   └── add.jinja
 └── styles/
-    └── default.css      # or default.yaml
+    └── default.css
 ```
 
 For brevity's sake, we've ignored a bunch of finer and relevant points:
@@ -789,4 +774,4 @@ fn main() -> anyhow::Result<()> {
 - Styles not loading
   - **Error:** `theme not found: default`
   - **Cause:** Stylesheet file missing or wrong path.
-  - **Fix:** Ensure `src/styles/default.css` or `default.yaml` exists. Check `embed_styles!` path matches your file structure.
+  - **Fix:** Ensure `src/styles/default.css` exists. Check `embed_styles!` path matches your file structure.

--- a/docs/guides/tldr-intro-to-standout.md
+++ b/docs/guides/tldr-intro-to-standout.md
@@ -69,7 +69,7 @@ Configure the app:
         .app_state(Database::connect()?)                 // Optional: shared state for handlers
         .templates(embed_templates!("src/templates"))    // Sets the root template path
         .styles(embed_styles!("src/styles"))             // Likewise the styles root
-        .default_theme("default")                        // Use styles/default.css or default.yaml
+        .default_theme("default")                        // Use styles/default.css
         .commands(Commands::dispatch_config())           // Register handlers from derive macro
     .build()?;
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,7 +106,7 @@ mod handlers {
 
 ### 2. Define Your Presentation
 
-Templates use MiniJinja with semantic style tags. Styles are defined separately in CSS or YAML.
+Templates use MiniJinja with semantic style tags. Styles are defined separately in CSS.
 
 ```jinja
 {# list.jinja #}
@@ -166,7 +166,7 @@ myapp list --output text    # Plain text, no ANSI codes
 ### Rendering
 
 - [MiniJinja](https://github.com/mitsuhiko/minijinja) templates with semantic style tags
-- CSS or YAML stylesheets with light/dark mode support
+- CSS stylesheets with light/dark mode support
 - Hot reload during development—edit templates without recompiling
 - Tabular layouts with alignment, truncation, and Unicode support
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -135,7 +135,7 @@ pub fn list(_matches: &ArgMatches, _ctx: &CommandContext) -> HandlerResult<TodoR
 // Setup and configure standout:
 let app = App::builder()
     .templates(embed_templates!("src/templates"))  // Embeds all .jinja/.j2/.txt files
-    .styles(embed_styles!("src/styles"))           // Embeds all .yaml/.yml files
+    .styles(embed_styles!("src/styles"))           // Embeds all .css files
     .default_theme("default")                      // Set the default theme
     .commands(Commands::dispatch_config())         // Generated auto dispatch
     .build()?;

--- a/docs/topics/app-configuration.md
+++ b/docs/topics/app-configuration.md
@@ -62,13 +62,13 @@ Templates are referenced by path without extension: `"list"`, `"db/migrate"`.
 .styles(embed_styles!("src/styles"))
 ```
 
-Collects files matching: `.yaml`, `.yml`.
+Collects files matching: `.css` (and legacy `.yaml`, `.yml`).
 
 ```text
 src/styles/
-  default.yaml
-  dark.yaml
-  light.yaml
+  default.css
+  dark.css
+  light.css
 ```
 
 Themes are referenced by filename without extension: `"default"`, `"dark"`.
@@ -110,7 +110,7 @@ If `.default_theme()` is not called, `AppBuilder` attempts to load a theme from 
 2. `theme`
 3. `base`
 
-This allows you to provide a standard `base.yaml` or `theme.yaml` without requiring explicit configuration code. If the explicit theme isn't found, `build()` returns `SetupError::ThemeNotFound`.
+This allows you to provide a standard `base.css` or `theme.css` without requiring explicit configuration code. If the explicit theme isn't found, `build()` returns `SetupError::ThemeNotFound`.
 
 ### Explicit Theme
 
@@ -408,12 +408,9 @@ Template `src/templates/list.j2`:
 [muted]v{{ version }}[/muted]
 ```
 
-Style `src/styles/default.yaml`:
+Style `src/styles/default.css`:
 
-```yaml
-header:
-  fg: cyan
-  bold: true
-muted:
-  dim: true
+```css
+.header { color: cyan; font-weight: bold; }
+.muted { opacity: 0.5; }
 ```


### PR DESCRIPTION
## Summary

Addresses user feedback with improvements to documentation clarity, API ergonomics, and dependency freshness.

- **Bump `console` crate to 0.16** — Resolves version mismatch where users who `cargo add console` got 0.16, incompatible with standout's internal 0.15. No API changes needed — all console APIs are compatible.
- **Add passthrough commands** — New `command_passthrough()` on `App` and `passthrough()` on `GroupBuilder` for commands that bypass the rendering pipeline but still participate in help/completions/dispatch. Solves the "had to parse clap matches twice" workaround for commands like `init-sh` or `config` that manage their own output.
- **CSS as primary styling format** — All documentation restructured to present CSS as the recommended format. YAML themes still supported but documented as legacy. Every example, guide, and rustdoc comment now leads with CSS.
- **Complete working example page** — New `docs/guides/complete-example.md` with a self-contained, copy-paste project (Cargo.toml, main.rs, template, CSS stylesheet) so new users can get running without piecing fragments together.

### Breaking changes

- `console` dependency bumped from 0.15 to 0.16. Users constructing `console::Style` values programmatically must match the version.

## Test plan

- [x] All 1,315+ workspace lib tests pass
- [x] All integration tests and doctests pass
- [x] `cargo check`, `cargo fmt --check`, `cargo clippy` clean
- [x] Passthrough command tests added (both App-level and GroupBuilder-level)
- [ ] Verify deployed docs site rebuilds correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)