### PR TITLE
Add injectable environment detection (width/TTY/color)

### DIFF
--- a/crates/standout-render/Cargo.toml
+++ b/crates/standout-render/Cargo.toml
@@ -22,6 +22,7 @@ quick-xml = { version = "0.36", features = ["serialize"] }
 csv = "1.3"
 unicode-width = "0.2"
 cssparser = "0.31"
+terminal_size = "0.4"
 standout-bbparser = { version = "7.5.0", path = "../standout-bbparser" }
 
 [dev-dependencies]

--- a/crates/standout-render/src/environment.rs
+++ b/crates/standout-render/src/environment.rs
@@ -1,0 +1,159 @@
+//! Injectable environment detection.
+//!
+//! This module centralizes process-global detection of terminal properties
+//! — width, TTY status, and ANSI color capability — behind overridable
+//! function pointers so tests can force specific values without touching
+//! real environment state.
+//!
+//! It follows the same pattern used by
+//! [`set_theme_detector`](crate::set_theme_detector) and
+//! [`set_icon_detector`](crate::set_icon_detector).
+//!
+//! # Usage
+//!
+//! In application code, call the `detect_*` functions. They resolve to real
+//! terminal queries by default:
+//!
+//! ```rust
+//! use standout_render::{detect_terminal_width, detect_is_tty, detect_color_capability};
+//!
+//! let _width = detect_terminal_width();
+//! let _tty = detect_is_tty();
+//! let _color = detect_color_capability();
+//! ```
+//!
+//! In tests, override any of them with a closure:
+//!
+//! ```rust
+//! use standout_render::{set_terminal_width_detector, detect_terminal_width};
+//!
+//! set_terminal_width_detector(|| Some(80));
+//! assert_eq!(detect_terminal_width(), Some(80));
+//! ```
+//!
+//! Overrides are process-global, so tests that set them should be annotated
+//! with `#[serial]` (via the `serial_test` crate).
+
+use console::Term;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+type WidthDetector = fn() -> Option<usize>;
+type TtyDetector = fn() -> bool;
+type ColorDetector = fn() -> bool;
+
+static WIDTH_DETECTOR: Lazy<Mutex<WidthDetector>> =
+    Lazy::new(|| Mutex::new(default_width_detector));
+static TTY_DETECTOR: Lazy<Mutex<TtyDetector>> = Lazy::new(|| Mutex::new(default_tty_detector));
+static COLOR_DETECTOR: Lazy<Mutex<ColorDetector>> =
+    Lazy::new(|| Mutex::new(default_color_detector));
+
+/// Overrides the detector used to query terminal width.
+///
+/// The detector returns `Some(cols)` when a width can be determined and
+/// `None` when output is not a terminal. Useful to force a fixed width in
+/// snapshot tests.
+pub fn set_terminal_width_detector(detector: WidthDetector) {
+    *WIDTH_DETECTOR.lock().unwrap() = detector;
+}
+
+/// Overrides the detector used to check whether stdout is a TTY.
+pub fn set_tty_detector(detector: TtyDetector) {
+    *TTY_DETECTOR.lock().unwrap() = detector;
+}
+
+/// Overrides the detector used to check whether ANSI color is supported on
+/// stdout.
+///
+/// This is what [`OutputMode::Auto`](crate::OutputMode::Auto) consults to
+/// decide between applying and stripping style tags.
+pub fn set_color_capability_detector(detector: ColorDetector) {
+    *COLOR_DETECTOR.lock().unwrap() = detector;
+}
+
+/// Returns the current terminal width in columns, or `None` when unavailable.
+pub fn detect_terminal_width() -> Option<usize> {
+    (*WIDTH_DETECTOR.lock().unwrap())()
+}
+
+/// Returns `true` when stdout is attached to a terminal.
+pub fn detect_is_tty() -> bool {
+    (*TTY_DETECTOR.lock().unwrap())()
+}
+
+/// Returns `true` when ANSI color output is supported on stdout.
+pub fn detect_color_capability() -> bool {
+    (*COLOR_DETECTOR.lock().unwrap())()
+}
+
+fn default_width_detector() -> Option<usize> {
+    terminal_size::terminal_size().map(|(w, _)| w.0 as usize)
+}
+
+fn default_tty_detector() -> bool {
+    Term::stdout().is_term()
+}
+
+fn default_color_detector() -> bool {
+    Term::stdout().features().colors_supported()
+}
+
+/// Resets every detector to its default (real-terminal) implementation.
+///
+/// Tests that installed overrides should call this in teardown to avoid
+/// leaking state into sibling tests.
+pub fn reset_detectors() {
+    set_terminal_width_detector(default_width_detector);
+    set_tty_detector(default_tty_detector);
+    set_color_capability_detector(default_color_detector);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn width_override_is_honored() {
+        set_terminal_width_detector(|| Some(42));
+        assert_eq!(detect_terminal_width(), Some(42));
+        set_terminal_width_detector(|| None);
+        assert_eq!(detect_terminal_width(), None);
+        reset_detectors();
+    }
+
+    #[test]
+    #[serial]
+    fn tty_override_is_honored() {
+        set_tty_detector(|| true);
+        assert!(detect_is_tty());
+        set_tty_detector(|| false);
+        assert!(!detect_is_tty());
+        reset_detectors();
+    }
+
+    #[test]
+    #[serial]
+    fn color_override_is_honored() {
+        set_color_capability_detector(|| true);
+        assert!(detect_color_capability());
+        set_color_capability_detector(|| false);
+        assert!(!detect_color_capability());
+        reset_detectors();
+    }
+
+    #[test]
+    #[serial]
+    fn reset_restores_defaults() {
+        set_terminal_width_detector(|| Some(1));
+        set_tty_detector(|| true);
+        set_color_capability_detector(|| true);
+
+        reset_detectors();
+
+        let _ = detect_terminal_width();
+        let _ = detect_is_tty();
+        let _ = detect_color_capability();
+    }
+}

