### PR TITLE
Fix CSS stylesheet hot-reload parse error; drop YAML-centric assumptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CSS stylesheets now hot-reload correctly in debug builds.** `EmbeddedStyles::into::<StylesheetRegistry>()` was parsing every on-disk stylesheet as YAML, so `.css` files failed with a YAML error and the registry silently fell back to the compile-time embedded content — making edits appear to be "cached" until the next rebuild. The hot-reload path and `StylesheetRegistry::add_inline` now use the same auto-detecting CSS/YAML parser as the release embedded path.
+
+### Changed
+
+- `StylesheetRegistry::add_inline` parameter renamed `yaml` → `content`; it accepts either CSS or YAML (format auto-detected). The method's behavior is strictly wider than before, so no caller changes are required.
+- Docs and doc-examples across `standout-render`, `standout-macros`, and top-level docs updated to describe stylesheets as CSS (preferred) with legacy YAML, instead of YAML-only.
+
 ## [7.3.0] - 2026-04-16
 
 ### Added

--- a/crates/standout-macros/src/embed.rs
+++ b/crates/standout-macros/src/embed.rs
@@ -136,7 +136,7 @@ fn resolve_path(path: &str) -> PathBuf {
 /// Collects all files from a directory with matching extensions.
 ///
 /// Returns a vector of (name_with_ext, content) pairs where name_with_ext
-/// is the relative path from root INCLUDING the extension (e.g., "themes/dark.yaml").
+/// is the relative path from root INCLUDING the extension (e.g., "themes/dark.css").
 ///
 /// NO extension stripping or priority logic is done here - that's the registry's job.
 fn collect_files(dir: &Path, extensions: &[&str]) -> Result<Vec<(String, String)>, String> {

--- a/crates/standout-macros/src/lib.rs
+++ b/crates/standout-macros/src/lib.rs
@@ -102,11 +102,15 @@ pub fn embed_templates(input: TokenStream) -> TokenStream {
 /// # Supported Extensions
 ///
 /// Files are recognized by extension (in priority order):
-/// - `.yaml` (highest priority)
-/// - `.yml` (lowest priority)
+/// - `.css` (highest priority — preferred format)
+/// - `.yaml` (legacy)
+/// - `.yml` (legacy, lowest priority)
+///
+/// The format is auto-detected from the content itself at parse time, so the
+/// extension only matters for file discovery and priority resolution.
 ///
 /// When multiple files share the same base name with different extensions
-/// (e.g., `dark.yaml` and `dark.yml`), the higher-priority extension wins.
+/// (e.g., `dark.css` and `dark.yaml`), the higher-priority extension wins.
 ///
 /// # Hot Reload Behavior
 ///

--- a/crates/standout-render/src/embedded.rs
+++ b/crates/standout-render/src/embedded.rs
@@ -30,9 +30,8 @@ use std::marker::PhantomData;
 use std::path::Path;
 
 use crate::file_loader::{build_embedded_registry, walk_dir};
-use crate::style::{StylesheetRegistry, STYLESHEET_EXTENSIONS};
+use crate::style::{parse_theme_content, StylesheetRegistry, STYLESHEET_EXTENSIONS};
 use crate::template::{walk_template_dir, TemplateRegistry};
-use crate::theme::Theme;
 
 /// Marker type for template resources.
 #[derive(Debug, Clone, Copy)]
@@ -151,7 +150,8 @@ impl From<EmbeddedStyles> for StylesheetRegistry {
     ///
     /// # Panics
     ///
-    /// Panics if embedded YAML content fails to parse (should be caught in dev).
+    /// Panics if embedded stylesheet content (CSS or YAML) fails to parse
+    /// (should be caught in dev).
     fn from(source: EmbeddedStyles) -> Self {
         if source.should_hot_reload() {
             // Debug mode with existing source path: load from filesystem
@@ -192,8 +192,8 @@ impl From<EmbeddedStyles> for StylesheetRegistry {
                 .collect();
 
             let inline =
-                match build_embedded_registry(&entries_refs, STYLESHEET_EXTENSIONS, |yaml| {
-                    Theme::from_yaml(yaml)
+                match build_embedded_registry(&entries_refs, STYLESHEET_EXTENSIONS, |content| {
+                    parse_theme_content(content)
                 }) {
                     Ok(map) => map,
                     Err(e) => {

--- a/crates/standout-render/src/file_loader.rs
+++ b/crates/standout-render/src/file_loader.rs
@@ -33,9 +33,9 @@
 //! │   └── report/
 //! │       └── summary.jinja
 //! └── styles/
-//!     ├── default.yaml
+//!     ├── default.css
 //!     └── themes/
-//!         └── dark.yaml
+//!         └── dark.css
 //! ```
 //!
 //! ## Name Resolution
@@ -46,7 +46,7 @@
 //! |-----------|-----------------|
 //! | `templates/list.jinja` | `"list"` |
 //! | `templates/report/summary.jinja` | `"report/summary"` |
-//! | `styles/themes/dark.yaml` | `"themes/dark"` |
+//! | `styles/themes/dark.css` | `"themes/dark"` |
 //!
 //! ## Development Usage
 //!
@@ -56,7 +56,7 @@
 //! use standout_render::file_loader::{FileRegistry, FileRegistryConfig};
 //!
 //! let config = FileRegistryConfig {
-//!     extensions: &[".yaml", ".yml"],
+//!     extensions: &[".css", ".yaml", ".yml"],
 //!     transform: |content| Ok(content.to_string()),
 //! };
 //!
@@ -91,10 +91,10 @@
 //! base name, the extension appearing earlier wins for extensionless lookups:
 //!
 //! ```rust,ignore
-//! // With extensions: [".yaml", ".yml"]
-//! // If both default.yaml and default.yml exist:
-//! registry.get("default")     // → default.yaml (higher priority)
-//! registry.get("default.yml") // → default.yml (explicit)
+//! // With extensions: [".css", ".yaml", ".yml"]
+//! // If both default.css and default.yaml exist:
+//! registry.get("default")      // → default.css (higher priority)
+//! registry.get("default.yaml") // → default.yaml (explicit)
 //! ```
 //!
 //! # Extension-Agnostic Resolution
@@ -104,11 +104,11 @@
 //! callers to use any known extension regardless of the actual file extension:
 //!
 //! ```rust,ignore
-//! // File on disk: config.yaml
-//! // Registry has: "config" and "config.yaml"
-//! registry.get("config")       // → found (extensionless key)
-//! registry.get("config.yaml")  // → found (exact match)
-//! registry.get("config.yml")   // → found (strips .yml, falls back to "config")
+//! // File on disk: theme.css
+//! // Registry has: "theme" and "theme.css"
+//! registry.get("theme")        // → found (extensionless key)
+//! registry.get("theme.css")    // → found (exact match)
+//! registry.get("theme.yaml")   // → found (strips .yaml, falls back to "theme")
 //! ```
 //!
 //! # Collision Detection
@@ -123,7 +123,7 @@
 //! | Resource | Extensions | Transform |
 //! |----------|------------|-----------|
 //! | Templates | `.jinja`, `.jinja2`, `.j2`, `.txt` | Identity |
-//! | Stylesheets | `.yaml`, `.yml` | YAML parsing |
+//! | Stylesheets | `.css`, `.yaml`, `.yml` | Auto-detect CSS or YAML |
 //! | Custom | User-defined | User-defined |
 //!
 //! The registry is generic over content type `T`, enabling consistent behavior
@@ -396,9 +396,9 @@ pub enum LoadedEntry<T> {
 ///     transform: |content| Ok(content.to_string()),
 /// }
 ///
-/// // For stylesheet files (YAML parsing)
+/// // For stylesheet files (auto-detects CSS or YAML)
 /// FileRegistryConfig {
-///     extensions: &[".yaml", ".yml"],
+///     extensions: &[".css", ".yaml", ".yml"],
 ///     transform: |content| parse_style_definitions(content),
 /// }
 /// ```

--- a/crates/standout-render/src/style/file_registry.rs
+++ b/crates/standout-render/src/style/file_registry.rs
@@ -1,7 +1,9 @@
 //! Stylesheet registry for file-based theme loading.
 //!
 //! This module provides [`StylesheetRegistry`], which manages theme resolution
-//! from multiple sources: inline YAML, filesystem directories, or embedded content.
+//! from multiple sources: inline content, filesystem directories, or embedded
+//! content. Stylesheets may be written in CSS (preferred) or YAML (legacy);
+//! the format is auto-detected from the content itself.
 //!
 //! # Design
 //!
@@ -24,7 +26,7 @@
 //!
 //! 1. Inline stylesheets (added via [`StylesheetRegistry::add_inline`]) have highest priority
 //! 2. File stylesheets are searched in directory registration order (first directory wins)
-//! 3. Names can be specified with or without extension: both `"darcula"` and `"darcula.yaml"` resolve
+//! 3. Names can be specified with or without extension: both `"darcula"` and `"darcula.css"` resolve
 //!
 //! # Supported Extensions
 //!
@@ -32,11 +34,12 @@
 //!
 //! | Priority | Extension | Description |
 //! |----------|-----------|-------------|
-//! | 1 (highest) | `.yaml` | Standard YAML extension |
-//! | 2 (lowest) | `.yml` | Short YAML extension |
+//! | 1 (highest) | `.css`  | CSS stylesheet (preferred) |
+//! | 2           | `.yaml` | YAML stylesheet (legacy) |
+//! | 3 (lowest)  | `.yml`  | YAML stylesheet, short extension (legacy) |
 //!
 //! If multiple files exist with the same base name but different extensions
-//! (e.g., `darcula.yaml` and `darcula.yml`), the higher-priority extension wins.
+//! (e.g., `darcula.css` and `darcula.yaml`), the higher-priority extension wins.
 //!
 //! # Collision Handling
 //!
@@ -90,7 +93,7 @@ fn stylesheet_config() -> FileRegistryConfig<Theme> {
 ///
 /// CSS is detected by the presence of a CSS class selector (`.name {`),
 /// which distinguishes it from YAML inline maps that also use `{`.
-fn parse_theme_content(content: &str) -> Result<Theme, StylesheetError> {
+pub(crate) fn parse_theme_content(content: &str) -> Result<Theme, StylesheetError> {
     let trimmed = content.trim_start();
     // CSS files start with class selectors (.name), comments (/*), or @media queries
     if trimmed.starts_with('.') || trimmed.starts_with("/*") || trimmed.starts_with("@media") {
@@ -125,11 +128,9 @@ fn parse_theme_content(content: &str) -> Result<Theme, StylesheetError> {
 /// ```rust,ignore
 /// let mut registry = StylesheetRegistry::new();
 ///
-/// // Add inline theme (highest priority)
+/// // Add inline theme (highest priority) — CSS or YAML, auto-detected
 /// registry.add_inline("custom", r#"
-/// header:
-///   fg: cyan
-///   bold: true
+/// .header { color: cyan; font-weight: bold; }
 /// "#)?;
 ///
 /// // Add from directory
@@ -161,7 +162,11 @@ impl StylesheetRegistry {
         }
     }
 
-    /// Adds an inline theme from a YAML string.
+    /// Adds an inline theme from stylesheet content (CSS or YAML).
+    ///
+    /// The format is auto-detected: content starting with a class selector
+    /// (`.name`), a comment (`/*`), or `@media` is parsed as CSS; everything
+    /// else is parsed as YAML.
     ///
     /// Inline themes have the highest priority and will shadow any
     /// file-based themes with the same name.
@@ -169,29 +174,34 @@ impl StylesheetRegistry {
     /// # Arguments
     ///
     /// * `name` - The theme name for resolution
-    /// * `yaml` - The YAML content defining the theme
+    /// * `content` - The stylesheet content (CSS or YAML) defining the theme
     ///
     /// # Errors
     ///
-    /// Returns an error if the YAML content cannot be parsed.
+    /// Returns an error if the content cannot be parsed.
     ///
     /// # Example
     ///
     /// ```rust,ignore
+    /// // CSS
     /// registry.add_inline("custom", r#"
+    /// .header { color: cyan; font-weight: bold; }
+    /// .muted { opacity: 0.6; }
+    /// "#)?;
+    ///
+    /// // YAML
+    /// registry.add_inline("legacy", r#"
     /// header:
     ///   fg: cyan
     ///   bold: true
-    /// muted:
-    ///   dim: true
     /// "#)?;
     /// ```
     pub fn add_inline(
         &mut self,
         name: impl Into<String>,
-        yaml: &str,
+        content: &str,
     ) -> Result<(), StylesheetError> {
-        let theme = Theme::from_yaml(yaml)?;
+        let theme = parse_theme_content(content)?;
         self.inline.insert(name.into(), theme);
         Ok(())
     }
@@ -212,9 +222,10 @@ impl StylesheetRegistry {
     /// Adds a stylesheet directory to search for files.
     ///
     /// Themes in the directory are resolved by their filename without
-    /// extension. For example, with directory `./themes`:
+    /// extension. Both `.css` (preferred) and `.yaml`/`.yml` (legacy) files
+    /// are recognized. For example, with directory `./themes`:
     ///
-    /// - `"darcula"` → `./themes/darcula.yaml`
+    /// - `"darcula"` → `./themes/darcula.css`
     /// - `"monokai"` → `./themes/monokai.yaml`
     ///
     /// # Errors
@@ -266,15 +277,17 @@ impl StylesheetRegistry {
     ///
     /// # Arguments
     ///
-    /// * `entries` - Slice of `(name_with_ext, yaml_content)` pairs where `name_with_ext`
-    ///   is the relative path including extension (e.g., `"themes/dark.yaml"`)
+    /// * `entries` - Slice of `(name_with_ext, stylesheet_content)` pairs where
+    ///   `name_with_ext` is the relative path including extension
+    ///   (e.g., `"themes/dark.css"` or `"themes/dark.yaml"`)
     ///
     /// # Processing
     ///
     /// This method applies the same logic as runtime file loading:
     ///
-    /// 1. YAML parsing: Each entry's content is parsed as a theme definition
-    /// 2. Extension stripping: `"themes/dark.yaml"` → `"themes/dark"`
+    /// 1. Stylesheet parsing: Each entry's content is parsed as a theme
+    ///    definition, auto-detecting CSS vs YAML
+    /// 2. Extension stripping: `"themes/dark.css"` → `"themes/dark"`
     /// 3. Extension priority: When multiple files share a base name, the
     ///    higher-priority extension wins (see [`STYLESHEET_EXTENSIONS`])
     /// 4. Dual registration: Each theme is accessible by both its base
@@ -282,7 +295,7 @@ impl StylesheetRegistry {
     ///
     /// # Errors
     ///
-    /// Returns an error if any YAML content fails to parse.
+    /// Returns an error if any stylesheet content fails to parse.
     ///
     /// # Example
     ///
@@ -291,7 +304,7 @@ impl StylesheetRegistry {
     ///
     /// // Typically generated by embed_styles! macro
     /// let entries: &[(&str, &str)] = &[
-    ///     ("default.yaml", "header:\n  fg: cyan\n  bold: true"),
+    ///     ("default.css", ".header { color: cyan; font-weight: bold; }"),
     ///     ("themes/dark.yaml", "panel:\n  fg: white"),
     /// ];
     ///
@@ -299,7 +312,7 @@ impl StylesheetRegistry {
     ///
     /// // Access by base name or full name
     /// assert!(registry.get("default").is_ok());
-    /// assert!(registry.get("default.yaml").is_ok());
+    /// assert!(registry.get("default.css").is_ok());
     /// assert!(registry.get("themes/dark").is_ok());
     /// ```
     pub fn from_embedded_entries(entries: &[(&str, &str)]) -> Result<Self, StylesheetError> {

--- a/crates/standout-render/src/style/mod.rs
+++ b/crates/standout-render/src/style/mod.rs
@@ -1,4 +1,7 @@
-//! Style system for named styles, aliases, and YAML-based stylesheets.
+//! Style system for named styles, aliases, and stylesheets.
+//!
+//! Stylesheets can be written in CSS (preferred) or YAML (legacy). The
+//! [`StylesheetRegistry`] auto-detects the format from content when loading.
 //!
 //! This module provides the complete styling infrastructure:
 //!
@@ -8,11 +11,12 @@
 //! - [`Styles`]: A registry of named styles
 //! - [`StyleValidationError`]: Errors from style validation
 //!
-//! ## YAML Stylesheet Parsing
+//! ## Stylesheet Parsing
 //!
-//! - [`parse_stylesheet`]: Parse YAML into theme variants
+//! - [`parse_css`]: Parse CSS source into theme variants
+//! - [`parse_stylesheet`]: Parse YAML source into theme variants (legacy)
 //! - [`ThemeVariants`]: Styles resolved for base/light/dark modes
-//! - [`StylesheetRegistry`]: File-based theme management
+//! - [`StylesheetRegistry`]: File-based theme management (auto-detects CSS/YAML)
 //!
 //! ## YAML Schema
 //!
@@ -96,5 +100,6 @@ pub use attributes::StyleAttributes;
 pub use color::ColorDef;
 pub use css_parser::parse_css;
 pub use definition::StyleDefinition;
+pub(crate) use file_registry::parse_theme_content;
 pub use file_registry::{StylesheetRegistry, STYLESHEET_EXTENSIONS};
 pub use parser::{parse_stylesheet, ThemeVariants};

--- a/crates/standout-render/src/theme/theme.rs
+++ b/crates/standout-render/src/theme/theme.rs
@@ -1,8 +1,8 @@
 //! Theme struct for building style collections.
 //!
 //! Themes are named collections of styles that can adapt to the user's
-//! display mode (light/dark). They support both programmatic construction
-//! and YAML-based file loading.
+//! display mode (light/dark). They support programmatic construction and
+//! file loading from CSS (preferred) or YAML (legacy) stylesheets.
 //!
 //! # Adaptive Styles
 //!

--- a/crates/standout/tests/embed_macros.rs
+++ b/crates/standout/tests/embed_macros.rs
@@ -146,6 +146,66 @@ fn test_embed_styles_extension_priority() {
 }
 
 // =============================================================================
+// CSS stylesheet tests
+//
+// Regression coverage for a bug where the debug hot-reload path parsed every
+// on-disk stylesheet as YAML, causing `.css` files to fail to parse and silently
+// fall back to the compile-time embedded copy. Both fixtures below are `.css`
+// so they exercise `parse_theme_content`'s CSS branch end-to-end through the
+// embed macro and the hot-reload path.
+// =============================================================================
+
+#[test]
+fn test_embed_styles_css_file() {
+    let mut styles: StylesheetRegistry = embed_styles!("tests/fixtures/styles").into();
+
+    // screen.css has no YAML sibling — if CSS parsing were broken, this would
+    // fail at load time or return a theme with no styles.
+    let theme = styles.get("screen").expect("screen.css should load");
+    let resolved = theme.resolve_styles(None);
+    assert!(
+        resolved.has("header"),
+        "CSS .header class should be registered"
+    );
+    assert!(
+        resolved.has("muted"),
+        "CSS .muted class should be registered"
+    );
+}
+
+#[test]
+fn test_embed_styles_css_accessible_by_full_name() {
+    let mut styles: StylesheetRegistry = embed_styles!("tests/fixtures/styles").into();
+
+    let theme = styles
+        .get("screen.css")
+        .expect("screen.css should be accessible by full filename");
+    let resolved = theme.resolve_styles(None);
+    assert!(resolved.has("header"));
+}
+
+#[test]
+fn test_embed_styles_css_beats_yaml_priority() {
+    // Both themes/light.css and themes/light.yaml exist with the same base name.
+    // Per STYLESHEET_EXTENSIONS = [".css", ".yaml", ".yml"], the CSS file wins.
+    let mut styles: StylesheetRegistry = embed_styles!("tests/fixtures/styles").into();
+
+    let theme = styles
+        .get("themes/light")
+        .expect("themes/light should resolve");
+    let resolved = theme.resolve_styles(None);
+
+    assert!(
+        resolved.has("css_wins"),
+        "CSS file must win priority — expected `css_wins` style from light.css"
+    );
+    assert!(
+        !resolved.has("yaml_loses"),
+        "YAML file must lose priority — `yaml_loses` should not be present"
+    );
+}
+
+// =============================================================================
 // EmbeddedSource tests
 // =============================================================================
 

--- a/crates/standout/tests/fixtures/styles/screen.css
+++ b/crates/standout/tests/fixtures/styles/screen.css
@@ -1,0 +1,12 @@
+/* Pure CSS fixture — regression test for the hot-reload CSS parsing bug
+ * where CSS files were mis-parsed as YAML.
+ */
+
+.header {
+    color: cyan;
+    font-weight: bold;
+}
+
+.muted {
+    opacity: 0.6;
+}

--- a/crates/standout/tests/fixtures/styles/themes/light.css
+++ b/crates/standout/tests/fixtures/styles/themes/light.css
@@ -1,0 +1,16 @@
+/* CSS variant for priority tests — both light.css and light.yaml exist
+ * with the same base name. Priority resolution must pick THIS file
+ * (.css beats .yaml per STYLESHEET_EXTENSIONS).
+ *
+ * The style name `css_wins` is unique to this file; tests assert it
+ * resolves so we know the CSS file was picked (not the YAML one).
+ */
+
+.css_wins {
+    color: blue;
+    font-weight: bold;
+}
+
+.header {
+    color: blue;
+}

--- a/crates/standout/tests/fixtures/styles/themes/light.yaml
+++ b/crates/standout/tests/fixtures/styles/themes/light.yaml
@@ -1,0 +1,8 @@
+# YAML variant for priority tests — must LOSE to light.css.
+# The style `yaml_loses` is unique to this file: if a test ever sees
+# this style when resolving `themes/light`, .css/.yaml priority has
+# regressed.
+yaml_loses:
+  fg: magenta
+header:
+  fg: magenta

--- a/docs/dev/features.txt
+++ b/docs/dev/features.txt
@@ -229,7 +229,9 @@ Template Extensions Supported:
   - .stpl: simple engine templates
 
 Stylesheet Extensions:
-  - .yaml, .yml: YAML stylesheets (priority order)
+  - .css: CSS stylesheets (preferred, highest priority)
+  - .yaml, .yml: YAML stylesheets (legacy)
+  Format is auto-detected from content; extension controls discovery/priority only.
 
 
 HELP SYSTEM

--- a/docs/information-lib.lex
+++ b/docs/information-lib.lex
@@ -1046,20 +1046,22 @@ THEME: Themes & Styles
 43. How do I load themes from files?
 
 	Single file:
-		let theme = Theme::from_file("themes/dark.yaml")?;
+		let theme = Theme::from_file("themes/dark.css")?;
 	:: rust ::
 
-	The theme name is extracted from the filename (without extension).
+	The theme name is extracted from the filename (without extension). CSS
+	(preferred) and YAML (legacy) are both accepted; the format is auto-detected
+	from content.
 
 	Directory of themes (StylesheetRegistry):
 		let mut registry = StylesheetRegistry::new();
 		registry.load_directory("themes/")?;
 
-		let dark = registry.get("dark")?;   // themes/dark.yaml
-		let light = registry.get("light")?; // themes/light.yaml
+		let dark = registry.get("dark")?;   // themes/dark.css
+		let light = registry.get("light")?; // themes/light.css
 	:: rust ::
 
-	Supported extensions: .yaml, .yml
+	Supported extensions: .css (preferred), .yaml, .yml (legacy)
 
 
 44. How do I validate a theme?
@@ -1288,7 +1290,7 @@ THEME: App Configuration
 	:: rust ::
 
 	embed_templates! collects files matching: .jinja, .jinja2, .j2, .txt
-	embed_styles! collects files matching: .yaml, .yml
+	embed_styles! collects files matching: .css (preferred), .yaml, .yml (legacy)
 
 	The macros produce EmbeddedSource<T> containing:
 	  - Static array of (filename, content) pairs

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -93,7 +93,7 @@ src/
         list.jinja
         add.jinja  # each command has its own template, by default name-matched
     styles/
-        default.yml
+        default.css
 ```
 
 And your application:


### PR DESCRIPTION
## Summary

- Hot-reload path for embedded stylesheets was parsing every on-disk file as YAML, so `.css` files failed with a YAML parse error and the registry silently fell back to the compile-time embedded content — edits looked "cached" until the next `cargo build`.
- Root cause: `embedded.rs:195` called `Theme::from_yaml` directly instead of the auto-detecting `parse_theme_content` helper that the release embedded path already used. `StylesheetRegistry::add_inline` had the same bug.
- Anti-recurrence: renamed the misleading `|yaml|` closure param and `yaml:` method param to `content`, swept rustdoc/macro docs/external docs for YAML-only language about stylesheets, and added CSS regression tests so this exact class of bug can't reappear quietly.

## Details

**Fix**
- `crates/standout-render/src/style/file_registry.rs` — promote `parse_theme_content` to `pub(crate)`; `add_inline` now uses it (accepts CSS or YAML, auto-detected). Param `yaml` → `content`.
- `crates/standout-render/src/embedded.rs` — hot-reload closure uses `parse_theme_content` instead of `Theme::from_yaml`; closure param `|yaml|` → `|content|`.
- `crates/standout-render/src/style/mod.rs` — re-export `parse_theme_content` crate-internally.

**Tests**
- New CSS fixtures: `screen.css`, `themes/light.css`, plus a losing `themes/light.yaml`.
- New tests in `tests/embed_macros.rs`:
  - `test_embed_styles_css_file` — pure CSS loads end-to-end through the fixed hot-reload path.
  - `test_embed_styles_css_accessible_by_full_name` — resolves by full `.css` filename.
  - `test_embed_styles_css_beats_yaml_priority` — with both `.css` and `.yaml` present for the same base name, `.css` wins. Uses unique style names in each fixture (`css_wins` / `yaml_loses`) so the assertion is unambiguous.

**Docs / anti-drift**
- `embed_styles!` macro rustdoc now lists `.css` as highest-priority extension with `.yaml`/`.yml` noted as legacy.
- Rustdoc sweep: `file_registry.rs`, `embedded.rs`, `file_loader.rs`, `style/mod.rs`, `theme/theme.rs` — priority tables, examples, and descriptions updated to describe stylesheets as CSS (preferred) + YAML (legacy) rather than "YAML-based".
- External docs: `docs/information-lib.lex` (2 call-outs), `docs/intro.md`, `docs/dev/features.txt`.

## Compatibility

- `add_inline` accepts a strictly wider input (CSS or YAML, was YAML-only). No caller changes needed. Parameter name rename is source-compatible because the param is positional.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all --all-features -- -D warnings` clean
- [x] `cargo test --workspace` — all unit + integration tests pass, including 3 new CSS regression tests
- [x] Pre-commit hook passes (runs full CI locally)
- [ ] Verify in a downstream consumer (dodot) that editing a `.css` file in `src/styles/` and running `cargo build && target/debug/<app> <cmd>` now picks up the edit without a rebuild

Note: one pre-existing doctest failure in `standout-render::tabular::util::visible_width` is unrelated to this change (reproduces on unmodified `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)