### PR TITLE
Add standout-test crate with unified TestHarness builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tmp/
 local
 site/
 book/
+.claude/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ members = [
     "crates/standout-render",
     "crates/standout-pipe",
     "crates/standout-seeker",
+    "crates/standout-test",
 ]

--- a/crates/standout-input/Cargo.toml
+++ b/crates/standout-input/Cargo.toml
@@ -19,6 +19,7 @@ inquire = ["dep:inquire"]
 [dependencies]
 thiserror = "2"
 clap = { version = "4", default-features = false, features = ["std"] }
+once_cell = "1.19"
 
 # Optional: editor support
 tempfile = { version = "3", optional = true }
@@ -30,3 +31,4 @@ inquire = { version = "0.7", optional = true, features = ["editor"] }
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = "3"

--- a/crates/standout-input/src/env.rs
+++ b/crates/standout-input/src/env.rs
@@ -13,9 +13,8 @@
 //! implementation.
 //!
 //! Tests can swap in a mock without touching handler code by calling
-//! [`set_default_stdin_reader`] / [`set_default_clipboard_reader`] — the
-//! [`TestHarness`](../../standout_test/index.html) in the `standout-test`
-//! crate wires these automatically.
+//! [`set_default_stdin_reader`] / [`set_default_clipboard_reader`]. The
+//! `TestHarness` in the `standout-test` crate wires these automatically.
 
 use once_cell::sync::Lazy;
 use std::io::{self, IsTerminal, Read};

--- a/crates/standout-input/src/env.rs
+++ b/crates/standout-input/src/env.rs
@@ -3,8 +3,23 @@
 //! This module provides traits that abstract over OS interactions,
 //! allowing tests to run without depending on actual terminal state,
 //! stdin piping, or clipboard contents.
+//!
+//! # Default readers and test overrides
+//!
+//! [`StdinSource::new`](crate::StdinSource::new) and
+//! [`ClipboardSource::new`](crate::ClipboardSource::new) both use "default"
+//! readers ([`DefaultStdin`], [`DefaultClipboard`]) that consult a
+//! process-global override before falling back to the real OS-backed
+//! implementation.
+//!
+//! Tests can swap in a mock without touching handler code by calling
+//! [`set_default_stdin_reader`] / [`set_default_clipboard_reader`] — the
+//! [`TestHarness`](../../standout_test/index.html) in the `standout-test`
+//! crate wires these automatically.
 
+use once_cell::sync::Lazy;
 use std::io::{self, IsTerminal, Read};
+use std::sync::{Arc, Mutex};
 
 use crate::InputError;
 
@@ -215,9 +230,102 @@ impl ClipboardReader for MockClipboard {
     }
 }
 
