### PR TITLE
Docs: testing guide + topic page; position testability as primary value

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 **Test your data. Render your view.**
 
-Standout is a CLI framework for Rust that enforces separation between logic and presentation. Your handlers return structs, not strings—making CLI logic as testable as any other code.
+Standout is a CLI framework for Rust built around one claim: a shell application's logic should be as testable as any other Rust code, and its full pipeline — argv in, rendered output out — should be testable in-process, not through brittle subprocess-and-regex dances. Handlers return structs, not strings. A dedicated test harness runs the whole app against a controlled environment (piped stdin, env vars, fixture files, clipboard, terminal width, color capability) in microseconds.
+
+If you've been writing CLI integration tests by spawning the binary and grepping stdout, Standout is built to replace most of them. See **[Introduction to Testing](https://standout.magik.works/guides/intro-to-testing.html)**.
 
 ## The Problem
 
@@ -47,9 +49,30 @@ fn test_list_filters_completed() {
 
 Because your logic returns a struct, you test the struct. No stdout capture, no regex, no brittleness.
 
+For full-pipeline tests — "run the CLI as if it were invoked from a shell, with *this* env, *this* piped stdin, *these* fixture files" — the `standout-test` crate runs the whole app in-process:
+
+```rust
+use standout_test::TestHarness;
+
+#[test]
+#[serial]
+fn list_reads_from_env_configured_file() {
+    let result = TestHarness::new()
+        .env("TODO_FILE", "other.txt")
+        .fixture("other.txt", "buy milk\nwrite tests\n")
+        .no_color()
+        .run(&app, cmd, ["myapp", "list"]);
+
+    result.assert_success();
+    result.assert_stdout_contains("buy milk");
+}
+```
+
+No subprocess. No stdout plumbing. Env vars, cwd, stdin, clipboard, terminal width, and color capability are all controllable, and every override is restored on drop — even on panic. See **[Introduction to Testing](https://standout.magik.works/guides/intro-to-testing.html)** for the full tour.
+
 ## Features
 
-- **Testable by design** — Handlers return data; framework handles rendering
+- **Testable by design** — Handlers return data; `standout-test` runs the full pipeline in-process against a controlled environment
 - **Multiple output modes** — Rich terminal, JSON, YAML, CSV from the same handler
 - **MiniJinja templates** — Familiar syntax with partials, filters, and hot reload
 - **CSS/YAML styling** — Semantic styles with light/dark mode support
@@ -93,7 +116,8 @@ myapp list --output json    # JSON for scripting
 
 You can find comprehensive documentation in our book: **[standout.magik.works](https://standout.magik.works/)**
 
-- [Introduction to Standout](https://standout.magik.works/guides/intro-to-standout.html) — Start here
+- [Introduction to Testing](https://standout.magik.works/guides/intro-to-testing.html) — The primary value prop: why Standout CLIs are testable end-to-end, in-process, without subprocess spawning
+- [Introduction to Standout](https://standout.magik.works/guides/intro-to-standout.html) — Adopting the framework in an existing CLI
 - [Rendering System](https://standout.magik.works/topics/rendering-system.html) — Templates and styles
 - [Tabular Layouts](https://standout.magik.works/topics/tabular.html) — Tables and alignment
 - [All Topics](https://standout.magik.works/topics/index.html) — Complete reference

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Because your logic returns a struct, you test the struct. No stdout capture, no 
 For full-pipeline tests — "run the CLI as if it were invoked from a shell, with *this* env, *this* piped stdin, *these* fixture files" — the `standout-test` crate runs the whole app in-process:
 
 ```rust
-use standout_test::TestHarness;
+use standout_test::{serial, TestHarness};
 
 #[test]
 #[serial]

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Complete Working Example](./guides/complete-example.md)
 - [Quick Start](./guides/tldr-intro-to-standout.md)
 - [Introduction to Standout](./guides/intro-to-standout.md)
+- [Introduction to Testing](./guides/intro-to-testing.md)
 
 ---
 
@@ -35,3 +36,4 @@
 
 - [Output Modes](./topics/output-modes.md)
 - [App Configuration](./topics/app-configuration.md)
+- [Testing](./topics/testing.md)

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -6,6 +6,7 @@ Step-by-step walkthroughs covering principles, rationale, and features.
 
 - **[Introduction to Standout](./intro-to-standout.md)** — Adopting Standout in a working CLI. Start here.
 - **[TLDR Quick Start](./tldr-intro-to-standout.md)** — Fast-paced intro for experienced developers.
+- **[Introduction to Testing](./intro-to-testing.md)** — Testing Standout CLIs end-to-end, in-process, with full environment control.
 
 ## Crate Guides
 
@@ -25,5 +26,7 @@ For detailed guides on the underlying libraries:
 If you're new to Standout, begin with [Introduction to Standout](./intro-to-standout.md). It walks through adopting Standout in an existing CLI, step by step.
 
 For a quick overview without the explanations, see the [TLDR Quick Start](./tldr-intro-to-standout.md).
+
+Once you have the framework in place, [Introduction to Testing](./intro-to-testing.md) shows how the architecture plus the `standout-test` harness largely replaces slow, brittle subprocess-based CLI tests with fast in-process ones.
 
 If you want to use the crates independently (without the full framework), start with the crate-specific guides above.

--- a/docs/guides/intro-to-testing.md
+++ b/docs/guides/intro-to-testing.md
@@ -349,17 +349,19 @@ fn list_prefers_env_var_over_cwd_file() {
 #[test]
 #[serial]
 fn add_reads_from_piped_stdin_when_no_arg() {
-    let result = TestHarness::new()
+    // Capture the fixture tempdir path *before* .run() consumes the
+    // builder, so we can read files back after the handler has written
+    // to them. The tempdir itself lives inside the returned TestResult
+    // and stays alive until that result drops at end of scope.
+    let harness = TestHarness::new()
         .fixture("todos.txt", "")
-        .piped_stdin("buy milk")
-        .run(&app(), command(), ["todo", "add"]);
+        .piped_stdin("buy milk");
+    let todos_path = harness.tempdir().unwrap().join("todos.txt");
 
+    let result = harness.run(&app(), command(), ["todo", "add"]);
     result.assert_success();
 
-    // The handler wrote to todos.txt in the fixture tempdir — read it back
-    // to confirm the side effect.
-    let path = TestHarness::new().tempdir().unwrap().join("todos.txt");
-    let contents = std::fs::read_to_string(path).unwrap();
+    let contents = std::fs::read_to_string(todos_path).unwrap();
     assert!(contents.contains("buy milk"));
 }
 
@@ -431,8 +433,8 @@ TestHarness::new()
     // terminal detectors (see standout-render::environment)
     .terminal_width(80)
     .no_terminal_width()
-    .is_tty() | .no_tty()
-    .with_color() | .no_color()
+    .is_tty()                                 // or .no_tty()
+    .with_color()                             // or .no_color()
 
     // forced output mode (injects --output=<mode> into argv)
     .output_mode(OutputMode::Json)

--- a/docs/guides/intro-to-testing.md
+++ b/docs/guides/intro-to-testing.md
@@ -1,0 +1,468 @@
+# Testing Standout CLIs
+
+This is the guide for testing CLIs built with Standout. It starts from a claim most people nod at but few act on — *"shell apps should be easy to test"* — and shows how Standout's architecture, combined with the `standout-test` crate, actually makes that true.
+
+**See also:**
+
+- [Handler Contract](../crates/dispatch/topics/handler-contract.md)
+- [Testing (Topic)](../topics/testing.md) — reference for the `standout-test` API surface
+- [Output Modes](../topics/output-modes.md)
+
+## 1. The claim no one keeps
+
+"Shell applications should be easy to test. Just keep logic separate from output."
+
+Sure. And yet look at any CLI in the wild and count the tests that:
+
+- Spawn the compiled binary as a subprocess
+- Pipe some argv in
+- Capture stdout
+- Regex-match the output
+
+That's not testing behavior. That's reverse-engineering the user interface on every run. When you test a function via its rendered output, every trivial copy change breaks the test. Every color tweak breaks the test. Every time you add an emoji, every time the column widths shift, every time a locale flips — broken tests.
+
+The honest answer is that most CLI codebases *don't* keep logic and output cleanly separated, because there's no discipline enforcing it. `println!` is always one line away. The tests you end up writing reflect that: they're shell-out + regex, because the production code is too tangled to test any other way.
+
+## 2. The free win: architecture
+
+Standout's first contribution to testability has nothing to do with testing tools. It's the architecture itself.
+
+A handler is a pure function:
+
+```rust
+pub fn list(m: &ArgMatches, ctx: &CommandContext) -> HandlerResult<TodoResult> {
+    let show_all = m.get_flag("all");
+    let todos = storage::list()?
+        .into_iter()
+        .filter(|t| show_all || matches!(t.status, Status::Pending))
+        .collect();
+    Ok(Output::Render(TodoResult { todos }))
+}
+```
+
+Output is data. Rendering lives somewhere else — a template, a stylesheet. The handler never touches stdout.
+
+This means you can test the handler the way you test any other Rust function:
+
+```rust
+#[test]
+fn list_filters_completed_by_default() {
+    let matches = build_matches(&["list"]);
+    let ctx = CommandContext::default();
+
+    let Output::Render(result) = list(&matches, &ctx).unwrap() else {
+        panic!("expected Render");
+    };
+
+    assert!(result.todos.iter().all(|t| matches!(t.status, Status::Pending)));
+}
+
+#[test]
+fn list_with_all_returns_everything() {
+    let matches = build_matches(&["list", "--all"]);
+    let ctx = CommandContext::default();
+
+    let Output::Render(result) = list(&matches, &ctx).unwrap() else { panic!() };
+    assert_eq!(result.todos.len(), storage::list().unwrap().len());
+}
+```
+
+No stdout capture. No regex. No subprocess. Just a function call and a struct assertion. The test reads like the behavior it describes.
+
+This covers the majority of real logic — filtering, aggregation, validation, business rules. Standout didn't *invent* the idea of testing a pure function; it made sure the surrounding framework doesn't tempt you away from it.
+
+> **Verify:** Pick a handler in your app. Write a test that calls it directly and asserts on the returned data. If you can't, the handler has logic tangled with side effects — that's the real bug.
+
+### Intermezzo A: What the architecture already bought you
+
+**What you got for free:**
+
+- Handlers are pure functions; logic tests are straightforward `fn() -> Result<T, E>` tests.
+- Output data is a `Serialize` struct. You can also assert on it as JSON (useful for cross-language consumers).
+- Argument parsing is clap's problem. Clap has its own extensive test suite — you don't need to re-test it.
+- Template rendering is `standout-render`'s problem. Its test suite covers MiniJinja syntax, tag parsing, style resolution, output modes.
+
+**What's left:**
+
+- **Integration** — does the full pipeline (argv → dispatch → handler → render → stdout) actually work for this command?
+- **Environment-dependent behavior** — does this command react correctly to piped stdin, a missing env var, a narrow terminal, no color support?
+- **Filesystem-dependent behavior** — does the command find, read, and write files in the right places?
+
+These three are where CLIs traditionally fall back to subprocess-based e2e tests. That's what the rest of this guide is about.
+
+## 3. The remaining gap
+
+Let's be precise about what the architecture *doesn't* solve and why subprocess tests are tempting.
+
+**Integration.** Even with clean handlers, a bug can live at the seam: an argument you thought was global isn't, a hook mutates state the handler doesn't see, a template references a field that doesn't exist. You want to assert on the *rendered output* of a full invocation, not just on the handler's return value.
+
+**The environment.** CLIs read from the environment in a dozen places: `$EDITOR`, `$HOME`, piped stdin, the clipboard, the terminal width, whether stdout is a TTY, whether the terminal supports color, the current working directory, files at specific paths. Any of these can change behavior. None of them are the handler's "input" in the argv sense.
+
+**Filesystem state.** Your command may need to read a config file at `~/.myapp/config.toml`, write a lockfile, list entries in a working directory. Testing this with real paths pollutes the developer's machine; testing it by hand-rolling temp dirs in every test file duplicates code.
+
+The default answer is:
+
+```rust
+#[test]
+fn list_shows_todos() {
+    let output = Command::cargo_bin("myapp")
+        .unwrap()
+        .args(["list"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+    assert!(text.contains("buy milk"));
+}
+```
+
+This works. It's also:
+
+- **Slow.** Spawning your binary is tens to hundreds of milliseconds, not microseconds.
+- **Opaque.** If it fails, you get the stdout blob and a non-zero exit. You can't step into it, you can't inspect intermediate state.
+- **Brittle.** The assertion is on rendered text; any presentation change breaks it.
+- **Hostile to invariants.** Want to assert "the command set no env var as a side effect"? "The JSON payload had exactly these keys"? "A specific template was selected"? Good luck.
+
+Subprocess tests have a place — and section 6 below names it — but they shouldn't be the default.
+
+## 4. The `standout-test` harness
+
+`standout-test` gives you a fluent builder that runs your app *in-process* with full control over the environment, then hands back a `TestResult` with typed accessors and assertion helpers.
+
+```toml
+# Cargo.toml
+[dev-dependencies]
+standout-test = "7.5"
+```
+
+The smallest possible test:
+
+```rust
+use serial_test::serial;
+use standout_test::TestHarness;
+
+#[test]
+#[serial]
+fn list_runs() {
+    let app = build_app();              // your normal App::builder().build()?
+    let cmd = build_cli_command();      // your clap Command
+
+    let result = TestHarness::new().run(&app, cmd, ["myapp", "list"]);
+
+    result.assert_success();
+    result.assert_stdout_contains("buy milk");
+}
+```
+
+That's it. `run()` drives the same dispatch path as production — same clap parsing, same handler lookup, same render pipeline — and returns the rendered text. No subprocess, no stdout capture gymnastics.
+
+> **Why `#[serial]`?** The harness mutates process-global state (env vars, cwd, terminal detectors, default input readers). Tests that use `TestHarness` must run serially. The `serial_test::serial` attribute is re-exported from `standout_test` for convenience: `use standout_test::serial;`.
+
+> **Verify:** Add a `TestHarness::new().run(...)` test to your app. It should run in under 10ms, not 100ms.
+
+### 4.1 Env vars
+
+Your command reads `$EDITOR`? Set it:
+
+```rust
+#[test]
+#[serial]
+fn respects_editor_env() {
+    let result = TestHarness::new()
+        .env("EDITOR", "vim")
+        .run(&app, cmd, ["myapp", "note", "new"]);
+
+    result.assert_stdout_contains("opening vim");
+}
+```
+
+Need to *remove* an env var that exists on your dev machine?
+
+```rust
+.env_remove("HOME")
+```
+
+Both are backed by real `std::env::set_var` / `remove_var`. The originals are captured before the run and restored when the `TestResult` drops — including on panic unwind, so a failing assertion never leaks state into the next test.
+
+### 4.2 Fixtures and working directory
+
+For commands that read or write files:
+
+```rust
+#[test]
+#[serial]
+fn reads_config() {
+    let result = TestHarness::new()
+        .fixture("config.toml", r#"format = "short""#)
+        .fixture("todos/today.md", "- buy milk\n- write tests\n")
+        .run(&app, cmd, ["myapp", "show"]);
+
+    result.assert_stdout_contains("buy milk");
+}
+```
+
+Each `.fixture()` call writes a file into a freshly created `tempfile::TempDir`. The first fixture call also sets that tempdir as the working directory for the run, so handlers using relative paths just work.
+
+You can access the tempdir directly if you need absolute paths as handler arguments:
+
+```rust
+let harness = TestHarness::new().fixture("input.txt", "hello\n");
+let path = harness.tempdir().unwrap().join("input.txt");
+let result = harness.run(&app, cmd, ["myapp", "cat", path.to_str().unwrap()]);
+```
+
+Fixture paths must be relative and stay inside the tempdir — absolute paths and `..` components are rejected so a stray fixture can't clobber your real home directory.
+
+### 4.3 Piped stdin
+
+Want to test the "CLI piped as input" path?
+
+```rust
+#[test]
+#[serial]
+fn reads_from_stdin() {
+    let result = TestHarness::new()
+        .piped_stdin("draft text\n")
+        .run(&app, cmd, ["myapp", "publish"]);
+
+    result.assert_stdout_contains("draft text");
+}
+```
+
+Any handler built on `standout-input::StdinSource::new()` — or on `standout_input::read_if_piped()` — transparently sees the mock. It reports `is_terminal() == false` and reads the content you supplied.
+
+The counterpart:
+
+```rust
+.interactive_stdin()    // StdinSource::new().is_terminal() reports true; nothing to read
+```
+
+### 4.4 Clipboard
+
+Same story for the system clipboard:
+
+```rust
+.clipboard("https://example.com/pasted-url")
+```
+
+`ClipboardSource::new()` returns the mock content; no shelling out to `pbpaste` / `xclip`.
+
+### 4.5 Terminal state
+
+Three orthogonal knobs, all routed through Phase 1's environment detectors:
+
+```rust
+.terminal_width(80)     // forces a fixed width for tabular layouts
+.no_color()             // forces OutputMode::Auto to behave like Text
+.with_color()           // forces Auto to behave like Term even when piped
+.no_tty()               // stdout reports as not-a-TTY
+.is_tty()               // stdout reports as a TTY
+```
+
+Useful for snapshot testing: pin the width, turn off color, and the rendered string is deterministic across developer machines and CI.
+
+### 4.6 Forcing an output mode
+
+Sometimes you want to assert on structured output regardless of what the user's `--output` flag would have chosen. Instead of manually appending `--output=json` to argv:
+
+```rust
+#[test]
+#[serial]
+fn list_as_json_has_expected_shape() {
+    let result = TestHarness::new()
+        .output_mode(OutputMode::Json)
+        .run(&app, cmd, ["myapp", "list"]);
+
+    let value: serde_json::Value =
+        serde_json::from_str(result.stdout()).unwrap();
+    assert!(value["todos"].is_array());
+    assert_eq!(value["todos"].as_array().unwrap().len(), 3);
+}
+```
+
+If your app renamed the flag via `AppBuilder::output_flag(Some("format"))`, tell the harness:
+
+```rust
+.output_flag_name("format")
+```
+
+### Intermezzo B: A full-pipeline test, in-process
+
+**What you achieved:** Your integration tests run in the same process, in microseconds, with complete environment control.
+
+**What's now possible:**
+
+- Assert on both the rendered output *and* the handler's return data in the same test (via `result.outcome()`).
+- Test env-dependent branches without touching `std::env` from your test code directly.
+- Pin terminal width and color for snapshot tests.
+- Replace a subprocess-based integration suite with a harness-based one; watch the run time drop by an order of magnitude.
+
+**What's next:** A worked example, and the boundaries — what the harness still can't do.
+
+## 5. A worked example
+
+Let's test a todo CLI end-to-end. The app reads todos from `$TODO_FILE` (or `todos.txt` in the cwd), supports adding via argument or piped stdin, and renders either as a styled list or as JSON.
+
+```rust
+use clap::Command;
+use serial_test::serial;
+use standout_test::TestHarness;
+use standout_render::OutputMode;
+
+fn app() -> standout::cli::App {
+    // your real App::builder() -> build()
+    todo!()
+}
+
+fn command() -> Command {
+    // your real clap Command definition
+    todo!()
+}
+
+#[test]
+#[serial]
+fn list_shows_todos_from_cwd_file() {
+    let result = TestHarness::new()
+        .fixture("todos.txt", "buy milk\nwrite tests\n")
+        .run(&app(), command(), ["todo", "list"]);
+
+    result.assert_success();
+    result.assert_stdout_contains("buy milk");
+    result.assert_stdout_contains("write tests");
+}
+
+#[test]
+#[serial]
+fn list_prefers_env_var_over_cwd_file() {
+    let result = TestHarness::new()
+        .fixture("todos.txt", "from-cwd\n")
+        .fixture("other.txt", "from-env\n")
+        .env("TODO_FILE", "other.txt")
+        .run(&app(), command(), ["todo", "list"]);
+
+    result.assert_stdout_contains("from-env");
+    assert!(!result.stdout().contains("from-cwd"));
+}
+
+#[test]
+#[serial]
+fn add_reads_from_piped_stdin_when_no_arg() {
+    let result = TestHarness::new()
+        .fixture("todos.txt", "")
+        .piped_stdin("buy milk")
+        .run(&app(), command(), ["todo", "add"]);
+
+    result.assert_success();
+
+    // The handler wrote to todos.txt in the fixture tempdir — read it back
+    // to confirm the side effect.
+    let path = TestHarness::new().tempdir().unwrap().join("todos.txt");
+    let contents = std::fs::read_to_string(path).unwrap();
+    assert!(contents.contains("buy milk"));
+}
+
+#[test]
+#[serial]
+fn list_as_json_is_valid_and_shaped() {
+    let result = TestHarness::new()
+        .fixture("todos.txt", "a\nb\nc\n")
+        .output_mode(OutputMode::Json)
+        .run(&app(), command(), ["todo", "list"]);
+
+    let v: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+    let items = v["todos"].as_array().unwrap();
+    assert_eq!(items.len(), 3);
+    assert_eq!(items[0]["title"], "a");
+}
+
+#[test]
+#[serial]
+fn list_without_color_strips_ansi() {
+    let result = TestHarness::new()
+        .fixture("todos.txt", "one\n")
+        .no_color()
+        .run(&app(), command(), ["todo", "list"]);
+
+    assert!(
+        !result.stdout().contains('\x1b'),
+        "expected no ANSI escapes in output, got: {:?}",
+        result.stdout()
+    );
+}
+```
+
+Every test reads like a statement of behavior. Nothing runs in a subprocess. Nothing depends on the developer's real home directory or clipboard. Every test restores the environment on drop.
+
+### Intermezzo C: Integration tests that don't suck
+
+**What you achieved:** A full integration test suite that runs in under a second, covers env-dependent branches, and breaks only when the behavior actually changes — not when someone tweaks a template.
+
+**What you traded:** Your tests are `#[serial]` (they mutate process globals). For a CLI binary that isn't a library dependency of a massive workspace, this is almost never a problem — CLI test suites are small enough that serial execution is fine.
+
+## 6. What the harness still can't do
+
+Be honest about the boundaries. There are things you shouldn't try to test in-process:
+
+**Real PTY behavior.** If your CLI drives progress bars, raw-mode TUIs, or prompts that sniff `isatty()` on a PTY (not just on the `StdinReader` abstraction), the harness can't simulate that. Use `rexpect` or `expectrl` with a spawned subprocess.
+
+**Signals.** SIGINT / SIGTERM handling only makes sense against a real process.
+
+**Subprocess fan-out from your app.** If your handler shells out to `git`, `rg`, `$EDITOR`, or any other external program, the harness can't intercept that call. *This is the focus of Phase 3 of the test-tooling work — a `ProcessRunner` abstraction that routes through `CommandContext`, with a mock variant for tests. It's not yet shipped; until it is, shell-outs remain a boundary.* In the meantime, structure handlers so the shell-out is a trait you can swap for a mock in the handler's tests directly.
+
+**Binary-level concerns.** If you're testing that the compiled binary has the right linkage, exits with the right code, or handles `--version` through a specific path — that's genuinely integration-of-the-build, and a small `assert_cmd` suite is the right tool.
+
+The goal isn't to replace subprocess tests entirely. It's to reduce them to the small set of cases where they're actually earning their keep.
+
+## 7. Cheat sheet
+
+```rust
+TestHarness::new()
+    // environment variables (real OS env, restored on drop)
+    .env("KEY", "value")
+    .env_remove("KEY")
+
+    // working directory and fixture files
+    .cwd("/some/path")                       // explicit cwd
+    .fixture("notes/todo.txt", "content")    // writes file, sets cwd to tempdir
+    .fixture_bytes("data.bin", vec![1,2,3])
+
+    // terminal detectors (see standout-render::environment)
+    .terminal_width(80)
+    .no_terminal_width()
+    .is_tty() | .no_tty()
+    .with_color() | .no_color()
+
+    // forced output mode (injects --output=<mode> into argv)
+    .output_mode(OutputMode::Json)
+    .text_output()                            // shortcut for OutputMode::Text
+    .output_flag_name("format")               // if AppBuilder::output_flag was renamed
+
+    // stdin (routed through standout-input's default reader)
+    .piped_stdin("content")
+    .interactive_stdin()
+
+    // clipboard (same)
+    .clipboard("content")
+
+    // execute
+    .run(&app, cmd, ["binname", "subcommand", "--flag"])
+
+// TestResult
+result.assert_success();                // Handled / Silent / Binary
+result.assert_no_match();               // clap didn't match any subcommand
+result.assert_stdout_contains("hi");
+result.assert_stdout_eq("hi\n");
+result.stdout();                        // &str
+result.outcome();                       // &RunResult, for bespoke assertions
+result.binary();                        // Option<(&[u8], &str)> for Binary
+```
+
+## Appendix: common pitfalls
+
+- **Tests leak state into each other.** Every test that uses `TestHarness` must be `#[serial]`. Parallel execution mixed with process-global mutations is unsupported.
+- **A `TestHarness::new()` without `.run(...)` does nothing.** The harness is `#[must_use]` — inert until you call `.run`.
+- **`output_mode(...)` injects `--output=<mode>` into argv.** If your app uses a different flag name (via `AppBuilder::output_flag(Some("format"))`), set `.output_flag_name("format")`.
+- **Detectors reset to library defaults, not to prior overrides.** Don't mix a `TestHarness` with a manually installed `set_*_detector` on the same thread; the harness's `Drop` will wipe your override.
+- **Handlers that bypass `standout-input`.** If a handler reads stdin directly via `std::io::stdin()` instead of `StdinSource::new()` or `read_if_piped()`, the harness's `.piped_stdin()` won't reach it. Prefer the abstractions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ Because your logic returns a struct, you test the struct. No stdout capture, no 
 What Standout provides:
 
 - Enforced architecture splitting data and presentation
-- Logic is testable as any Rust code
+- Logic is testable as any Rust code — and full CLI invocations are testable in-process via the [`standout-test`](guides/intro-to-testing.md) harness, without subprocess spawning or stdout parsing
 - Boilerplateless: declaratively link your handlers to command names and templates, Standout handles the rest
 - Autodispatch: save keystrokes with auto dispatch from the known command tree
 - Free [output handling](topics/output-modes.md): rich terminal with graceful degradation, plus structured data (JSON, YAML, CSV)
@@ -197,6 +197,7 @@ See the [Partial Adoption Guide](crates/dispatch/topics/partial-adoption.md) for
 ## Next Steps
 
 - **[Introduction to Standout](guides/intro-to-standout.md)** — Adopting Standout in a working CLI. Start here.
+- **[Introduction to Testing](guides/intro-to-testing.md)** — Why Standout CLIs are testable by design, and how the `standout-test` harness replaces slow, brittle subprocess tests with fast in-process ones.
 - [Introduction to Rendering](crates/render/guides/intro-to-rendering.md) — Creating polished terminal output
 - [Introduction to Tabular](crates/render/guides/intro-to-tabular.md) — Building aligned, readable tabular layouts
 - [All Topics](topics/index.md) — In-depth documentation for specific systems

--- a/docs/topics/testing.md
+++ b/docs/topics/testing.md
@@ -1,0 +1,194 @@
+# Testing
+
+Standout treats testability as a primary design constraint, not an afterthought. This page is the reference view: how Standout's layers compose to make a CLI testable, which seams the framework exposes, and where each testing technique fits.
+
+For the tutorial introduction — how to *use* `TestHarness` starting from a small surface — see [Introduction to Testing](../guides/intro-to-testing.md).
+
+## Why this section exists
+
+Most CLI frameworks punt on testing. Users end up with one of two patterns: (a) a tangled handler they can't unit test, tested only via subprocess + regex on stdout; (b) a split architecture they enforce by convention, with scaffolding to match mocks to sources duplicated across every test file. Standout tries to make the clean path the easy path.
+
+This is a mix of architectural choices (which move more testable code closer to the surface) and concrete tooling (`standout-test`, environment detectors, default reader shims).
+
+## Three levels, three tools
+
+A Standout app has three testing layers, each appropriate to a different kind of change:
+
+| Level | What it covers | Tool | Speed |
+|---|---|---|---|
+| Unit | A single handler's logic, as a pure function | Plain `#[test]` + direct call | Microseconds |
+| Integration | Full dispatch pipeline in-process: argv → handler → render | `standout-test::TestHarness` | Microseconds to low milliseconds |
+| End-to-end | Real process, real PTY, real signals, real subprocess fan-out | `assert_cmd`, `expectrl`, `rexpect` | Tens to hundreds of milliseconds per test |
+
+Choose by what the change touches. A bug in a filter predicate belongs in level 1. A bug in "does this command actually read `$TODO_FILE`?" belongs in level 2. A bug in raw-mode TUI redraw belongs in level 3 — and is a signal to look hard at whether the logic in question could be extracted.
+
+## What each layer gives you for free
+
+### Handlers are pure functions
+
+The `HandlerResult<T>` contract is that a handler takes `&ArgMatches` + `&CommandContext` and returns a serializable value. It doesn't touch stdout. It doesn't render. It returns data.
+
+This alone covers the majority of a real CLI's logic surface. You test handlers the way you test any Rust function: construct inputs, call, assert on the output struct. No stdout capture, no regex.
+
+For the canonical example, see [the Introduction to Standout](../guides/intro-to-standout.md#2-hard-split-logic-and-formatting). The key invariant is that *nothing about the handler depends on terminal state*.
+
+### Clap is already tested
+
+Argument parsing is clap's responsibility, and clap has an extensive test suite of its own. You don't need to rewrite those tests; you just need to trust the seam. If you have truly exotic arg-parsing logic, test it by calling `Command::try_get_matches_from(...)` directly — that's clap's in-process API.
+
+### Rendering is already tested
+
+`standout-render` has snapshot tests for MiniJinja template evaluation, CSS parsing, style resolution, tag transforms, tabular layouts, and every output mode. Again, you don't need to re-test it — you need to test that *your* templates render the shape of data you think they do. The harness covers that naturally by running the full pipeline.
+
+## What the harness adds
+
+`TestHarness` (in the `standout-test` crate) is the unified in-process runner. It wraps `App::run_to_string` with fluent setup for every injectable piece of state:
+
+- Env vars (real `std::env::set_var`, originals captured and restored on drop)
+- Working directory (real `std::env::set_current_dir`, original restored on drop)
+- Fixture files (written into a `tempfile::TempDir`)
+- Terminal detectors: width, TTY, color capability
+- Stdin reader (process-global override consulted by `StdinSource::new()`)
+- Clipboard reader (same mechanism for `ClipboardSource::new()`)
+- Forced `OutputMode` (injected as `--output=<mode>` into argv)
+
+A `RestoreState` held inside the returned `TestResult` runs on drop — on both normal exit and panic unwind — and undoes every mutation. This means a failing assertion never leaks state into sibling tests.
+
+The harness is `#[must_use]`: a `TestHarness::new()` without a `.run(...)` does nothing and gets flagged by the compiler.
+
+See [Introduction to Testing](../guides/intro-to-testing.md) for the full builder tour.
+
+## Environment seams exposed by the framework
+
+The harness doesn't invent new mechanisms; it wires together seams that Standout exposes deliberately, all of which you can also use directly.
+
+### `standout-render::environment`
+
+The render crate exposes three overridable detectors:
+
+```rust
+use standout_render::{
+    set_terminal_width_detector, set_tty_detector, set_color_capability_detector,
+    reset_environment_detectors, DetectorGuard,
+};
+```
+
+Each takes a `fn() -> T` (function pointer or non-capturing closure). `DetectorGuard` is a RAII helper that resets all three on drop.
+
+These drive `OutputMode::Auto`'s color decision and the render context's terminal width. Install an override in any test that snapshots rendered output, and the result becomes deterministic across machines.
+
+### `standout-input` default readers
+
+`StdinSource::new()` and `ClipboardSource::new()` resolve their reader through the `DefaultStdin` / `DefaultClipboard` shims. Each shim first consults a process-global override; if none is installed, it falls back to the real OS-backed reader.
+
+```rust
+use standout_input::{
+    set_default_stdin_reader, reset_default_stdin_reader,
+    set_default_clipboard_reader, reset_default_clipboard_reader,
+};
+use standout_input::env::{MockStdin, MockClipboard};
+
+set_default_stdin_reader(Arc::new(MockStdin::piped("hello")));
+// ... run test ...
+reset_default_stdin_reader();
+```
+
+Handlers that use `StdinSource::new()` / `ClipboardSource::new()` / `read_if_piped()` pick up the mock transparently — no handler refactor needed.
+
+Handlers that need per-instance control keep using `StdinSource::with_reader(MockStdin::piped(...))` as before.
+
+### Env vars and cwd
+
+These aren't proxied through a Standout abstraction — they're just real OS primitives. Use `std::env::set_var` / `std::env::set_current_dir` (directly or through the harness). The harness adds: (a) capture-and-restore around `.run()`, and (b) a tempdir per test for fixtures.
+
+## Concurrency model
+
+Every seam above is process-global. Parallel tests that mutate them will interfere with each other.
+
+Use `#[serial]` from the `serial_test` crate (re-exported as `standout_test::serial`) on every test that uses `TestHarness` or any of the lower-level detectors. Within a test binary, serial execution is automatic; across test binaries, cargo runs one test binary at a time by default, so there's no extra coordination needed.
+
+## Recipes
+
+### Snapshot testing with `insta`
+
+Pin terminal state for determinism, run, snapshot the output:
+
+```rust
+use insta::assert_snapshot;
+
+#[test]
+#[serial]
+fn list_snapshot() {
+    let result = TestHarness::new()
+        .fixture("todos.txt", "a\nb\nc\n")
+        .terminal_width(80)
+        .no_color()
+        .run(&app(), command(), ["todo", "list"]);
+
+    assert_snapshot!(result.stdout());
+}
+```
+
+### Asserting JSON shape
+
+Force `OutputMode::Json` to bypass the template and serialize the handler's data directly:
+
+```rust
+let result = TestHarness::new()
+    .output_mode(OutputMode::Json)
+    .run(&app, cmd, ["myapp", "list"]);
+
+let v: serde_json::Value = serde_json::from_str(result.stdout()).unwrap();
+assert_eq!(v["todos"].as_array().unwrap().len(), 3);
+```
+
+### Testing a handler without going through dispatch
+
+For pure logic tests, skip the harness entirely:
+
+```rust
+#[test]
+fn filter_excludes_done_by_default() {
+    let matches = Command::new("t")
+        .arg(clap::Arg::new("all").long("all").action(clap::ArgAction::SetTrue))
+        .try_get_matches_from(["t"])
+        .unwrap();
+    let ctx = CommandContext::default();
+
+    let Output::Render(result) = list(&matches, &ctx).unwrap() else { panic!() };
+    assert!(result.todos.iter().all(|t| matches!(t.status, Status::Pending)));
+}
+```
+
+This path has no `#[serial]` requirement — nothing global is touched.
+
+### Mixing levels
+
+A common layout for a CLI crate:
+
+```text
+tests/
+├── handlers.rs       # level 1 — direct handler calls
+├── harness.rs        # level 2 — TestHarness integration tests
+└── e2e.rs            # level 3 — assert_cmd for the few things the harness can't cover
+```
+
+Run them together with `cargo test`. Level 1 is by far the largest file; level 3 is usually less than a dozen tests.
+
+## Boundaries
+
+`TestHarness` is an in-process runner. It cannot simulate:
+
+- **Real PTY.** `isatty()` on the real stdin file descriptor, raw-mode terminals, progress bars that depend on cursor control. Use `expectrl` / `rexpect` with a spawned subprocess.
+- **Signals.** SIGINT / SIGTERM handling needs a real process.
+- **Shelling out from your handler.** If a handler invokes `git`, `rg`, `$EDITOR`, etc., those run as real subprocesses in the test too. A `ProcessRunner` abstraction to address this is in progress (Phase 3 of the test-tooling work); until it lands, structure shell-outs behind a local trait you can swap for a mock in handler tests.
+- **Build / linker integration.** Testing that the compiled binary has the right embedded resources, dependencies, or `--version` output is fair game for a small `assert_cmd` suite.
+
+The goal is to keep level-3 tests small and intentional — the cases where you really do need a real process — and put everything else at level 1 or 2.
+
+## See also
+
+- [Introduction to Testing](../guides/intro-to-testing.md) — the tutorial
+- [Handler Contract](../crates/dispatch/topics/handler-contract.md) — what makes a handler pure
+- [Output Modes](./output-modes.md) — forcing deterministic output
+- [Introduction to Input](../crates/input/guides/intro-to-input.md) — input sources and their mock variants

--- a/docs/topics/testing.md
+++ b/docs/topics/testing.md
@@ -52,7 +52,10 @@ Argument parsing is clap's responsibility, and clap has an extensive test suite 
 - Clipboard reader (same mechanism for `ClipboardSource::new()`)
 - Forced `OutputMode` (injected as `--output=<mode>` into argv)
 
-A `RestoreState` held inside the returned `TestResult` runs on drop — on both normal exit and panic unwind — and undoes every mutation. This means a failing assertion never leaks state into sibling tests.
+A `RestoreState` held inside the returned `TestResult` runs on drop — on both normal exit and panic unwind — and tears down every override, so a failing assertion never leaks state into sibling tests. Two nuances worth knowing:
+
+- **Env vars and cwd** are restored to the values captured at `run()` time. This is a true "put it back the way you found it."
+- **Terminal detectors and default stdin/clipboard readers** are reset to the library defaults, not to whatever was installed before `run()`. If you mix `TestHarness` with a manually installed `set_*_detector` / `set_default_*_reader` on the same thread, the harness's drop will wipe your override. Keep them separate, or scope the manual override entirely outside the harness.
 
 The harness is `#[must_use]`: a `TestHarness::new()` without a `.run(...)` does nothing and gets flagged by the compiler.
 
@@ -82,6 +85,7 @@ These drive `OutputMode::Auto`'s color decision and the render context's termina
 `StdinSource::new()` and `ClipboardSource::new()` resolve their reader through the `DefaultStdin` / `DefaultClipboard` shims. Each shim first consults a process-global override; if none is installed, it falls back to the real OS-backed reader.
 
 ```rust
+use std::sync::Arc;
 use standout_input::{
     set_default_stdin_reader, reset_default_stdin_reader,
     set_default_clipboard_reader, reset_default_clipboard_reader,


### PR DESCRIPTION
## Summary

Adds two new docs pages covering CLI testing with Standout, and reframes the README and docs index around testability as the primary value proposition.

- **\`docs/guides/intro-to-testing.md\`** — tutorial-style walkthrough in the same voice as \`intro-to-standout.md\`. Opens with the honest problem (most CLIs end up grepping stdout from a spawned binary), explains what Standout's architecture already buys for free, names the remaining gap, then walks the \`TestHarness\` builder from a single \`.run()\` up through env vars, fixtures, piped stdin, clipboard, terminal state, and forced output modes. Includes a full worked example and a cheat sheet, and is explicit about what the harness still can't do (real PTY, signals, subprocess fan-out — flagged as Phase 3 in progress).
- **\`docs/topics/testing.md\`** — reference-style companion: three testing levels (unit / integration / e2e) with a table of what each covers, what each layer already guarantees, the seams \`standout-render\` and \`standout-input\` expose, recipes for \`insta\` snapshots and JSON-shape assertions, and clear boundaries.

## Wiring

- \`docs/SUMMARY.md\`, \`docs/guides/index.md\`, \`docs/index.md\` — link both pages from \"Getting Started,\" \"Framework Topics,\" and \"Where to Start.\"
- \`README.md\` — reopen with the testability claim up front, add a \`standout-test\` code sample between the handler-test snippet and the features list, and list Introduction to Testing first in the docs links (primary value prop).

## Verified

- \`mdbook build\` succeeds; both pages render cleanly.
- All intra-doc links resolve against existing files.

## Test plan

- [x] \`mdbook build\` green
- [x] Both new pages present in \`book/\` output
- [x] README reads coherently end-to-end
- [ ] Visual review in your browser