--- a/crates/standout-render/src/environment.rs
+++ b/crates/standout-render/src/environment.rs
@@ -22,7 +22,8 @@
 //! let _color = detect_color_capability();
 //! ```
 //!
-//! In tests, override any of them with a closure:
+//! In tests, override any of them with a function pointer or a non-capturing
+//! closure (both coerce to `fn(...) -> T`):
 //!
 //! ```rust
 //! use standout_render::{set_terminal_width_detector, detect_terminal_width};
@@ -31,8 +32,12 @@
 //! assert_eq!(detect_terminal_width(), Some(80));
 //! ```
 //!
+//! Capturing closures are not supported — if you need per-test state, route
+//! it through a thread-local or a static the detector reads from.
+//!
 //! Overrides are process-global, so tests that set them should be annotated
-//! with `#[serial]` (via the `serial_test` crate).
+//! with `#[serial]` (via the `serial_test` crate) and should use
+//! [`DetectorGuard`] to guarantee cleanup even when the test panics.
 
 use console::Term;
 use once_cell::sync::Lazy;
@@ -50,14 +55,16 @@ static COLOR_DETECTOR: Lazy<Mutex<ColorDetector>> =
 
 /// Overrides the detector used to query terminal width.
 ///
-/// The detector returns `Some(cols)` when a width can be determined and
-/// `None` when output is not a terminal. Useful to force a fixed width in
-/// snapshot tests.
+/// Accepts a `fn` pointer or a non-capturing closure. The detector returns
+/// `Some(cols)` when a width can be determined and `None` when output is not
+/// a terminal. Useful to force a fixed width in snapshot tests.
 pub fn set_terminal_width_detector(detector: WidthDetector) {
     *WIDTH_DETECTOR.lock().unwrap() = detector;
 }
 
 /// Overrides the detector used to check whether stdout is a TTY.
+///
+/// Accepts a `fn` pointer or a non-capturing closure.
 pub fn set_tty_detector(detector: TtyDetector) {
     *TTY_DETECTOR.lock().unwrap() = detector;
 }
