### PR TITLE
Route framework warnings to a styled banner after command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Framework warnings now render as a styled banner after the command output.** Non-fatal problems that standout detects during setup — stylesheet hot-reload failures, template walk errors, etc. — used to emit `Warning:` lines via `eprintln!` *before* the command ran, jammed on top of the real output as plain text. They now flow through a new thread-local collector (`standout::warnings`) and are flushed to stderr at the end of `App::run`, under a `Standout :: Warnings` banner with each entry on its own tab-indented line.
+
+  Two new styles in `Theme::default()` — `standout_warning_banner` (black on orange #208, bold) and `standout_warning_item` — control the look; user themes can override either. Styling is applied only when stderr supports color; piped/redirected stderr still gets plain text. `OutputMode::Text` forces plain output.
+
+  Public API: `standout::warnings::{push_warning, drain_warnings, has_warnings, flush_to_stderr}`.
+
 ## [7.4.0] - 2026-04-17
 
 ### Fixed

--- a/crates/standout-render/src/embedded.rs
+++ b/crates/standout-render/src/embedded.rs
@@ -32,6 +32,7 @@ use std::path::Path;
 use crate::file_loader::{build_embedded_registry, walk_dir};
 use crate::style::{parse_theme_content, StylesheetRegistry, STYLESHEET_EXTENSIONS};
 use crate::template::{walk_template_dir, TemplateRegistry};
+use crate::warnings::push_warning;
 
 /// Marker type for template resources.
 #[derive(Debug, Clone, Copy)]
@@ -118,20 +119,20 @@ impl From<EmbeddedTemplates> for TemplateRegistry {
             let files = match walk_template_dir(source.source_path) {
                 Ok(files) => files,
                 Err(e) => {
-                    eprintln!(
-                        "Warning: Failed to walk templates directory '{}', using embedded: {}",
+                    push_warning(format!(
+                        "Failed to walk templates directory '{}', using embedded: {}",
                         source.source_path, e
-                    );
+                    ));
                     return TemplateRegistry::from_embedded_entries(source.entries);
                 }
             };
 
             let mut registry = TemplateRegistry::new();
             if let Err(e) = registry.add_from_files(files) {
-                eprintln!(
-                    "Warning: Failed to register templates from '{}', using embedded: {}",
+                push_warning(format!(
+                    "Failed to register templates from '{}', using embedded: {}",
                     source.source_path, e
-                );
+                ));
                 return TemplateRegistry::from_embedded_entries(source.entries);
             }
             registry
@@ -160,10 +161,10 @@ impl From<EmbeddedStyles> for StylesheetRegistry {
             let files = match walk_dir(Path::new(source.source_path), STYLESHEET_EXTENSIONS) {
                 Ok(files) => files,
                 Err(e) => {
-                    eprintln!(
-                        "Warning: Failed to walk styles directory '{}', using embedded: {}",
+                    push_warning(format!(
+                        "Failed to walk styles directory '{}', using embedded: {}",
                         source.source_path, e
-                    );
+                    ));
                     return StylesheetRegistry::from_embedded_entries(source.entries)
                         .expect("embedded stylesheets should parse");
                 }
@@ -175,11 +176,11 @@ impl From<EmbeddedStyles> for StylesheetRegistry {
                 .filter_map(|file| match std::fs::read_to_string(&file.path) {
                     Ok(content) => Some((file.name_with_ext, content)),
                     Err(e) => {
-                        eprintln!(
-                            "Warning: Failed to read stylesheet '{}': {}",
+                        push_warning(format!(
+                            "Failed to read stylesheet '{}': {}",
                             file.path.display(),
                             e
-                        );
+                        ));
                         None
                     }
                 })
@@ -197,10 +198,10 @@ impl From<EmbeddedStyles> for StylesheetRegistry {
                 }) {
                     Ok(map) => map,
                     Err(e) => {
-                        eprintln!(
-                            "Warning: Failed to parse stylesheets from '{}', using embedded: {}",
+                        push_warning(format!(
+                            "Failed to parse stylesheets from '{}', using embedded: {}",
                             source.source_path, e
-                        );
+                        ));
                         return StylesheetRegistry::from_embedded_entries(source.entries)
                             .expect("embedded stylesheets should parse");
                     }

--- a/crates/standout-render/src/lib.rs
+++ b/crates/standout-render/src/lib.rs
@@ -156,6 +156,7 @@ pub mod tabular;
 pub mod template;
 pub mod theme;
 mod util;
+pub mod warnings;
 
 // Error type
 pub use error::RenderError;

--- a/crates/standout-render/src/theme/theme.rs
+++ b/crates/standout-render/src/theme/theme.rs
@@ -686,6 +686,20 @@ impl Default for Theme {
         //   purple:  53 (#5f005f)                   purple: 225 (#ffd7ff)
 
         Self::new()
+            // ── Framework warnings ──────────────────────────────────────
+            // Banner shown before the per-warning list when the framework
+            // emits deferred warnings (e.g. stylesheet hot-reload failures).
+            // Black text on orange (ANSI 256 #208) with bold for prominence.
+            // Items are rendered without extra styling; the leading tab is
+            // applied by the CLI flush path, not the style.
+            .add(
+                "standout_warning_banner",
+                Style::new()
+                    .fg(Color::Black)
+                    .bg(Color::Color256(208))
+                    .bold(),
+            )
+            .add("standout_warning_item", Style::new())
             // ── Base (gray) ─────────────────────────────────────────────
             .add("table_row_even", Style::new())
             .add_adaptive(

--- a/crates/standout-render/src/warnings.rs
+++ b/crates/standout-render/src/warnings.rs
@@ -1,0 +1,247 @@
+//! Framework warning collection and deferred rendering.
+//!
+//! Some parts of standout-render (notably the embedded-resource hot-reload
+//! path in [`crate::embedded`]) can encounter non-fatal problems during
+//! application startup — e.g. a stylesheet fails to parse and the framework
+//! silently falls back to the compile-time embedded copy. Historically these
+//! were emitted via `eprintln!` *during* initialization, which meant they
+//! printed *before* the command's own output and as plain text, even when
+//! rendering into a rich terminal.
+//!
+//! This module routes those messages through a process-local collector so
+//! the CLI layer can render them *after* the command output, styled through
+//! the active theme, with a clear banner separating them from the rest of
+//! the terminal session.
+//!
+//! # Scope
+//!
+//! Only *framework warnings* (problems with standout's own setup / resource
+//! loading) should go through this module. User-facing diagnostics that are
+//! part of a handler's legitimate output — clipboard access failures, input
+//! validation feedback, handler-generated I/O errors — stay on stderr as
+//! before; interleaving them with other output is the correct behavior.
+//!
+//! # Usage
+//!
+//! Inside the framework, call [`push_warning`] instead of `eprintln!`:
+//!
+//! ```rust,ignore
+//! use standout_render::warnings::push_warning;
+//! push_warning(format!("Failed to parse stylesheets from '{}': {}", path, err));
+//! ```
+//!
+//! The CLI layer drains the collector at the end of `App::run` and renders
+//! the batch through the theme; see the `standout` crate for the flush
+//! logic.
+
+use std::cell::RefCell;
+use std::io::Write;
+
+use crate::output::OutputMode;
+use crate::theme::Theme;
+
+thread_local! {
+    /// Thread-local buffer of framework warnings collected during this run.
+    ///
+    /// A CLI process is effectively single-threaded for the duration of
+    /// `App::run` (handlers themselves may spawn threads, but framework
+    /// warnings come from the main-thread setup path), so a thread-local
+    /// is sufficient and avoids the overhead of a mutex.
+    static WARNINGS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Appends a framework warning to the thread-local collector.
+///
+/// The warning is stored verbatim — callers should format a complete,
+/// self-contained message (no trailing newline). The CLI layer adds the
+/// tab indent and banner when flushing.
+pub fn push_warning(message: impl Into<String>) {
+    WARNINGS.with(|w| w.borrow_mut().push(message.into()));
+}
+
+/// Removes and returns all collected warnings for the current thread.
+///
+/// After this call the collector is empty. The CLI layer calls this once
+/// at the end of `App::run` to render the batch.
+pub fn drain_warnings() -> Vec<String> {
+    WARNINGS.with(|w| std::mem::take(&mut *w.borrow_mut()))
+}
+
+/// Returns `true` if any warnings are currently buffered for this thread.
+///
+/// Intended for hot-path checks that want to skip the rendering work when
+/// there is nothing to emit.
+pub fn has_warnings() -> bool {
+    WARNINGS.with(|w| !w.borrow().is_empty())
+}
+
+/// Style name for the "Standout :: Warnings" banner, looked up in the theme.
+pub const WARNING_BANNER_STYLE: &str = "standout_warning_banner";
+
+/// Style name for each individual warning line, looked up in the theme.
+pub const WARNING_ITEM_STYLE: &str = "standout_warning_item";
+
+/// Literal banner text. Leading/trailing spaces give the background color
+/// room to breathe when the banner is styled with a bg fill.
+const BANNER_TEXT: &str = " Standout :: Warnings ";
+
+/// Drains the collector and emits the warnings to stderr.
+///
+/// Called by the CLI layer at the end of `App::run`, *after* the command
+/// output has been written to stdout, so the banner is the last thing the
+/// user sees. Does nothing if no warnings have been collected.
+///
+/// # Styling
+///
+/// Styling is applied when stderr is a TTY that supports color and
+/// `output_mode` does not explicitly forbid ANSI output (`Text` mode). The
+/// banner pulls its style from [`WARNING_BANNER_STYLE`] in `theme`; each
+/// warning line pulls from [`WARNING_ITEM_STYLE`]. Themes that don't define
+/// these styles fall back to unstyled text.
+pub fn flush_to_stderr(theme: &Theme, output_mode: OutputMode) {
+    let warnings = drain_warnings();
+    if warnings.is_empty() {
+        return;
+    }
+
+    let use_color = should_style_stderr(output_mode);
+    let styles = theme.resolve_styles(None);
+
+    // Write everything through a single stderr lock so the banner and its
+    // items cannot be interleaved with other output on a shared stream.
+    let stderr = std::io::stderr();
+    let mut out = stderr.lock();
+
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "{}",
+        style_for_stderr(&styles, WARNING_BANNER_STYLE, BANNER_TEXT, use_color)
+    );
+
+    for w in warnings {
+        let _ = writeln!(
+            out,
+            "\t{}",
+            style_for_stderr(&styles, WARNING_ITEM_STYLE, &w, use_color)
+        );
+    }
+}
+
+/// Applies `style_name` to `text`, forcing ANSI on/off based on `use_color`
+/// rather than the crate-wide `console::colors_enabled()` (which tracks
+/// stdout). This matters when stdout is piped but stderr is still a TTY:
+/// `Styles::apply` would see the global flag and strip codes we actually
+/// want to keep for stderr.
+///
+/// Falls back to unstyled text when the style is absent or `use_color` is
+/// false, rather than applying the "missing style" indicator — a warning
+/// with a stray `?` in front of it would be a worse UX than a plain one.
+fn style_for_stderr(
+    styles: &crate::style::Styles,
+    style_name: &str,
+    text: &str,
+    use_color: bool,
+) -> String {
+    if !use_color {
+        return text.to_string();
+    }
+    match styles.resolve(style_name) {
+        Some(style) => style
+            .clone()
+            .for_stderr()
+            .force_styling(true)
+            .apply_to(text)
+            .to_string(),
+        None => text.to_string(),
+    }
+}
+
+/// Decides whether the warnings block should use ANSI styling.
+///
+/// `OutputMode::Text` explicitly opts out of color. Structured modes
+/// (`Json`/`Yaml`/`Xml`/`Csv`) target stdout, not stderr, so they don't
+/// constrain our styling choices here — stderr TTY capability is what
+/// matters. `TermDebug` emits bracket tags instead of ANSI in the main
+/// output, but the warnings banner isn't subject to that contract, so we
+/// still honor the stderr TTY signal.
+fn should_style_stderr(output_mode: OutputMode) -> bool {
+    if matches!(output_mode, OutputMode::Text) {
+        return false;
+    }
+    console::Term::stderr().features().colors_supported()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use console::Style;
+
+    fn reset() {
+        let _ = drain_warnings();
+    }
+
+    #[test]
+    fn push_and_drain_roundtrip() {
+        reset();
+
+        assert!(!has_warnings());
+        push_warning("first");
+        push_warning(String::from("second"));
+        assert!(has_warnings());
+
+        let drained = drain_warnings();
+        assert_eq!(drained, vec!["first".to_string(), "second".to_string()]);
+        assert!(!has_warnings());
+
+        // Draining again yields nothing.
+        assert!(drain_warnings().is_empty());
+    }
+
+    #[test]
+    fn default_theme_registers_warning_styles() {
+        // Regression check: if Theme::default ever stops shipping these styles
+        // the flush helper silently emits plain text, so bake the presence of
+        // the style names into a test.
+        let theme = Theme::default();
+        let styles = theme.resolve_styles(None);
+        assert!(
+            styles.has(WARNING_BANNER_STYLE),
+            "Theme::default missing '{}'",
+            WARNING_BANNER_STYLE
+        );
+        assert!(
+            styles.has(WARNING_ITEM_STYLE),
+            "Theme::default missing '{}'",
+            WARNING_ITEM_STYLE
+        );
+    }
+
+    #[test]
+    fn style_for_stderr_plain_when_color_disabled() {
+        let mut styles = crate::style::Styles::new();
+        styles = styles.add("some_style", Style::new().red());
+        let out = style_for_stderr(&styles, "some_style", "hello", false);
+        assert_eq!(out, "hello");
+    }
+
+    #[test]
+    fn style_for_stderr_plain_when_style_missing() {
+        let styles = crate::style::Styles::new();
+        let out = style_for_stderr(&styles, "no_such_style", "hello", true);
+        // Fall back to plain text rather than emitting the missing-style marker.
+        assert_eq!(out, "hello");
+    }
+
+    #[test]
+    fn style_for_stderr_emits_ansi_when_enabled() {
+        let styles = crate::style::Styles::new().add("warn", Style::new().red().bold());
+        let out = style_for_stderr(&styles, "warn", "hello", true);
+        assert!(
+            out.contains("\x1b["),
+            "expected ANSI escape in styled output, got: {:?}",
+            out
+        );
+        assert!(out.contains("hello"));
+    }
+}

--- a/crates/standout/src/cli/builder/execution.rs
+++ b/crates/standout/src/cli/builder/execution.rs
@@ -321,17 +321,18 @@ impl AppBuilder {
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
     {
-        match self.dispatch_from(cmd, args) {
-            RunResult::Handled(output) => {
+        let result = self.dispatch_from(cmd, args);
+        let handled = match result {
+            RunResult::Handled(ref output) => {
                 if !output.is_empty() {
                     println!("{}", output);
                 }
                 true
             }
-            RunResult::Binary(bytes, filename) => {
+            RunResult::Binary(ref bytes, ref filename) => {
                 // For binary output, write to stdout or the suggested file
                 // By default, we write to the suggested filename
-                if let Err(e) = std::fs::write(&filename, &bytes) {
+                if let Err(e) = std::fs::write(filename, bytes) {
                     eprintln!("Error writing {}: {}", filename, e);
                 } else {
                     eprintln!("Wrote {} bytes to {}", bytes.len(), filename);
@@ -340,7 +341,18 @@ impl AppBuilder {
             }
             RunResult::Silent => true, // Handler ran successfully, no output
             RunResult::NoMatch(_) => false,
-        }
+        };
+
+        // After the primary output has been flushed to stdout, render any
+        // framework warnings collected during setup/dispatch to stderr so
+        // they appear last on the user's terminal. `OutputMode::Auto` is a
+        // safe default here: the renderer's final decision on styling is
+        // driven by whether stderr itself is a color-capable TTY.
+        let default_theme = crate::Theme::default();
+        let theme = self.theme.as_ref().unwrap_or(&default_theme);
+        standout_render::warnings::flush_to_stderr(theme, OutputMode::Auto);
+
+        handled
     }
 
     /// Runs the CLI and returns the rendered output as a string.

--- a/crates/standout/src/lib.rs
+++ b/crates/standout/src/lib.rs
@@ -234,6 +234,7 @@ pub use standout_render::context;
 pub use standout_render::file_loader;
 pub use standout_render::style;
 pub use standout_render::tabular;
+pub use standout_render::warnings;
 
 // Error type (from standout-render)
 pub use standout_render::RenderError;


### PR DESCRIPTION
## Summary

- Framework warnings (stylesheet/template hot-reload failures) used to print on top of command output as plain text. They now collect silently and flush to stderr **after** the command output, under a `Standout :: Warnings` banner, with each entry on its own tab-indented line.
- Banner styles ship in `Theme::default()` (black on orange 208, bold) and are overridable by user themes. Styling respects stderr TTY capability — piped/redirected stderr still gets plain text.
- Adds `standout::warnings` public API (`push_warning`, `drain_warnings`, `has_warnings`, `flush_to_stderr`).

## Before / After

**Before** — warnings were the very first thing you saw, jammed on top of output:

```
Warning: Failed to parse stylesheets from '.../src/styles', using embedded: ...
cross-pack conflicts detected:
  target: ~/.env.sh
    [command output continues]
```

**After** — command output renders normally, then a styled block at the very end:

```
cross-pack conflicts detected:
  target: ~/.env.sh
    [command output]
                                            <blank line>
 Standout :: Warnings                       <banner: black on orange>
	Failed to parse stylesheets from '.../src/styles', using embedded: ...
```

## What changed

**New module** — `crates/standout-render/src/warnings.rs`
- Thread-local `Vec<String>` collector (CLI is single-threaded for the setup path).
- `push_warning` / `drain_warnings` / `has_warnings`.
- `flush_to_stderr(&Theme, OutputMode)` renders the batch with the active theme's `standout_warning_banner` and `standout_warning_item` styles.

**Call site migration** — `crates/standout-render/src/embedded.rs`
- 5 `eprintln!("Warning: ...")` call sites (template walk/register failures, style walk/read/parse failures) now route through `push_warning`.

**Default theme** — `crates/standout-render/src/theme/theme.rs`
- `standout_warning_banner`: `Color::Black` fg on `Color256(208)` bg, bold.
- `standout_warning_item`: unstyled (leave room for user themes to add emphasis).

**Flush wiring** — `crates/standout/src/cli/builder/execution.rs`
- `App::run` calls `flush_to_stderr` after the main stdout write, regardless of which `RunResult` arm fired. This guarantees warnings are the last visible thing.

**Styling decision** — uses `Style::for_stderr().force_styling(true)` rather than the crate-wide `console::colors_enabled()`, which tracks stdout. This matters when stdout is piped (color off) but stderr is still a TTY — we want color on the warnings in that case. `OutputMode::Text` still forces plain output explicitly.

## Scope — what wasn't changed

Only the 5 hot-reload warnings in `embedded.rs` went through the collector. User-facing `eprintln!`s that should stay urgent are left alone:
- `standout-input/src/sources/clipboard.rs` — clipboard access feedback during input
- `standout-input/src/chain.rs` — interactive validation retry messages
- `standout/src/cli/builder/execution.rs` — binary write success/error in `run()`

## Tests

Added to `standout-render` lib tests:

- `push_and_drain_roundtrip` — collector API
- `default_theme_registers_warning_styles` — regression guard: if `Theme::default` ever drops the banner/item styles, the flush helper silently prints plain text. This test makes the presence load-bearing.
- `style_for_stderr_plain_when_color_disabled`
- `style_for_stderr_plain_when_style_missing` — falls back to plain text rather than the default "missing style" `?` marker, which would be hostile UX for a warning
- `style_for_stderr_emits_ansi_when_enabled`

Full workspace: 829 lib tests pass (was 824), all integration tests pass. Pre-existing `standout-render::tabular::util::visible_width` doctest failure is unrelated (reproduces on `main`).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all --all-features -- -D warnings` clean
- [x] `cargo test --workspace` — all unit + integration tests pass
- [x] Pre-commit hook (full CI) passes
- [ ] Verify in a downstream consumer (dodot): trigger a warning (e.g. syntactically invalid CSS in `src/styles/`), run the command, confirm the warning appears **after** the command output with the styled banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)