+// === Process-global default reader overrides ===
+//
+// `StdinSource::new()` and `ClipboardSource::new()` resolve their reader
+// through the `DefaultStdin` / `DefaultClipboard` shims below, which consult
+// these slots before falling back to the real OS-backed readers. Tests use
+// `set_default_*_reader` to install a mock for a serial scope; the
+// `standout-test` `TestHarness` handles teardown via its `Drop` impl.
+
+type SharedStdin = Arc<dyn StdinReader + Send + Sync>;
+type SharedClipboard = Arc<dyn ClipboardReader + Send + Sync>;
+
+static STDIN_OVERRIDE: Lazy<Mutex<Option<SharedStdin>>> = Lazy::new(|| Mutex::new(None));
+static CLIPBOARD_OVERRIDE: Lazy<Mutex<Option<SharedClipboard>>> = Lazy::new(|| Mutex::new(None));
+
+/// Installs a process-global stdin reader that [`DefaultStdin`] (and
+/// therefore [`StdinSource::new`](crate::StdinSource::new)) will delegate
+/// to until [`reset_default_stdin_reader`] is called.
+///
+/// Intended for test harnesses. Tests using this must run serially (e.g.
+/// via `#[serial]`) because the override is process-global.
+pub fn set_default_stdin_reader(reader: SharedStdin) {
+    *STDIN_OVERRIDE.lock().unwrap() = Some(reader);
+}
+
+/// Clears the stdin override installed by [`set_default_stdin_reader`].
+pub fn reset_default_stdin_reader() {
+    *STDIN_OVERRIDE.lock().unwrap() = None;
+}
+
+/// Installs a process-global clipboard reader that [`DefaultClipboard`]
+/// (and therefore [`ClipboardSource::new`](crate::ClipboardSource::new))
+/// will delegate to until [`reset_default_clipboard_reader`] is called.
+pub fn set_default_clipboard_reader(reader: SharedClipboard) {
+    *CLIPBOARD_OVERRIDE.lock().unwrap() = Some(reader);
+}
+
+/// Clears the clipboard override installed by
+/// [`set_default_clipboard_reader`].
+pub fn reset_default_clipboard_reader() {
+    *CLIPBOARD_OVERRIDE.lock().unwrap() = None;
+}
+
+fn current_stdin_override() -> Option<SharedStdin> {
+    STDIN_OVERRIDE.lock().unwrap().clone()
+}
+
+fn current_clipboard_override() -> Option<SharedClipboard> {
+    CLIPBOARD_OVERRIDE.lock().unwrap().clone()
+}
+
+/// Stdin reader used by [`StdinSource::new`](crate::StdinSource::new).
+///
+/// Delegates to a reader installed via [`set_default_stdin_reader`] if one
+/// is present; otherwise falls back to [`RealStdin`]. The indirection lets
+/// a test harness inject a [`MockStdin`] without reconstructing sources
+/// inside handler code.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DefaultStdin;
+
+impl StdinReader for DefaultStdin {
+    fn is_terminal(&self) -> bool {
+        if let Some(r) = current_stdin_override() {
+            return r.is_terminal();
+        }
+        RealStdin.is_terminal()
+    }
+
+    fn read_to_string(&self) -> io::Result<String> {
+        if let Some(r) = current_stdin_override() {
+            return r.read_to_string();
+        }
+        RealStdin.read_to_string()
+    }
+}
+
+/// Clipboard reader used by
+/// [`ClipboardSource::new`](crate::ClipboardSource::new).
+///
+/// Delegates to a reader installed via [`set_default_clipboard_reader`] if
+/// one is present; otherwise falls back to [`RealClipboard`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DefaultClipboard;
+
+impl ClipboardReader for DefaultClipboard {
+    fn read(&self) -> Result<Option<String>, InputError> {
+        if let Some(r) = current_clipboard_override() {
+            return r.read();
+        }
+        RealClipboard.read()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn mock_stdin_terminal() {
@@ -269,5 +377,34 @@ mod tests {
             clipboard.read().unwrap(),
             Some("clipboard text".to_string())
         );
+    }
+
+    #[test]
+    #[serial]
+    fn default_stdin_uses_override() {
+        set_default_stdin_reader(Arc::new(MockStdin::piped("overridden")));
+        let reader = DefaultStdin;
+        assert!(!reader.is_terminal());
+        assert_eq!(reader.read_to_string().unwrap(), "overridden");
+        reset_default_stdin_reader();
+    }
+
+    #[test]
+    #[serial]
+    fn default_stdin_falls_back_without_override() {
+        reset_default_stdin_reader();
+        // Behaviour matches RealStdin; we can only assert it doesn't panic
+        // and reports a terminal state consistent with the current process.
+        let reader = DefaultStdin;
+        let _ = reader.is_terminal();
+    }
+
+    #[test]
+    #[serial]
+    fn default_clipboard_uses_override() {
+        set_default_clipboard_reader(Arc::new(MockClipboard::with_content("paste")));
+        let reader = DefaultClipboard;
+        assert_eq!(reader.read().unwrap(), Some("paste".to_string()));
+        reset_default_clipboard_reader();
     }
 }

--- a/crates/standout-input/src/lib.rs
+++ b/crates/standout-input/src/lib.rs
@@ -77,3 +77,9 @@ pub use sources::{
 
 // Re-export mock types for testing
 pub use env::{MockClipboard, MockEnv, MockStdin};
+
+// Re-export process-global default reader controls (used by test harnesses)
+pub use env::{
+    reset_default_clipboard_reader, reset_default_stdin_reader, set_default_clipboard_reader,
+    set_default_stdin_reader, DefaultClipboard, DefaultStdin,
+};

--- a/crates/standout-input/src/sources/clipboard.rs
+++ b/crates/standout-input/src/sources/clipboard.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use clap::ArgMatches;
 
 use crate::collector::InputCollector;
-use crate::env::{ClipboardReader, RealClipboard};
+use crate::env::{ClipboardReader, DefaultClipboard};
 use crate::InputError;
 
 /// Collect input from the system clipboard.
@@ -39,22 +39,28 @@ use crate::InputError;
 /// let source = ClipboardSource::with_reader(MockClipboard::with_content("clipboard text"));
 /// ```
 #[derive(Clone)]
-pub struct ClipboardSource<R: ClipboardReader = RealClipboard> {
+pub struct ClipboardSource<R: ClipboardReader = DefaultClipboard> {
     reader: Arc<R>,
     trim: bool,
 }
 
-impl ClipboardSource<RealClipboard> {
-    /// Create a new clipboard source using real system clipboard.
+impl ClipboardSource<DefaultClipboard> {
+    /// Create a new clipboard source.
+    ///
+    /// Reads via
+    /// [`DefaultClipboard`](crate::env::DefaultClipboard), which honors a
+    /// test override installed through
+    /// [`set_default_clipboard_reader`](crate::env::set_default_clipboard_reader)
+    /// and otherwise falls back to the platform clipboard.
     pub fn new() -> Self {
         Self {
-            reader: Arc::new(RealClipboard),
+            reader: Arc::new(DefaultClipboard),
             trim: true,
         }
     }
 }
 
-impl Default for ClipboardSource<RealClipboard> {
+impl Default for ClipboardSource<DefaultClipboard> {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/standout-input/src/sources/stdin.rs
+++ b/crates/standout-input/src/sources/stdin.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use clap::ArgMatches;
 
 use crate::collector::InputCollector;
-use crate::env::{RealStdin, StdinReader};
+use crate::env::{DefaultStdin, StdinReader};
 use crate::InputError;
 
 /// Collect input from piped stdin.
@@ -35,22 +35,28 @@ use crate::InputError;
 /// let source = StdinSource::with_reader(MockStdin::piped("test input"));
 /// ```
 #[derive(Clone)]
-pub struct StdinSource<R: StdinReader = RealStdin> {
+pub struct StdinSource<R: StdinReader = DefaultStdin> {
     reader: Arc<R>,
     trim: bool,
 }
 
-impl StdinSource<RealStdin> {
-    /// Create a new stdin source using real stdin.
+impl StdinSource<DefaultStdin> {
+    /// Create a new stdin source.
+    ///
+    /// The source reads via
+    /// [`DefaultStdin`](crate::env::DefaultStdin), which honors a test
+    /// override installed through
+    /// [`set_default_stdin_reader`](crate::env::set_default_stdin_reader)
+    /// and otherwise falls back to real stdin.
     pub fn new() -> Self {
         Self {
-            reader: Arc::new(RealStdin),
+            reader: Arc::new(DefaultStdin),
             trim: true,
         }
     }
 }
 
-impl Default for StdinSource<RealStdin> {
+impl Default for StdinSource<DefaultStdin> {
     fn default() -> Self {
         Self::new()
     }
@@ -117,9 +123,10 @@ impl<R: StdinReader + 'static> InputCollector<String> for StdinSource<R> {
 /// Convenience function to read stdin if piped.
 ///
 /// Returns `Ok(Some(content))` if stdin is piped and has content,
-/// `Ok(None)` if stdin is a terminal or empty.
+/// `Ok(None)` if stdin is a terminal or empty. Honors any reader installed
+/// via [`set_default_stdin_reader`](crate::env::set_default_stdin_reader).
 pub fn read_if_piped() -> Result<Option<String>, InputError> {
-    let reader = RealStdin;
+    let reader = DefaultStdin;
     if reader.is_terminal() {
         return Ok(None);
     }

--- a/crates/standout-test/Cargo.toml
+++ b/crates/standout-test/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "standout-test"
+version = "7.5.0"
+edition = "2021"
+description = "In-process test harness for applications built with the standout CLI framework"
+license = "MIT"
+keywords = ["cli", "testing", "harness", "standout"]
+categories = ["command-line-interface", "development-tools::testing"]
+repository = "https://github.com/arthur-debert/standout"
+
+[dependencies]
+standout = { version = "7.5.0", path = "../standout" }
+standout-input = { version = "7.5.0", path = "../standout-input" }
+standout-render = { version = "7.5.0", path = "../standout-render" }
+clap = { version = "4", features = ["derive", "help"] }
+serial_test = "3"
+tempfile = "3"
+
+[dev-dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/standout-test/src/lib.rs
+++ b/crates/standout-test/src/lib.rs
@@ -1,0 +1,537 @@
+//! In-process test harness for apps built on the `standout` CLI framework.
+//!
+//! `TestHarness` bundles the scattered injection seams — environment
+//! detectors, env vars, working directory, stdin, clipboard, output mode,
+//! and tempdir fixtures — into a single fluent builder, and restores every
+//! override when the harness is dropped.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use standout_test::TestHarness;
+//! # fn example(app: &standout::cli::App, cmd: clap::Command) {
+//! let result = TestHarness::new()
+//!     .env("HOME", "/tmp/fake")
+//!     .clipboard("pasted content")
+//!     .terminal_width(80)
+//!     .piped_stdin("extra input\n")
+//!     .no_color()
+//!     .fixture("notes/todo.txt", "- buy milk\n")
+//!     .run(app, cmd, ["myapp", "notes", "list"]);
+//!
+//! result.assert_success();
+//! result.assert_stdout_contains("buy milk");
+//! # }
+//! ```
+//!
+//! # Concurrency
+//!
+//! The harness mutates process-global state (env vars, cwd, environment
+//! detectors, default input readers). Tests that instantiate a
+//! `TestHarness` must be annotated `#[serial]` (from the re-exported
+//! `serial_test` crate). A `Drop` impl restores every override, including
+//! on panic unwind.
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use clap::Command;
+use standout::cli::{App, RunResult};
+use standout_input::env::{MockClipboard, MockStdin};
+use standout_input::{
+    reset_default_clipboard_reader, reset_default_stdin_reader, set_default_clipboard_reader,
+    set_default_stdin_reader,
+};
+use standout_render::{
+    reset_environment_detectors, set_color_capability_detector, set_terminal_width_detector,
+    set_tty_detector, OutputMode,
+};
+use tempfile::TempDir;
+
+pub use serial_test::serial;
+
+/// How stdin should appear to handlers during the run.
+#[derive(Debug, Clone)]
+enum StdinMode {
+    /// Leave the real-stdin default in place.
+    Inherit,
+    /// Simulate piped stdin with the given content.
+    Piped(String),
+    /// Simulate an interactive terminal (no piped input).
+    Interactive,
+}
+
+/// Fluent builder for in-process CLI tests.
+///
+/// See the [crate-level docs](crate) for the usage pattern. The harness
+/// installs every override in [`TestHarness::run`] and tears them down on
+/// [`Drop`], so a failed assertion never leaks state into the next test.
+#[must_use = "TestHarness is inert until you call run(...)"]
+pub struct TestHarness {
+    env_set: HashMap<String, String>,
+    env_remove: Vec<String>,
+    cwd: Option<PathBuf>,
+    tempdir: Option<TempDir>,
+    fixtures: Vec<(PathBuf, Vec<u8>)>,
+    terminal_width: Option<Option<usize>>,
+    is_tty: Option<bool>,
+    color_capable: Option<bool>,
+    output_mode: Option<OutputMode>,
+    stdin: StdinMode,
+    clipboard: Option<String>,
+}
+
+impl TestHarness {
+    /// Creates an empty harness with no overrides applied.
+    pub fn new() -> Self {
+        Self {
+            env_set: HashMap::new(),
+            env_remove: Vec::new(),
+            cwd: None,
+            tempdir: None,
+            fixtures: Vec::new(),
+            terminal_width: None,
+            is_tty: None,
+            color_capable: None,
+            output_mode: None,
+            stdin: StdinMode::Inherit,
+            clipboard: None,
+        }
+    }
+
+    // --- environment variables ------------------------------------------------
+
+    /// Sets `key=value` as a real environment variable for the duration of
+    /// the run. Handlers that use `EnvSource::new` / `std::env::var` will
+    /// see it.
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env_set.insert(key.into(), value.into());
+        self
+    }
+
+    /// Removes `key` from the real environment for the duration of the run.
+    pub fn env_remove(mut self, key: impl Into<String>) -> Self {
+        self.env_remove.push(key.into());
+        self
+    }
+
+    // --- terminal detectors ---------------------------------------------------
+
+    /// Forces the reported terminal width to `cols`.
+    pub fn terminal_width(mut self, cols: usize) -> Self {
+        self.terminal_width = Some(Some(cols));
+        self
+    }
+
+    /// Forces terminal-width detection to report "unknown" (as if stdout
+    /// is not a TTY).
+    pub fn no_terminal_width(mut self) -> Self {
+        self.terminal_width = Some(None);
+        self
+    }
+
+    /// Claims stdout is attached to a TTY.
+    pub fn is_tty(mut self) -> Self {
+        self.is_tty = Some(true);
+        self
+    }
+
+    /// Claims stdout is not a TTY (piped, redirected, …).
+    pub fn no_tty(mut self) -> Self {
+        self.is_tty = Some(false);
+        self
+    }
+
+    /// Declares that the output target supports ANSI color.
+    pub fn with_color(mut self) -> Self {
+        self.color_capable = Some(true);
+        self
+    }
+
+    /// Declares that the output target does not support ANSI color. When
+    /// `--output=auto` is used, this forces the `Text` render path.
+    pub fn no_color(mut self) -> Self {
+        self.color_capable = Some(false);
+        self
+    }
+
+    // --- explicit output-mode override ---------------------------------------
+
+    /// Forces a specific [`OutputMode`] regardless of the `--output` flag.
+    ///
+    /// Internally this injects `--output=<mode>` as the last argument when
+    /// [`TestHarness::run`] is called.
+    pub fn output_mode(mut self, mode: OutputMode) -> Self {
+        self.output_mode = Some(mode);
+        self
+    }
+
+    /// Shortcut for [`output_mode(OutputMode::Text)`](Self::output_mode).
+    pub fn text_output(self) -> Self {
+        self.output_mode(OutputMode::Text)
+    }
+
+    // --- stdin ----------------------------------------------------------------
+
+    /// Simulates piped stdin with `content`. Handlers using
+    /// `StdinSource::new()` will see `is_terminal() == false` and read
+    /// `content`.
+    pub fn piped_stdin(mut self, content: impl Into<String>) -> Self {
+        self.stdin = StdinMode::Piped(content.into());
+        self
+    }
+
+    /// Simulates an interactive terminal for stdin (no piped content).
+    pub fn interactive_stdin(mut self) -> Self {
+        self.stdin = StdinMode::Interactive;
+        self
+    }
+
+    // --- clipboard ------------------------------------------------------------
+
+    /// Installs `content` as the mock clipboard. Handlers using
+    /// `ClipboardSource::new()` will read it.
+    pub fn clipboard(mut self, content: impl Into<String>) -> Self {
+        self.clipboard = Some(content.into());
+        self
+    }
+
+    // --- filesystem -----------------------------------------------------------
+
+    /// Sets the working directory for the run to `path`.
+    ///
+    /// If not set and any [`fixture`](Self::fixture) is declared, the
+    /// harness uses the fixture tempdir as the cwd.
+    pub fn cwd(mut self, path: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(path.into());
+        self
+    }
+
+    /// Declares a file that should exist at `path` (relative to the
+    /// fixture tempdir) with the given text `content`.
+    ///
+    /// The first call to `fixture` creates a fresh `tempfile::TempDir`
+    /// which becomes the default cwd. Access it via [`tempdir`](Self::tempdir).
+    pub fn fixture(mut self, path: impl AsRef<Path>, content: impl Into<String>) -> Self {
+        let path = path.as_ref().to_path_buf();
+        self.fixtures.push((path, content.into().into_bytes()));
+        self.ensure_tempdir();
+        self
+    }
+
+    /// Declares a binary fixture file. Same as [`fixture`](Self::fixture)
+    /// but takes raw bytes.
+    pub fn fixture_bytes(mut self, path: impl AsRef<Path>, content: impl Into<Vec<u8>>) -> Self {
+        let path = path.as_ref().to_path_buf();
+        self.fixtures.push((path, content.into()));
+        self.ensure_tempdir();
+        self
+    }
+
+    /// Returns the fixture tempdir path if one has been allocated.
+    ///
+    /// Useful for constructing absolute paths to pass as handler arguments.
+    pub fn tempdir(&self) -> Option<&Path> {
+        self.tempdir.as_ref().map(|t| t.path())
+    }
+
+    fn ensure_tempdir(&mut self) {
+        if self.tempdir.is_none() {
+            self.tempdir =
+                Some(TempDir::new().expect("TestHarness: failed to create tempdir for fixtures"));
+        }
+    }
+
+    // --- execution ------------------------------------------------------------
+
+    /// Installs every override, runs `app` with the given `cmd` definition
+    /// and argv, and returns a [`TestResult`].
+    ///
+    /// Overrides are torn down when the returned guard held inside the
+    /// `TestResult` is dropped. The `TestResult` and the harness share the
+    /// same lifetime, so a typical test binds the result and lets it fall
+    /// out of scope at the end.
+    pub fn run<I, T>(mut self, app: &App, cmd: Command, args: I) -> TestResult
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        // 1. Materialize fixtures + cwd.
+        let mut restore = RestoreState::default();
+
+        if let Some(dir) = self.tempdir.as_ref() {
+            for (rel, content) in &self.fixtures {
+                let abs = dir.path().join(rel);
+                if let Some(parent) = abs.parent() {
+                    std::fs::create_dir_all(parent)
+                        .expect("TestHarness: failed to create fixture parent dir");
+                }
+                std::fs::write(&abs, content).expect("TestHarness: failed to write fixture file");
+            }
+        }
+
+        let cwd_target = self
+            .cwd
+            .clone()
+            .or_else(|| self.tempdir.as_ref().map(|d| d.path().to_path_buf()));
+        if let Some(target) = cwd_target {
+            restore.original_cwd = std::env::current_dir().ok();
+            std::env::set_current_dir(&target)
+                .expect("TestHarness: failed to change working directory");
+        }
+
+        // 2. Env vars. Save originals so we can restore even on panic.
+        for (k, v) in &self.env_set {
+            restore
+                .env_originals
+                .insert(k.clone(), std::env::var(k).ok());
+            std::env::set_var(k, v);
+        }
+        for k in &self.env_remove {
+            restore
+                .env_originals
+                .insert(k.clone(), std::env::var(k).ok());
+            std::env::remove_var(k);
+        }
+
+        // 3. Environment detectors.
+        if let Some(w) = self.terminal_width {
+            static WIDTH_SLOT: std::sync::OnceLock<std::sync::Mutex<Option<usize>>> =
+                std::sync::OnceLock::new();
+            let slot = WIDTH_SLOT.get_or_init(|| std::sync::Mutex::new(None));
+            *slot.lock().unwrap() = w;
+            set_terminal_width_detector(|| {
+                *WIDTH_SLOT
+                    .get()
+                    .expect("width slot initialized above")
+                    .lock()
+                    .unwrap()
+            });
+            restore.reset_env_detectors = true;
+        }
+        if let Some(flag) = self.is_tty {
+            static TTY_SLOT: std::sync::OnceLock<std::sync::Mutex<bool>> =
+                std::sync::OnceLock::new();
+            let slot = TTY_SLOT.get_or_init(|| std::sync::Mutex::new(false));
+            *slot.lock().unwrap() = flag;
+            set_tty_detector(|| {
+                *TTY_SLOT
+                    .get()
+                    .expect("tty slot initialized above")
+                    .lock()
+                    .unwrap()
+            });
+            restore.reset_env_detectors = true;
+        }
+        if let Some(flag) = self.color_capable {
+            static COLOR_SLOT: std::sync::OnceLock<std::sync::Mutex<bool>> =
+                std::sync::OnceLock::new();
+            let slot = COLOR_SLOT.get_or_init(|| std::sync::Mutex::new(false));
+            *slot.lock().unwrap() = flag;
+            set_color_capability_detector(|| {
+                *COLOR_SLOT
+                    .get()
+                    .expect("color slot initialized above")
+                    .lock()
+                    .unwrap()
+            });
+            restore.reset_env_detectors = true;
+        }
+
+        // 4. Stdin / clipboard overrides.
+        match std::mem::replace(&mut self.stdin, StdinMode::Inherit) {
+            StdinMode::Inherit => {}
+            StdinMode::Piped(content) => {
+                set_default_stdin_reader(Arc::new(MockStdin::piped(content)));
+                restore.reset_stdin = true;
+            }
+            StdinMode::Interactive => {
+                set_default_stdin_reader(Arc::new(MockStdin::terminal()));
+                restore.reset_stdin = true;
+            }
+        }
+        if let Some(content) = self.clipboard.take() {
+            set_default_clipboard_reader(Arc::new(MockClipboard::with_content(content)));
+            restore.reset_clipboard = true;
+        }
+
+        // 5. Argv: append --output=<mode> if forced.
+        let mut argv: Vec<OsString> = args.into_iter().map(|a| a.into()).collect();
+        if let Some(mode) = self.output_mode {
+            argv.push(format!("--output={}", output_mode_flag(mode)).into());
+        }
+
+        let outcome = app.run_to_string(cmd, argv);
+
+        // `self` (and its tempdir) move into TestResult so the fixture dir
+        // survives until the test is finished with the result.
+        TestResult {
+            outcome,
+            _tempdir: self.tempdir.take(),
+            _restore: restore,
+        }
+    }
+}
+
+impl Default for TestHarness {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn output_mode_flag(mode: OutputMode) -> &'static str {
+    match mode {
+        OutputMode::Auto => "auto",
+        OutputMode::Term => "term",
+        OutputMode::Text => "text",
+        OutputMode::TermDebug => "term-debug",
+        OutputMode::Json => "json",
+        OutputMode::Yaml => "yaml",
+        OutputMode::Xml => "xml",
+        OutputMode::Csv => "csv",
+    }
+}
+
+/// Restores process-global state when dropped.
+///
+/// The harness hands ownership of this to the [`TestResult`] so restoration
+/// runs after the test has finished consuming the result (and on panic).
+#[derive(Default)]
+struct RestoreState {
+    env_originals: HashMap<String, Option<String>>,
+    original_cwd: Option<PathBuf>,
+    reset_env_detectors: bool,
+    reset_stdin: bool,
+    reset_clipboard: bool,
+}
+
+impl Drop for RestoreState {
+    fn drop(&mut self) {
+        for (k, original) in self.env_originals.drain() {
+            match original {
+                Some(v) => std::env::set_var(&k, v),
+                None => std::env::remove_var(&k),
+            }
+        }
+        if let Some(cwd) = self.original_cwd.take() {
+            let _ = std::env::set_current_dir(cwd);
+        }
+        if self.reset_env_detectors {
+            reset_environment_detectors();
+        }
+        if self.reset_stdin {
+            reset_default_stdin_reader();
+        }
+        if self.reset_clipboard {
+            reset_default_clipboard_reader();
+        }
+    }
+}
+
+/// Outcome of a [`TestHarness::run`] invocation.
+///
+/// Holds the raw [`RunResult`] produced by the app, plus convenience
+/// accessors and assertion helpers oriented at text output.
+pub struct TestResult {
+    outcome: RunResult,
+    // Kept alive so fixture files remain readable while the test inspects
+    // the result; dropped after restore state is torn down.
+    _tempdir: Option<TempDir>,
+    _restore: RestoreState,
+}
+
+impl TestResult {
+    /// Returns the raw [`RunResult`] for cases where the structured
+    /// accessors aren't enough.
+    pub fn outcome(&self) -> &RunResult {
+        &self.outcome
+    }
+
+    /// Returns the rendered text output, or `""` for `Silent` / `Binary` /
+    /// `NoMatch`.
+    pub fn stdout(&self) -> &str {
+        match &self.outcome {
+            RunResult::Handled(s) => s.as_str(),
+            _ => "",
+        }
+    }
+
+    /// Returns `true` if the run produced text output.
+    pub fn is_handled(&self) -> bool {
+        matches!(self.outcome, RunResult::Handled(_))
+    }
+
+    /// Returns `true` if no handler matched the argv.
+    pub fn is_no_match(&self) -> bool {
+        matches!(self.outcome, RunResult::NoMatch(_))
+    }
+
+    /// If the run produced binary output, returns the bytes and suggested
+    /// filename.
+    pub fn binary(&self) -> Option<(&[u8], &str)> {
+        match &self.outcome {
+            RunResult::Binary(bytes, filename) => Some((bytes.as_slice(), filename.as_str())),
+            _ => None,
+        }
+    }
+
+    // --- assertions ----------------------------------------------------------
+
+    /// Panics unless the run ended in `RunResult::Handled` or
+    /// `RunResult::Silent` (successful dispatch).
+    #[track_caller]
+    pub fn assert_success(&self) {
+        match &self.outcome {
+            RunResult::Handled(_) | RunResult::Silent | RunResult::Binary(_, _) => {}
+            RunResult::NoMatch(_) => {
+                panic!("expected successful dispatch but no handler matched; stdout was empty")
+            }
+        }
+    }
+
+    /// Panics unless the run ended in `RunResult::NoMatch`.
+    #[track_caller]
+    pub fn assert_no_match(&self) {
+        if !self.is_no_match() {
+            panic!(
+                "expected no handler match, got: {:?}",
+                describe_outcome(&self.outcome)
+            );
+        }
+    }
+
+    /// Panics unless [`stdout`](Self::stdout) contains `needle`.
+    #[track_caller]
+    pub fn assert_stdout_contains(&self, needle: &str) {
+        let out = self.stdout();
+        if !out.contains(needle) {
+            panic!(
+                "stdout did not contain {:?}\n--- stdout ---\n{}\n--------------",
+                needle, out
+            );
+        }
+    }
+
+    /// Panics unless [`stdout`](Self::stdout) equals `expected` exactly.
+    #[track_caller]
+    pub fn assert_stdout_eq(&self, expected: &str) {
+        let out = self.stdout();
+        if out != expected {
+            panic!(
+                "stdout mismatch\n--- expected ---\n{}\n--- actual -----\n{}\n----------------",
+                expected, out
+            );
+        }
+    }
+}
+
+fn describe_outcome(o: &RunResult) -> String {
+    match o {
+        RunResult::Handled(s) => format!("Handled({:?})", s),
+        RunResult::Silent => "Silent".into(),
+        RunResult::Binary(b, f) => format!("Binary(len={}, {:?})", b.len(), f),
+        RunResult::NoMatch(_) => "NoMatch".into(),
+    }
+}

--- a/crates/standout-test/src/lib.rs
+++ b/crates/standout-test/src/lib.rs
@@ -24,13 +24,22 @@
 //! # }
 //! ```
 //!
-//! # Concurrency
+//! # Concurrency and restoration
 //!
 //! The harness mutates process-global state (env vars, cwd, environment
 //! detectors, default input readers). Tests that instantiate a
 //! `TestHarness` must be annotated `#[serial]` (from the re-exported
-//! `serial_test` crate). A `Drop` impl restores every override, including
-//! on panic unwind.
+//! `serial_test` crate).
+//!
+//! A `Drop` impl restores every override on both normal exit and panic
+//! unwind, with two nuances:
+//!
+//! - Env vars and cwd are restored to the values captured at `run()` time.
+//! - Terminal detectors and default input readers are reset to the
+//!   library defaults, not to whatever was installed before `run()`. This
+//!   matches the behavior of [`standout_render::DetectorGuard`]. Don't
+//!   mix a `TestHarness` with a manually installed detector override on
+//!   the same thread.
 
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -79,6 +88,7 @@ pub struct TestHarness {
     is_tty: Option<bool>,
     color_capable: Option<bool>,
     output_mode: Option<OutputMode>,
+    output_flag_name: String,
     stdin: StdinMode,
     clipboard: Option<String>,
 }
@@ -96,6 +106,7 @@ impl TestHarness {
             is_tty: None,
             color_capable: None,
             output_mode: None,
+            output_flag_name: "output".to_string(),
             stdin: StdinMode::Inherit,
             clipboard: None,
         }
@@ -161,10 +172,24 @@ impl TestHarness {
 
     /// Forces a specific [`OutputMode`] regardless of the `--output` flag.
     ///
-    /// Internally this injects `--output=<mode>` as the last argument when
-    /// [`TestHarness::run`] is called.
+    /// Internally this injects `--<flag>=<mode>` as the last argument when
+    /// [`TestHarness::run`] is called. `<flag>` defaults to `output`;
+    /// override it with [`output_flag_name`](Self::output_flag_name) for
+    /// apps that renamed the flag via `AppBuilder::output_flag(...)`.
     pub fn output_mode(mut self, mode: OutputMode) -> Self {
         self.output_mode = Some(mode);
+        self
+    }
+
+    /// Configures the CLI flag name used to force [`output_mode`](Self::output_mode).
+    ///
+    /// Defaults to `"output"` (matching `AppBuilder`'s default). Change it
+    /// if the app under test was built with a renamed flag (e.g.
+    /// `AppBuilder::output_flag(Some("format"))`).
+    ///
+    /// No-op when [`output_mode`](Self::output_mode) isn't set.
+    pub fn output_flag_name(mut self, name: impl Into<String>) -> Self {
+        self.output_flag_name = name.into();
         self
     }
 
@@ -214,17 +239,23 @@ impl TestHarness {
     ///
     /// The first call to `fixture` creates a fresh `tempfile::TempDir`
     /// which becomes the default cwd. Access it via [`tempdir`](Self::tempdir).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `path` is absolute or contains a `..` component — both
+    /// would let the fixture escape the harness-owned tempdir and
+    /// potentially clobber files in the user's real filesystem.
     pub fn fixture(mut self, path: impl AsRef<Path>, content: impl Into<String>) -> Self {
-        let path = path.as_ref().to_path_buf();
+        let path = validate_fixture_path(path.as_ref());
         self.fixtures.push((path, content.into().into_bytes()));
         self.ensure_tempdir();
         self
     }
 
     /// Declares a binary fixture file. Same as [`fixture`](Self::fixture)
-    /// but takes raw bytes.
+    /// but takes raw bytes. Applies the same path validation.
     pub fn fixture_bytes(mut self, path: impl AsRef<Path>, content: impl Into<Vec<u8>>) -> Self {
-        let path = path.as_ref().to_path_buf();
+        let path = validate_fixture_path(path.as_ref());
         self.fixtures.push((path, content.into()));
         self.ensure_tempdir();
         self
@@ -283,16 +314,23 @@ impl TestHarness {
         }
 
         // 2. Env vars. Save originals so we can restore even on panic.
+        // Record each original only once per key (before any mutation), so
+        // if the same key appears in both env_set and env_remove, or is
+        // listed multiple times, restore brings back the true original.
+        // Precedence: set is applied first, then remove — so removal wins
+        // when both are requested for the same key.
         for (k, v) in &self.env_set {
             restore
                 .env_originals
-                .insert(k.clone(), std::env::var(k).ok());
+                .entry(k.clone())
+                .or_insert_with(|| std::env::var(k).ok());
             std::env::set_var(k, v);
         }
         for k in &self.env_remove {
             restore
                 .env_originals
-                .insert(k.clone(), std::env::var(k).ok());
+                .entry(k.clone())
+                .or_insert_with(|| std::env::var(k).ok());
             std::env::remove_var(k);
         }
 
@@ -357,10 +395,10 @@ impl TestHarness {
             restore.reset_clipboard = true;
         }
 
-        // 5. Argv: append --output=<mode> if forced.
+        // 5. Argv: append --<flag>=<mode> if an output mode was forced.
         let mut argv: Vec<OsString> = args.into_iter().map(|a| a.into()).collect();
         if let Some(mode) = self.output_mode {
-            argv.push(format!("--output={}", output_mode_flag(mode)).into());
+            argv.push(format!("--{}={}", self.output_flag_name, output_mode_flag(mode)).into());
         }
 
         let outcome = app.run_to_string(cmd, argv);
@@ -379,6 +417,33 @@ impl Default for TestHarness {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn validate_fixture_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+    if path.is_absolute() {
+        panic!(
+            "TestHarness::fixture: path {:?} is absolute; only relative paths are allowed so \
+             the fixture is confined to the harness tempdir",
+            path
+        );
+    }
+    for component in path.components() {
+        match component {
+            Component::ParentDir => panic!(
+                "TestHarness::fixture: path {:?} contains a `..` component; only relative \
+                 paths that stay inside the tempdir are allowed",
+                path
+            ),
+            Component::Prefix(_) | Component::RootDir => panic!(
+                "TestHarness::fixture: path {:?} has a root or prefix component; only \
+                 relative paths inside the tempdir are allowed",
+                path
+            ),
+            _ => {}
+        }
+    }
+    path.to_path_buf()
 }
 
 fn output_mode_flag(mode: OutputMode) -> &'static str {
@@ -479,8 +544,9 @@ impl TestResult {
 
     // --- assertions ----------------------------------------------------------
 
-    /// Panics unless the run ended in `RunResult::Handled` or
-    /// `RunResult::Silent` (successful dispatch).
+    /// Panics unless the run ended in a successful dispatch
+    /// (`RunResult::Handled`, `RunResult::Silent`, or `RunResult::Binary`).
+    /// `RunResult::NoMatch` triggers a panic.
     #[track_caller]
     pub fn assert_success(&self) {
         match &self.outcome {

--- a/crates/standout-test/tests/harness.rs
+++ b/crates/standout-test/tests/harness.rs
@@ -1,0 +1,284 @@
+//! Integration tests for `TestHarness`.
+//!
+//! All tests are `#[serial]` because the harness mutates process-global
+//! state (env vars, cwd, detectors, default input readers).
+
+use clap::Command;
+use serde_json::json;
+use serial_test::serial;
+use standout::cli::{App, Output};
+use standout_input::{ClipboardSource, EnvSource, InputChain, StdinSource};
+use standout_render::OutputMode;
+use standout_test::TestHarness;
+
+fn build_echo_app(template: &'static str) -> App {
+    App::builder()
+        .command(
+            "echo",
+            |m, _ctx| {
+                let msg = m
+                    .get_one::<String>("msg")
+                    .cloned()
+                    .unwrap_or_else(|| "no-arg".into());
+                Ok(Output::Render(json!({ "msg": msg })))
+            },
+            template,
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+fn echo_command() -> Command {
+    Command::new("app")
+        .subcommand(Command::new("echo").arg(clap::Arg::new("msg").required(false).index(1)))
+}
+
+#[test]
+#[serial]
+fn simple_handler_returns_rendered_text() {
+    let app = build_echo_app("{{ msg }}");
+    let result = TestHarness::new().run(&app, echo_command(), vec!["app", "echo", "hello"]);
+    result.assert_success();
+    result.assert_stdout_eq("hello");
+}
+
+#[test]
+#[serial]
+fn env_var_visible_to_handler() {
+    let app = App::builder()
+        .command(
+            "whoami",
+            |_m, _ctx| {
+                let v = InputChain::<String>::new()
+                    .try_source(EnvSource::new("STANDOUT_TEST_USER"))
+                    .default("anon".into())
+                    .resolve(_m)
+                    .unwrap();
+                Ok(Output::Render(json!({ "user": v })))
+            },
+            "{{ user }}",
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let cmd = Command::new("app").subcommand(Command::new("whoami"));
+    let result = TestHarness::new().env("STANDOUT_TEST_USER", "arthur").run(
+        &app,
+        cmd,
+        vec!["app", "whoami"],
+    );
+    result.assert_stdout_eq("arthur");
+}
+
+#[test]
+#[serial]
+fn env_remove_hides_existing_value() {
+    std::env::set_var("STANDOUT_TEST_TOKEN", "real");
+
+    let app = App::builder()
+        .command(
+            "tok",
+            |_m, _ctx| {
+                let v = InputChain::<String>::new()
+                    .try_source(EnvSource::new("STANDOUT_TEST_TOKEN"))
+                    .default("missing".into())
+                    .resolve(_m)
+                    .unwrap();
+                Ok(Output::Render(json!({ "tok": v })))
+            },
+            "{{ tok }}",
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let cmd = Command::new("app").subcommand(Command::new("tok"));
+    {
+        let result =
+            TestHarness::new()
+                .env_remove("STANDOUT_TEST_TOKEN")
+                .run(&app, cmd, vec!["app", "tok"]);
+        result.assert_stdout_eq("missing");
+    }
+
+    // Restore should bring the original back.
+    assert_eq!(std::env::var("STANDOUT_TEST_TOKEN").as_deref(), Ok("real"));
+    std::env::remove_var("STANDOUT_TEST_TOKEN");
+}
+
+#[test]
+#[serial]
+fn piped_stdin_reaches_handler() {
+    let app = App::builder()
+        .command(
+            "read",
+            |_m, _ctx| {
+                let v = InputChain::<String>::new()
+                    .try_source(StdinSource::new())
+                    .default("nothing".into())
+                    .resolve(_m)
+                    .unwrap();
+                Ok(Output::Render(json!({ "val": v })))
+            },
+            "{{ val }}",
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let cmd = Command::new("app").subcommand(Command::new("read"));
+    let result = TestHarness::new()
+        .piped_stdin("piped-in")
+        .run(&app, cmd, vec!["app", "read"]);
+    result.assert_stdout_eq("piped-in");
+}
+
+#[test]
+#[serial]
+fn interactive_stdin_falls_through_to_default() {
+    let app = App::builder()
+        .command(
+            "read",
+            |_m, _ctx| {
+                let v = InputChain::<String>::new()
+                    .try_source(StdinSource::new())
+                    .default("no-pipe".into())
+                    .resolve(_m)
+                    .unwrap();
+                Ok(Output::Render(json!({ "val": v })))
+            },
+            "{{ val }}",
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let cmd = Command::new("app").subcommand(Command::new("read"));
+    let result = TestHarness::new()
+        .interactive_stdin()
+        .run(&app, cmd, vec!["app", "read"]);
+    result.assert_stdout_eq("no-pipe");
+}
+
+#[test]
+#[serial]
+fn clipboard_reaches_handler() {
+    let app = App::builder()
+        .command(
+            "paste",
+            |_m, _ctx| {
+                let v = InputChain::<String>::new()
+                    .try_source(ClipboardSource::new())
+                    .default("empty".into())
+                    .resolve(_m)
+                    .unwrap();
+                Ok(Output::Render(json!({ "val": v })))
+            },
+            "{{ val }}",
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let cmd = Command::new("app").subcommand(Command::new("paste"));
+    let result =
+        TestHarness::new()
+            .clipboard("clipboard-content")
+            .run(&app, cmd, vec!["app", "paste"]);
+    result.assert_stdout_eq("clipboard-content");
+}
+
+#[test]
+#[serial]
+fn fixture_files_are_materialized_in_cwd() {
+    let app = App::builder()
+        .command(
+            "cat",
+            |m, _ctx| {
+                let path = m.get_one::<String>("path").cloned().unwrap();
+                let text = std::fs::read_to_string(path).unwrap();
+                Ok(Output::Render(json!({ "text": text })))
+            },
+            "{{ text }}",
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let cmd = Command::new("app")
+        .subcommand(Command::new("cat").arg(clap::Arg::new("path").required(true).index(1)));
+    let result = TestHarness::new()
+        .fixture("notes/todo.txt", "- buy milk\n- write tests\n")
+        .run(&app, cmd, vec!["app", "cat", "notes/todo.txt"]);
+    result.assert_stdout_contains("buy milk");
+    result.assert_stdout_contains("write tests");
+}
+
+#[test]
+#[serial]
+fn output_mode_override_forces_json() {
+    let app = build_echo_app("{{ msg }}");
+    let result = TestHarness::new().output_mode(OutputMode::Json).run(
+        &app,
+        echo_command(),
+        vec!["app", "echo", "hello"],
+    );
+    let out = result.stdout();
+    assert!(out.contains("\"msg\""));
+    assert!(out.contains("\"hello\""));
+}
+
+#[test]
+#[serial]
+fn terminal_width_override_is_observable_via_detector() {
+    // The harness installs the override for the duration of run(); we
+    // can't easily probe it inside a handler without adding a context
+    // provider, so we assert the render layer sees it by forcing an
+    // auto-mode render and observing no ANSI (no_color) + text mode.
+    let app = build_echo_app("{{ msg }}");
+    let result = TestHarness::new().terminal_width(42).no_color().run(
+        &app,
+        echo_command(),
+        vec!["app", "echo", "hi"],
+    );
+    result.assert_stdout_eq("hi");
+}
+
+#[test]
+#[serial]
+fn overrides_are_restored_on_drop() {
+    let original = std::env::var("STANDOUT_RESTORE_PROBE").ok();
+    std::env::set_var("STANDOUT_RESTORE_PROBE", "before");
+
+    {
+        let app = build_echo_app("{{ msg }}");
+        let _result = TestHarness::new()
+            .env("STANDOUT_RESTORE_PROBE", "during")
+            .env("STANDOUT_BRAND_NEW", "new")
+            .run(&app, echo_command(), vec!["app", "echo", "x"]);
+    }
+
+    assert_eq!(
+        std::env::var("STANDOUT_RESTORE_PROBE").as_deref(),
+        Ok("before")
+    );
+    assert!(std::env::var("STANDOUT_BRAND_NEW").is_err());
+
+    // Cleanup
+    std::env::remove_var("STANDOUT_RESTORE_PROBE");
+    if let Some(v) = original {
+        std::env::set_var("STANDOUT_RESTORE_PROBE", v);
+    }
+}
+
+#[test]
+#[serial]
+fn no_match_reports_cleanly() {
+    let app = build_echo_app("{{ msg }}");
+    let result = TestHarness::new().run(&app, echo_command(), vec!["app", "unknown"]);
+    // clap will emit an error string via Handled for unknown subcommand
+    // at this level; accept either Handled-with-clap-error or NoMatch.
+    assert!(result.is_handled() || result.is_no_match());
+}

--- a/crates/standout-test/tests/harness.rs
+++ b/crates/standout-test/tests/harness.rs
@@ -233,10 +233,9 @@ fn output_mode_override_forces_json() {
 #[test]
 #[serial]
 fn terminal_width_override_is_observable_via_detector() {
-    // The harness installs the override for the duration of run(); we
-    // can't easily probe it inside a handler without adding a context
-    // provider, so we assert the render layer sees it by forcing an
-    // auto-mode render and observing no ANSI (no_color) + text mode.
+    // The override stays installed for the lifetime of the TestResult
+    // (restored when it drops), so we can probe the detector directly
+    // while the result is still in scope.
     let app = build_echo_app("{{ msg }}");
     let result = TestHarness::new().terminal_width(42).no_color().run(
         &app,
@@ -244,6 +243,79 @@ fn terminal_width_override_is_observable_via_detector() {
         vec!["app", "echo", "hi"],
     );
     result.assert_stdout_eq("hi");
+    assert_eq!(standout_render::detect_terminal_width(), Some(42));
+    assert!(!standout_render::detect_color_capability());
+    drop(result);
+    // After drop, detectors are reset to library defaults — the override
+    // should no longer be visible.
+    let _ = standout_render::detect_terminal_width();
+}
+
+#[test]
+#[serial]
+#[should_panic(expected = "absolute")]
+fn fixture_rejects_absolute_path() {
+    let _ = TestHarness::new().fixture("/etc/passwd", "nope");
+}
+
+#[test]
+#[serial]
+#[should_panic(expected = "..")]
+fn fixture_rejects_parent_dir_escape() {
+    let _ = TestHarness::new().fixture("../outside", "nope");
+}
+
+#[test]
+#[serial]
+fn env_set_then_remove_restores_true_original() {
+    std::env::set_var("STANDOUT_DOUBLE_PROBE", "original");
+
+    let app = build_echo_app("{{ msg }}");
+    {
+        let _result = TestHarness::new()
+            .env("STANDOUT_DOUBLE_PROBE", "transient")
+            .env_remove("STANDOUT_DOUBLE_PROBE")
+            .run(&app, echo_command(), vec!["app", "echo", "x"]);
+    }
+
+    // If the harness recorded the mid-run value as the "original" it
+    // would restore "transient" here; the fix records only the first
+    // value seen per key.
+    assert_eq!(
+        std::env::var("STANDOUT_DOUBLE_PROBE").as_deref(),
+        Ok("original")
+    );
+    std::env::remove_var("STANDOUT_DOUBLE_PROBE");
+}
+
+#[test]
+#[serial]
+fn output_flag_name_is_configurable() {
+    // Build an app whose output flag is renamed to --format.
+    let app = standout::cli::App::builder()
+        .output_flag(Some("format"))
+        .command(
+            "echo",
+            |m, _ctx| {
+                let msg = m
+                    .get_one::<String>("msg")
+                    .cloned()
+                    .unwrap_or_else(|| "no-arg".into());
+                Ok(Output::Render(json!({ "msg": msg })))
+            },
+            "{{ msg }}",
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = TestHarness::new()
+        .output_mode(OutputMode::Json)
+        .output_flag_name("format")
+        .run(&app, echo_command(), vec!["app", "echo", "hello"]);
+    let out = result.stdout();
+    assert!(out.contains("\"msg\""), "expected JSON output, got: {out}");
+    assert!(out.contains("\"hello\""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Introduces a new `standout-test` crate with a fluent `TestHarness` builder that bundles the scattered injection seams (env vars, cwd, fixtures, terminal detectors, output mode, stdin, clipboard) into one place and restores every override on drop.

```rust
let result = TestHarness::new()
    .env(\"HOME\", \"/tmp/fake\")
    .clipboard(\"pasted content\")
    .terminal_width(80)
    .piped_stdin(\"extra input\\n\")
    .no_color()
    .fixture(\"notes/todo.txt\", \"- buy milk\\n\")
    .run(&app, cmd, [\"myapp\", \"notes\", \"list\"]);

result.assert_success();
result.assert_stdout_contains(\"buy milk\");
```

### What the harness wires together

| Concern | Mechanism |
|---|---|
| env vars | real `std::env::set_var` / `remove_var`, originals restored on drop |
| cwd + fixtures | `tempfile::TempDir` + `std::env::set_current_dir`; restored on drop |
| terminal width / TTY / color | Phase 1's `set_*_detector` functions |
| output mode | injects `--output=<mode>` into argv |
| stdin / clipboard | process-global default reader overrides (see below) |

### New in `standout-input`

To make stdin and clipboard mocking transparent to handler code, this PR adds:

- `DefaultStdin` / `DefaultClipboard` reader shims that consult a process-global override before falling back to real OS reads.
- `set_default_stdin_reader` / `reset_default_stdin_reader` (plus clipboard equivalents) to install the overrides.
- `StdinSource::new()` / `ClipboardSource::new()` / `read_if_piped()` now use the `Default*` shims, so a test harness override reaches every handler that uses the public API.

Handlers that want per-instance control still use `StdinSource::with_reader(...)` / `ClipboardSource::with_reader(...)` as before — that path is unchanged.

### `TestResult`

Exposes the raw `RunResult`, plus `stdout()`, `binary()`, `is_handled()`, `is_no_match()`, and assertion helpers: `assert_success`, `assert_no_match`, `assert_stdout_contains`, `assert_stdout_eq`.

## Test plan

- [x] 11 new integration tests in `standout-test/tests/harness.rs` cover env, stdin, clipboard, fixtures, output-mode override, and restore-on-drop
- [x] `cargo test --workspace --lib` green
- [x] `cargo test --workspace --tests` green
- [x] `cargo clippy -p standout-test` clean
- [ ] Exercised by Phase 3's `ProcessRunner` (follow-up PR) — the harness will expose a `.runner(MockProcessRunner)` method once Phase 3 lands

## Notes

- Harness is `#[must_use]` — inert until `.run(...)` is called.
- Tests using `TestHarness` must be `#[serial]` because env/cwd/detectors are process-global. The crate re-exports `serial_test::serial` for convenience.
- Restore happens in a `Drop` impl on `RestoreState`, which is owned by the returned `TestResult`, so cleanup runs even on panic unwind.