@@ -65,25 +72,32 @@ pub fn set_tty_detector(detector: TtyDetector) {
 /// Overrides the detector used to check whether ANSI color is supported on
 /// stdout.
 ///
-/// This is what [`OutputMode::Auto`](crate::OutputMode::Auto) consults to
-/// decide between applying and stripping style tags.
+/// Accepts a `fn` pointer or a non-capturing closure. This is what
+/// [`OutputMode::Auto`](crate::OutputMode::Auto) consults to decide between
+/// applying and stripping style tags.
 pub fn set_color_capability_detector(detector: ColorDetector) {
     *COLOR_DETECTOR.lock().unwrap() = detector;
 }
 
 /// Returns the current terminal width in columns, or `None` when unavailable.
 pub fn detect_terminal_width() -> Option<usize> {
-    (*WIDTH_DETECTOR.lock().unwrap())()
+    // Copy the fn pointer out and release the lock before invoking the
+    // detector. Holding the mutex across the call would poison it on panic
+    // and deadlock if the detector re-entered `set_*`/`reset_*`.
+    let detector = *WIDTH_DETECTOR.lock().unwrap();
+    detector()
 }
 
 /// Returns `true` when stdout is attached to a terminal.
 pub fn detect_is_tty() -> bool {
-    (*TTY_DETECTOR.lock().unwrap())()
+    let detector = *TTY_DETECTOR.lock().unwrap();
+    detector()
 }
 
 /// Returns `true` when ANSI color output is supported on stdout.
 pub fn detect_color_capability() -> bool {
-    (*COLOR_DETECTOR.lock().unwrap())()
+    let detector = *COLOR_DETECTOR.lock().unwrap();
+    detector()
 }
 
 fn default_width_detector() -> Option<usize> {
@@ -98,14 +112,54 @@ fn default_color_detector() -> bool {
     Term::stdout().features().colors_supported()
 }
 
-/// Resets every detector to its default (real-terminal) implementation.
+/// Resets every environment detector in this module to its default
+/// (real-terminal) implementation.
 ///
 /// Tests that installed overrides should call this in teardown to avoid
-/// leaking state into sibling tests.
+/// leaking state into sibling tests. For panic-safe cleanup, prefer
+/// [`DetectorGuard`] instead of calling this manually.
 pub fn reset_detectors() {
     set_terminal_width_detector(default_width_detector);
     set_tty_detector(default_tty_detector);
     set_color_capability_detector(default_color_detector);
+}
+
+/// RAII guard that calls [`reset_detectors`] when dropped.
+///
+/// Install at the start of a test to guarantee the overrides are torn down
+/// on normal exit *and* on panic-induced unwind, so a failing assertion
+/// doesn't leak state into the next serial test.
+///
+/// ```rust
+/// use standout_render::environment::{DetectorGuard, set_terminal_width_detector, detect_terminal_width};
+///
+/// let _guard = DetectorGuard::new();
+/// set_terminal_width_detector(|| Some(80));
+/// assert_eq!(detect_terminal_width(), Some(80));
+/// // `_guard` resets everything when it goes out of scope.
+/// ```
+#[must_use = "the guard only resets detectors when dropped; bind it to a variable"]
+pub struct DetectorGuard {
+    _private: (),
+}
+
+impl DetectorGuard {
+    /// Creates a guard that will reset all environment detectors on drop.
+    pub fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl Default for DetectorGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for DetectorGuard {
+    fn drop(&mut self) {
+        reset_detectors();
+    }
 }
 
 #[cfg(test)]
@@ -116,44 +170,78 @@ mod tests {
     #[test]
     #[serial]
     fn width_override_is_honored() {
+        let _guard = DetectorGuard::new();
         set_terminal_width_detector(|| Some(42));
         assert_eq!(detect_terminal_width(), Some(42));
         set_terminal_width_detector(|| None);
         assert_eq!(detect_terminal_width(), None);
-        reset_detectors();
     }
 
     #[test]
     #[serial]
     fn tty_override_is_honored() {
+        let _guard = DetectorGuard::new();
         set_tty_detector(|| true);
         assert!(detect_is_tty());
         set_tty_detector(|| false);
         assert!(!detect_is_tty());
-        reset_detectors();
     }
 
     #[test]
     #[serial]
     fn color_override_is_honored() {
+        let _guard = DetectorGuard::new();
         set_color_capability_detector(|| true);
         assert!(detect_color_capability());
         set_color_capability_detector(|| false);
         assert!(!detect_color_capability());
-        reset_detectors();
     }
 
     #[test]
     #[serial]
-    fn reset_restores_defaults() {
-        set_terminal_width_detector(|| Some(1));
-        set_tty_detector(|| true);
-        set_color_capability_detector(|| true);
+    fn reset_replaces_panicking_overrides() {
+        let _guard = DetectorGuard::new();
+
+        fn boom_width() -> Option<usize> {
+            panic!("width detector must not be called after reset")
+        }
+        fn boom_bool() -> bool {
+            panic!("bool detector must not be called after reset")
+        }
+
+        set_terminal_width_detector(boom_width);
+        set_tty_detector(boom_bool);
+        set_color_capability_detector(boom_bool);
 
         reset_detectors();
 
+        // If reset were a no-op the panicking detectors would still be
+        // installed and these calls would unwind.
         let _ = detect_terminal_width();
         let _ = detect_is_tty();
         let _ = detect_color_capability();
+    }
+
+    #[test]
+    #[serial]
+    fn guard_restores_on_drop() {
+        {
+            let _guard = DetectorGuard::new();
+            set_terminal_width_detector(|| Some(1));
+            set_tty_detector(|| true);
+            set_color_capability_detector(|| true);
+            assert_eq!(detect_terminal_width(), Some(1));
+        }
+
+        // Guard dropped — a fresh panicking detector should be reachable
+        // again (i.e. the override is gone) via reset_detectors. We verify
+        // reset was effective by installing panicking detectors, dropping a
+        // new guard, and confirming calls don't panic.
+        fn boom() -> Option<usize> {
+            panic!("override leaked past guard drop")
+        }
+        set_terminal_width_detector(boom);
+        drop(DetectorGuard::new());
+        let _ = detect_terminal_width();
     }
 }

--- a/crates/standout-render/src/lib.rs
+++ b/crates/standout-render/src/lib.rs
@@ -180,8 +180,9 @@ pub use output::{write_binary_output, write_output, OutputDestination, OutputMod
 
 // Environment detection exports
 pub use environment::{
-    detect_color_capability, detect_is_tty, detect_terminal_width, reset_detectors,
-    set_color_capability_detector, set_terminal_width_detector, set_tty_detector,
+    detect_color_capability, detect_is_tty, detect_terminal_width,
+    reset_detectors as reset_environment_detectors, set_color_capability_detector,
+    set_terminal_width_detector, set_tty_detector, DetectorGuard,
 };
 
 // Render module exports

--- a/crates/standout-render/src/lib.rs
+++ b/crates/standout-render/src/lib.rs
@@ -147,6 +147,7 @@
 pub mod colorspace;
 pub mod context;
 mod embedded;
+pub mod environment;
 mod error;
 pub mod file_loader;
 pub mod output;
@@ -176,6 +177,12 @@ pub use theme::{
 
 // Output module exports
 pub use output::{write_binary_output, write_output, OutputDestination, OutputMode};
+
+// Environment detection exports
+pub use environment::{
+    detect_color_capability, detect_is_tty, detect_terminal_width, reset_detectors,
+    set_color_capability_detector, set_terminal_width_detector, set_tty_detector,
+};
 
 // Render module exports
 pub use template::{

--- a/crates/standout-render/src/output.rs
+++ b/crates/standout-render/src/output.rs
@@ -36,7 +36,7 @@
 //! Use [`render_auto`](crate::render_auto) to automatically dispatch between
 //! templated and structured rendering based on output mode.
 
-use console::Term;
+use crate::environment::detect_color_capability;
 use std::io::Write;
 
 /// Destination for rendered output.
@@ -185,7 +185,7 @@ impl OutputMode {
     /// - `Json` returns `false` (structured output, no ANSI codes)
     pub fn should_use_color(&self) -> bool {
         match self {
-            OutputMode::Auto => Term::stdout().features().colors_supported(),
+            OutputMode::Auto => detect_color_capability(),
             OutputMode::Term => true,
             OutputMode::Text => false,
             OutputMode::TermDebug => false, // Handled specially

--- a/crates/standout-render/src/output.rs
+++ b/crates/standout-render/src/output.rs
@@ -19,11 +19,16 @@
 //!
 //! ## Auto Mode Resolution
 //!
-//! `Auto` queries terminal capabilities via the `console` crate:
+//! `Auto` queries terminal color capability via
+//! [`detect_color_capability`](crate::detect_color_capability) (which by
+//! default wraps the `console` crate):
 //! - TTY with color support → behaves like `Term` (ANSI codes applied)
 //! - Piped output or no color support → behaves like `Text` (tags stripped)
 //!
-//! This detection happens at render time, not startup.
+//! This detection happens at render time, not startup. Tests can override
+//! the result via
+//! [`set_color_capability_detector`](crate::set_color_capability_detector)
+//! — see the [`environment`](crate::environment) module.
 //!
 //! ## Structured Modes
 //!

--- a/crates/standout/Cargo.toml
+++ b/crates/standout/Cargo.toml
@@ -28,7 +28,6 @@ serde_json = "1"
 # CLI dependencies (formerly optional with clap feature)
 clap = { version = "4", features = ["derive", "help"] }
 anyhow = "1"
-terminal_size = "0.4"
 thiserror = "2"
 serde_yaml = "0.9"
 quick-xml = { version = "0.36", features = ["serialize"] }

--- a/crates/standout/src/cli/app.rs
+++ b/crates/standout/src/cli/app.rs
@@ -8,11 +8,6 @@ use clap::Command;
 use standout_dispatch::verify::{verify_handler_args, ExpectedArg};
 use std::collections::HashMap;
 
-/// Gets the current terminal width, or None if not available.
-pub(crate) fn get_terminal_width() -> Option<usize> {
-    terminal_size::terminal_size().map(|(w, _)| w.0 as usize)
-}
-
 pub(crate) fn find_subcommand_recursive<'a>(
     cmd: &'a Command,
     keywords: &[&str],

--- a/crates/standout/src/cli/builder/rendering.rs
+++ b/crates/standout/src/cli/builder/rendering.rs
@@ -98,7 +98,7 @@ impl AppBuilder {
             serde_json::to_value(data).map_err(|e| SetupError::Config(e.to_string()))?;
         let render_ctx = RenderContext::new(
             mode,
-            super::super::app::get_terminal_width(),
+            standout_render::detect_terminal_width(),
             &theme,
             &json_data,
         );

--- a/crates/standout/src/cli/dispatch.rs
+++ b/crates/standout/src/cli/dispatch.rs
@@ -70,7 +70,7 @@ pub(crate) fn render_handler_output<T: Serialize>(
 
                 let render_ctx = RenderContext::new(
                     output_mode,
-                    crate::cli::app::get_terminal_width(),
+                    standout_render::detect_terminal_width(),
                     theme,
                     &json_data,
                 );


### PR DESCRIPTION
## Summary

- Introduces `standout-render::environment` with overridable detectors for terminal width, TTY status, and ANSI color capability. Mirrors the existing `set_theme_detector` / `set_icon_detector` pattern.
- Routes `OutputMode::Auto`'s color decision and the dispatch/builder terminal-width lookup through the new detectors so tests can override them from one place.
- Removes the local `get_terminal_width` helper in `standout::cli::app` and the `terminal_size` dependency from the `standout` crate; detection now lives in one place (`standout-render`).

This is the first of three PRs that break up the test-tooling work discussed in the brainstorm. Phase 1 is pure plumbing and sets up the injection seams that Phase 2's `TestHarness` will consume.

## New public API

- `detect_terminal_width()`, `detect_is_tty()`, `detect_color_capability()` — default to real terminal queries.
- `set_terminal_width_detector(fn)`, `set_tty_detector(fn)`, `set_color_capability_detector(fn)` — install overrides (fn pointer or non-capturing closure).
- `reset_environment_detectors()` — restore defaults (re-exported at the crate root under this name; inside the submodule it's `environment::reset_detectors`).
- `DetectorGuard` — RAII helper that calls `reset_environment_detectors` on drop; recommended for scoping overrides inside tests so cleanup runs on panic unwind.

## Test plan

- [x] `cargo test --workspace --lib` green
- [x] `cargo test --workspace --tests` green
- [x] Pre-commit CI passes (`cargo check`, `cargo fmt`, `cargo clippy`, lib + doctest + integration tests)
- [x] New unit tests for each detector using `DetectorGuard`
- [x] `reset_replaces_panicking_overrides` proves `reset_detectors` is not a no-op (installs panicking detectors, resets, asserts calls don't unwind)
- [ ] Exercised by Phase 2's `TestHarness` (follow-up PR)

Note: one pre-existing doctest failure in `tabular::util::visible_width` reproduces on `main` and is unrelated to this change.