### PR TITLE
Add alternating table row styles with tinted variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Theme palette support** — `Theme::with_palette(ThemePalette)` lets you attach a palette of 8 anchor colors to a theme. Cube colors in stylesheets are resolved against this palette (or a default xterm palette if none is set).
 
+- **Alternating table row styles** — `Table::row_styles(even, odd)` wraps each data row in style tags that alternate between even and odd style names. The row counter auto-increments on every `row()` / `row_cells()` / `row_from()` / `row_from_trait()` call.
+
+  In templates, pass `row_styles` to the `table()` function:
+
+  ```jinja
+  {% set t = table(columns, row_styles=true) %}          {# default gray tint #}
+  {% set t = table(columns, row_styles="blue") %}         {# blue tint #}
+  {% set t = table(columns, row_styles=["a", "b"]) %}     {# custom style names #}
+  ```
+
+- **Built-in table row tint styles** — `Theme::default()` now ships with adaptive alternating-row styles in five tints: gray (default), blue, red, green, and purple. Each tint provides a subtle background color shift for odd rows, with dark- and light-mode variants.
+
+  | Tint | Dark bg (odd) | Light bg (odd) |
+  |--------|---------------|----------------|
+  | gray | 236 `#303030` | 254 `#e4e4e4` |
+  | blue | 17 `#00005f` | 189 `#d7d7ff` |
+  | red | 52 `#5f0000` | 224 `#ffd7d7` |
+  | green | 22 `#005f00` | 194 `#d7ffd7` |
+  | purple | 53 `#5f005f` | 225 `#ffd7ff` |
+
+  Style names follow the pattern `table_row_{even,odd}[_{tint}]`.
+
 ### Changed
 
 - `parse_stylesheet` and `parse_css` now accept an `Option<&ThemePalette>` parameter for resolving cube colors during style building.

--- a/crates/standout-render/docs/guides/intro-to-tabular.md
+++ b/crates/standout-render/docs/guides/intro-to-tabular.md
@@ -479,6 +479,33 @@ For dense data, add lines between rows:
 └──────┴────────────────────────────────────┘
 ```
 
+### Alternating Row Styles
+
+For long tables, alternating background colors on even/odd rows improves readability (sometimes called "zebra striping"). Pass `row_styles` to the `table()` function:
+
+```jinja
+{# Default gray tint — subtle dark/light gray alternation #}
+{% set t = table(columns, header_style="bold", row_styles=true) %}
+
+{# Named tint — blue, red, green, or purple #}
+{% set t = table(columns, header_style="bold", row_styles="blue") %}
+
+{# Fully custom style names #}
+{% set t = table(columns, row_styles=["my_even", "my_odd"]) %}
+```
+
+The default theme includes five adaptive tints that automatically adjust to the user's light/dark terminal setting:
+
+| Tint | Usage | Dark mode | Light mode |
+|--------|-------|-----------|------------|
+| gray | `row_styles=true` | dark gray bg | light gray bg |
+| blue | `row_styles="blue"` | dark navy bg | lavender bg |
+| red | `row_styles="red"` | dark crimson bg | blush bg |
+| green | `row_styles="green"` | dark forest bg | mint bg |
+| purple | `row_styles="purple"` | dark plum bg | lilac bg |
+
+The Rust API equivalent is `Table::row_styles("table_row_even", "table_row_odd")`.
+
 ---
 
 ## Step 13: The Complete Example

--- a/crates/standout-render/docs/topics/styling-system.md
+++ b/crates/standout-render/docs/topics/styling-system.md
@@ -254,6 +254,29 @@ if !errors.is_empty() {
 
 ---
 
+## Built-in Styles
+
+`Theme::default()` includes adaptive styles for alternating table row backgrounds. These are used automatically when you pass `row_styles=true` (or a tint name) to the `table()` template function.
+
+| Style name | Purpose |
+|------------|---------|
+| `table_row_even` | Even rows — no background (transparent) |
+| `table_row_odd` | Odd rows — subtle gray background shift |
+| `table_row_even_gray` | Alias for `table_row_even` |
+| `table_row_odd_gray` | Alias for `table_row_odd` |
+| `table_row_even_blue` | Even rows for blue tint |
+| `table_row_odd_blue` | Odd rows — dark navy / lavender bg |
+| `table_row_even_red` | Even rows for red tint |
+| `table_row_odd_red` | Odd rows — dark crimson / blush bg |
+| `table_row_even_green` | Even rows for green tint |
+| `table_row_odd_green` | Odd rows — dark forest / mint bg |
+| `table_row_even_purple` | Even rows for purple tint |
+| `table_row_odd_purple` | Odd rows — dark plum / lilac bg |
+
+All odd-row styles are adaptive: they resolve to a dark variant when the terminal is in dark mode, and a light variant in light mode. You can override any of these by defining the same style name in your theme.
+
+---
+
 ## Best Practices
 
 ### Semantic, Presentation, and Visual Layers

--- a/crates/standout-render/examples/table_row_styles.rs
+++ b/crates/standout-render/examples/table_row_styles.rs
@@ -1,0 +1,183 @@
+//! Visual test for alternating table row background colors with tint variants.
+//!
+//! Run with: cargo run -p standout-render --example table_row_styles
+
+use serde::Serialize;
+use standout_render::{render_with_mode, ColorMode, OutputMode, Theme};
+
+#[derive(Serialize)]
+struct Data {
+    rows: Vec<Row>,
+}
+
+#[derive(Clone, Serialize)]
+struct Row {
+    file: String,
+    code: String,
+    tests: String,
+    docs: String,
+    total: String,
+}
+
+fn main() {
+    console::set_colors_enabled(true);
+
+    let rows = vec![
+        r(
+            "crates/dodot-lib/src/testing/mod.rs",
+            "241",
+            "172",
+            "60",
+            "572",
+        ),
+        r(
+            "crates/dodot-lib/src/rules/mod.rs",
+            "230",
+            "381",
+            "45",
+            "777",
+        ),
+        r(
+            "crates/dodot-lib/src/execution/mod.rs",
+            "174",
+            "211",
+            "12",
+            "459",
+        ),
+        r(
+            "crates/dodot-lib/src/handlers/symlink.rs",
+            "172",
+            "171",
+            "22",
+            "463",
+        ),
+        r(
+            "crates/dodot-lib/src/paths/mod.rs",
+            "167",
+            "93",
+            "40",
+            "363",
+        ),
+        r("crates/dodot-cli/src/main.rs", "162", "0", "0", "175"),
+        r("crates/dodot-lib/src/commands/up.rs", "91", "0", "3", "106"),
+        r(
+            "crates/dodot-lib/src/commands/mod.rs",
+            "85",
+            "2",
+            "14",
+            "114",
+        ),
+        r(
+            "crates/dodot-lib/src/commands/fill.rs",
+            "85",
+            "100",
+            "10",
+            "231",
+        ),
+        r(
+            "crates/dodot-lib/src/render/mod.rs",
+            "83",
+            "67",
+            "19",
+            "207",
+        ),
+        r(
+            "crates/dodot-lib/src/datastore/mod.rs",
+            "79",
+            "0",
+            "56",
+            "156",
+        ),
+        r(
+            "crates/dodot-lib/src/handlers/mod.rs",
+            "69",
+            "37",
+            "49",
+            "175",
+        ),
+        r(
+            "crates/dodot-lib/src/packs/mod.rs",
+            "64",
+            "112",
+            "19",
+            "236",
+        ),
+        r(
+            "crates/dodot-lib/src/commands/status.rs",
+            "62",
+            "0",
+            "2",
+            "74",
+        ),
+        r(
+            "crates/dodot-lib/src/commands/down.rs",
+            "55",
+            "0",
+            "2",
+            "67",
+        ),
+        r(
+            "crates/dodot-lib/src/commands/adopt.rs",
+            "52",
+            "0",
+            "3",
+            "73",
+        ),
+    ];
+
+    let tints = ["gray", "blue", "red", "green", "purple"];
+    let theme = Theme::default().add("header", console::Style::new().cyan().bold());
+
+    for mode in [ColorMode::Dark, ColorMode::Light] {
+        let mode_name = match mode {
+            ColorMode::Dark => "DARK",
+            ColorMode::Light => "LIGHT",
+        };
+
+        println!("\n{}", "=".repeat(60));
+        println!("  {} MODE", mode_name);
+        println!("{}\n", "=".repeat(60));
+
+        for tint in &tints {
+            let template = format!(
+                r#"
+{{%- set t = table(
+    [{{"width": "fill"}},
+     {{"width": 16, "align": "right"}},
+     {{"width": 16, "align": "right"}},
+     {{"width": 16, "align": "right"}},
+     {{"width": 16, "align": "right"}}],
+    separator="  ",
+    header=["File", "Code", "Tests", "Docs", "Total"],
+    header_style="header",
+    row_styles="{}",
+    width=110
+) -%}}
+{{{{ t.header_row() }}}}
+{{%- for _ in range(110) %}}─{{%- endfor %}}
+{{%- for row in rows %}}
+{{{{ t.row([row.file, row.code, row.tests, row.docs, row.total]) }}}}
+{{%- endfor %}}
+{{%- for _ in range(110) %}}─{{%- endfor %}}
+{{{{ t.row(["Total (35 files)", "3334", "2690", "589", "8002"]) }}}}
+"#,
+                tint
+            );
+
+            let data = Data { rows: rows.clone() };
+            let output =
+                render_with_mode(&template, &data, &theme, OutputMode::Term, mode).unwrap();
+            println!("--- tint: {} ---\n{}\n", tint, output);
+        }
+    }
+}
+
+fn r(file: &str, code: &str, tests: &str, docs: &str, total: &str) -> Row {
+    Row {
+        file: file.to_string(),
+        code: code.to_string(),
+        tests: tests.to_string(),
+        docs: docs.to_string(),
+        total: total.to_string(),
+    }
+}

--- a/crates/standout-render/src/tabular/decorator.rs
+++ b/crates/standout-render/src/tabular/decorator.rs
@@ -35,6 +35,8 @@
 //! println!("{}", table.render(&data));
 //! ```
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use super::formatter::{CellValue, OwnedCellValue, TabularFormatter};
 use super::traits::{Tabular, TabularRow};
 use super::types::{FlatDataSpec, TabularSpec};
@@ -170,7 +172,10 @@ impl BorderChars {
 }
 
 /// A decorated table with borders, headers, and separators.
-#[derive(Clone, Debug)]
+///
+/// Supports alternating row styles (odd/even) via [`row_styles`](Table::row_styles).
+/// When set, data rows are automatically wrapped in `[style]...[/style]` tags
+/// that alternate between the two style names.
 pub struct Table {
     /// The underlying formatter.
     formatter: TabularFormatter,
@@ -182,6 +187,39 @@ pub struct Table {
     header_style: Option<String>,
     /// Whether to add separators between data rows.
     row_separator: bool,
+    /// Alternating row style names: (odd_style, even_style).
+    /// Row 0 uses even, row 1 uses odd, etc.
+    row_styles: Option<(String, String)>,
+    /// Counter for tracking data row index (for alternating styles).
+    row_counter: AtomicUsize,
+}
+
+impl Clone for Table {
+    fn clone(&self) -> Self {
+        Self {
+            formatter: self.formatter.clone(),
+            headers: self.headers.clone(),
+            border: self.border,
+            header_style: self.header_style.clone(),
+            row_separator: self.row_separator,
+            row_styles: self.row_styles.clone(),
+            row_counter: AtomicUsize::new(self.row_counter.load(Ordering::Relaxed)),
+        }
+    }
+}
+
+impl std::fmt::Debug for Table {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Table")
+            .field("formatter", &self.formatter)
+            .field("headers", &self.headers)
+            .field("border", &self.border)
+            .field("header_style", &self.header_style)
+            .field("row_separator", &self.row_separator)
+            .field("row_styles", &self.row_styles)
+            .field("row_counter", &self.row_counter.load(Ordering::Relaxed))
+            .finish()
+    }
 }
 
 impl Table {
@@ -194,6 +232,8 @@ impl Table {
             border: BorderStyle::None,
             header_style: None,
             row_separator: false,
+            row_styles: None,
+            row_counter: AtomicUsize::new(0),
         }
     }
 
@@ -206,6 +246,8 @@ impl Table {
             border: BorderStyle::None,
             header_style: None,
             row_separator: false,
+            row_styles: None,
+            row_counter: AtomicUsize::new(0),
         }
     }
 
@@ -288,6 +330,27 @@ impl Table {
         self
     }
 
+    /// Set alternating row styles for even and odd data rows.
+    ///
+    /// When set, each data row is wrapped in `[style]...[/style]` tags
+    /// that alternate between the two style names. Row 0 uses `even_style`,
+    /// row 1 uses `odd_style`, and so on.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let table = Table::new(spec, 80)
+    ///     .row_styles("table_row_even", "table_row_odd");
+    /// ```
+    pub fn row_styles(
+        mut self,
+        even_style: impl Into<String>,
+        odd_style: impl Into<String>,
+    ) -> Self {
+        self.row_styles = Some((odd_style.into(), even_style.into()));
+        self
+    }
+
     /// Get the border style.
     pub fn get_border(&self) -> BorderStyle {
         self.border
@@ -301,7 +364,7 @@ impl Table {
     /// Format a data row.
     pub fn row<S: AsRef<str>>(&self, values: &[S]) -> String {
         let content = self.formatter.format_row(values);
-        self.wrap_row(&content)
+        self.wrap_data_row(&content)
     }
 
     /// Format a data row with sub-column support.
@@ -310,7 +373,7 @@ impl Table {
     /// [`CellValue::Sub`]; all others should be [`CellValue::Single`].
     pub fn row_cells(&self, values: &[CellValue<'_>]) -> String {
         let content = self.formatter.format_row_cells(values);
-        self.wrap_row(&content)
+        self.wrap_data_row(&content)
     }
 
     /// Format a data row by extracting values from a serializable struct.
@@ -332,7 +395,7 @@ impl Table {
     /// ```
     pub fn row_from<T: serde::Serialize>(&self, value: &T) -> String {
         let content = self.formatter.row_from(value);
-        self.wrap_row(&content)
+        self.wrap_data_row(&content)
     }
 
     /// Format a data row using the `TabularRow` trait.
@@ -364,7 +427,7 @@ impl Table {
     /// ```
     pub fn row_from_trait<T: TabularRow>(&self, value: &T) -> String {
         let content = self.formatter.row_from_trait(value);
-        self.wrap_row(&content)
+        self.wrap_data_row(&content)
     }
 
     /// Format the header row.
@@ -400,6 +463,22 @@ impl Table {
     /// Generate the bottom border row.
     pub fn bottom_border(&self) -> String {
         self.horizontal_line(LineType::Bottom)
+    }
+
+    /// Wrap a data row with alternating style (if set) and borders.
+    fn wrap_data_row(&self, content: &str) -> String {
+        let bordered = self.wrap_row(content);
+        if let Some((odd_style, even_style)) = &self.row_styles {
+            let index = self.row_counter.fetch_add(1, Ordering::Relaxed);
+            let style = if index.is_multiple_of(2) {
+                even_style
+            } else {
+                odd_style
+            };
+            format!("[{}]{}[/{}]", style, bordered, style)
+        } else {
+            bordered
+        }
     }
 
     /// Wrap a row content with vertical borders.
@@ -479,6 +558,7 @@ impl Table {
     ///
     /// Includes top border, header (if set), separator, data rows, and bottom border.
     pub fn render<S: AsRef<str>>(&self, rows: &[Vec<S>]) -> String {
+        self.row_counter.store(0, Ordering::Relaxed);
         let mut output = Vec::new();
 
         // Top border
@@ -639,7 +719,7 @@ impl minijinja::value::Object for Table {
                 // Convert MiniJinja Value to serde_json::Value for field extraction
                 let json_value = minijinja::value::Value::from_serialize(&args[0]);
                 let formatted = self.formatter.row_from(&json_value);
-                Ok(minijinja::Value::from(self.wrap_row(&formatted)))
+                Ok(minijinja::Value::from(self.wrap_data_row(&formatted)))
             }
             "header_row" => {
                 // header_row() - format the header row

--- a/crates/standout-render/src/tabular/filters.rs
+++ b/crates/standout-render/src/tabular/filters.rs
@@ -247,6 +247,7 @@ fn register_table_functions(env: &mut Environment<'static>) {
             let row_separator = kwargs
                 .get::<Option<bool>>("row_separator")?
                 .unwrap_or(false);
+            let row_styles = kwargs.get::<Option<Value>>("row_styles")?;
             let width = kwargs.get::<Option<usize>>("width")?.unwrap_or(80);
             kwargs.assert_all_used()?;
 
@@ -284,6 +285,40 @@ fn register_table_functions(env: &mut Environment<'static>) {
             // Set row separator if enabled
             if row_separator {
                 table = table.row_separator(true);
+            }
+
+            // Set row styles for alternating row colors.
+            // Accepts:
+            //   row_styles=true              → default gray tint
+            //   row_styles="blue"            → blue tint (table_row_even_blue / table_row_odd_blue)
+            //   row_styles=["my_even","my_odd"] → custom style names
+            if let Some(rs) = row_styles {
+                if rs.is_true() {
+                    match rs.kind() {
+                        minijinja::value::ValueKind::Bool => {
+                            table = table.row_styles("table_row_even", "table_row_odd");
+                        }
+                        minijinja::value::ValueKind::String => {
+                            let tint = rs.to_string();
+                            let even = format!("table_row_even_{}", tint);
+                            let odd = format!("table_row_odd_{}", tint);
+                            table = table.row_styles(even, odd);
+                        }
+                        _ => {
+                            if let Ok(iter) = rs.try_iter() {
+                                let names: Vec<String> = iter.map(|v| v.to_string()).collect();
+                                if names.len() == 2 {
+                                    table = table.row_styles(&names[0], &names[1]);
+                                } else {
+                                    return Err(minijinja::Error::new(
+                                        minijinja::ErrorKind::InvalidOperation,
+                                        "row_styles array must have exactly 2 elements: [even_style, odd_style]",
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             Ok(Value::from_object(table))

--- a/crates/standout-render/src/theme/theme.rs
+++ b/crates/standout-render/src/theme/theme.rs
@@ -674,7 +674,61 @@ impl Theme {
 
 impl Default for Theme {
     fn default() -> Self {
+        use console::{Color, Style};
+
+        // ANSI 256 color reference for tints:
+        //
+        // Dark mode (very dark tinted bg):        Light mode (pastel tinted bg):
+        //   gray:   236 (#303030)                   gray:   254 (#e4e4e4)
+        //   blue:    17 (#00005f)                   blue:   189 (#d7d7ff)
+        //   red:     52 (#5f0000)                   red:    224 (#ffd7d7)
+        //   green:   22 (#005f00)                   green:  194 (#d7ffd7)
+        //   purple:  53 (#5f005f)                   purple: 225 (#ffd7ff)
+
         Self::new()
+            // ── Base (gray) ─────────────────────────────────────────────
+            .add("table_row_even", Style::new())
+            .add_adaptive(
+                "table_row_odd",
+                Style::new(),
+                Some(Style::new().bg(Color::Color256(254))),
+                Some(Style::new().bg(Color::Color256(236))),
+            )
+            // gray is an alias for the base variant
+            .add("table_row_even_gray", "table_row_even")
+            .add("table_row_odd_gray", "table_row_odd")
+            // ── Blue ────────────────────────────────────────────────────
+            .add("table_row_even_blue", Style::new())
+            .add_adaptive(
+                "table_row_odd_blue",
+                Style::new(),
+                Some(Style::new().bg(Color::Color256(189))),
+                Some(Style::new().bg(Color::Color256(17))),
+            )
+            // ── Red ─────────────────────────────────────────────────────
+            .add("table_row_even_red", Style::new())
+            .add_adaptive(
+                "table_row_odd_red",
+                Style::new(),
+                Some(Style::new().bg(Color::Color256(224))),
+                Some(Style::new().bg(Color::Color256(52))),
+            )
+            // ── Green ───────────────────────────────────────────────────
+            .add("table_row_even_green", Style::new())
+            .add_adaptive(
+                "table_row_odd_green",
+                Style::new(),
+                Some(Style::new().bg(Color::Color256(194))),
+                Some(Style::new().bg(Color::Color256(22))),
+            )
+            // ── Purple ──────────────────────────────────────────────────
+            .add("table_row_even_purple", Style::new())
+            .add_adaptive(
+                "table_row_odd_purple",
+                Style::new(),
+                Some(Style::new().bg(Color::Color256(225))),
+                Some(Style::new().bg(Color::Color256(53))),
+            )
     }
 }
 
@@ -830,7 +884,11 @@ mod tests {
     #[test]
     fn test_theme_default() {
         let theme = Theme::default();
-        assert!(theme.is_empty());
+        // Default theme includes built-in table row styles
+        assert!(!theme.is_empty());
+        let styles = theme.resolve_styles(Some(crate::ColorMode::Dark));
+        assert!(styles.resolve("table_row_even").is_some());
+        assert!(styles.resolve("table_row_odd").is_some());
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

- Add `Table::row_styles(even, odd)` for automatic zebra-striped data rows — each row is wrapped in alternating `[style]...[/style]` tags resolved by the BBParser
- Ship five built-in adaptive tints in `Theme::default()`: **gray** (default), **blue**, **red**, **green**, **purple** — each with dark-mode and light-mode background colors
- Template `table()` function gains `row_styles` kwarg: `true` (gray), `"blue"` (named tint), or `["even", "odd"]` (custom)
- `_gray` suffix aliases to the base `table_row_even`/`table_row_odd` names

## Color map

| Tint | Dark bg (odd) | Light bg (odd) |
|--------|---------------|----------------|
| gray | 236 `#303030` | 254 `#e4e4e4` |
| blue | 17 `#00005f` | 189 `#d7d7ff` |
| red | 52 `#5f0000` | 224 `#ffd7d7` |
| green | 22 `#005f00` | 194 `#d7ffd7` |
| purple | 53 `#5f005f` | 225 `#ffd7ff` |

## Test plan

- [x] All 824 standout-render lib tests pass
- [x] Full CI suite passes (check, fmt, clippy -D warnings, tests, doctests)
- [x] Visual example: `cargo run -p standout-render --example table_row_styles`
- [x] CHANGELOG, tabular guide, and styling-system docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)