### PR TITLE
Land standout-input framework integration end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Book navigation now lists the input crate.** `docs/SUMMARY.md` gains an "Input (standout-input)" section linking to the introduction, sources, backends, and a new framework-integration topic. The pages were already present on disk but were not reachable from the rendered mdBook.
 
+- **Heavier input backends are opt-in via standout features.** `standout` depends on `standout-input` with `default-features = false` and only enables `simple-prompts` (free, no extra deps) by default. Users who want the editor backend or inquire's TUI prompts add `features = ["input-editor"]` or `features = ["input-inquire"]` to their `standout` dependency. This preserves the "minimal by default" promise of `standout-input` — a default `standout` install no longer pulls `tempfile`, `which`, or `shell-words` transitively.
+
 ## [7.5.0] - 2026-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`standout-input` is now wired into the `App` builder.** Commands can attach declarative input chains alongside templates, hooks, and piping with the new `CommandConfig::input(name, chain)` method. Chains run in pre-dispatch — before the handler — and the resolved values land in a name-keyed `Inputs` bag on `ctx.extensions`. Handlers retrieve them via the new `CommandContextInput` extension trait:
+
+  ```rust
+  use standout::cli::{App, CommandContextInput, Output};
+  use standout::input::{ArgSource, EditorSource, InputChain, StdinSource};
+
+  App::builder()
+      .command_with("create", create, |cfg| {
+          cfg.template("create.jinja")
+              .input("body", InputChain::<String>::new()
+                  .try_source(ArgSource::new("body"))
+                  .try_source(StdinSource::new())
+                  .try_source(EditorSource::new()))
+      })?
+      .build()?;
+
+  fn create(_m: &ArgMatches, ctx: &CommandContext) -> HandlerResult<Value> {
+      let body: &String = ctx.input("body")?;
+      /* ... */
+  }
+  ```
+
+  Multiple `.input(...)` calls accumulate; a command can declare any number of named inputs of any types (including multiple inputs of the same type, which the `TypeId`-keyed `ctx.extensions` cannot disambiguate on its own).
+
+  Standalone `chain.resolve(&matches)?` still works for cases where input shape depends on already-resolved values.
+
+- **New `Inputs` storage type in `standout-input`** (`standout::input::Inputs`) — a name-keyed, type-safe container for resolved inputs, plus the `MissingInput` error type for `(name, T)` lookup failures.
+
+- **`standout::input` re-export** of the `standout-input` crate, so users do not need a separate dependency to access `InputChain` and the source types.
+
+- **Book navigation now lists the input crate.** `docs/SUMMARY.md` gains an "Input (standout-input)" section linking to the introduction, sources, backends, and a new framework-integration topic. The pages were already present on disk but were not reachable from the rendered mdBook.
+
 ## [7.5.0] - 2026-04-17
 
 ### Added

--- a/crates/standout-input/docs/topics/framework-integration.md
+++ b/crates/standout-input/docs/topics/framework-integration.md
@@ -193,7 +193,7 @@ For lower-level tests that don't need the harness, you can manipulate the reader
 
 ---
 
-## Re-exports
+## Re-exports and Feature Flags
 
 `standout` re-exports `standout-input` as `standout::input`, so a single dependency on `standout` is enough:
 
@@ -206,7 +206,19 @@ standout = "7"
 use standout::input::{ArgSource, InputChain, StdinSource};
 ```
 
-If you want optional backends (`inquire`, etc.), depend on `standout-input` directly to enable the feature flags.
+A default `standout` dependency only enables `standout-input`'s `simple-prompts` backend, which has no extra deps. The heavier backends are opt-in via these `standout` features:
+
+| Feature | Enables | Adds deps |
+|---------|---------|-----------|
+| `input-editor` | `EditorSource` (opens `$VISUAL` / `$EDITOR`) | `tempfile`, `which`, `shell-words` |
+| `input-inquire` | The `Inquire*` rich TUI prompt sources | `inquire` (~29 transitive) |
+
+```toml
+[dependencies]
+standout = { version = "7", features = ["input-editor"] }
+```
+
+You can still depend on `standout-input` directly if you want to bypass the `standout` re-export and pick features there.
 
 ---
 

--- a/crates/standout-input/docs/topics/framework-integration.md
+++ b/crates/standout-input/docs/topics/framework-integration.md
@@ -1,0 +1,221 @@
+# Framework Integration
+
+This page describes how `standout-input` plugs into the [`standout`](https://crates.io/crates/standout) CLI framework so that input chains become a declarative part of your command configuration. If you only want to use `standout-input` standalone, see [Introduction to Input](../guides/intro-to-input.md) — the framework integration is purely additive.
+
+---
+
+## The Picture
+
+Without framework integration, a handler resolves chains imperatively:
+
+```rust
+fn create(matches: &ArgMatches, _ctx: &CommandContext) -> HandlerResult<Pad> {
+    let body = InputChain::<String>::new()
+        .try_source(ArgSource::new("body"))
+        .try_source(StdinSource::new())
+        .try_source(EditorSource::new())
+        .resolve(matches)?;          // <-- handler does this itself
+
+    /* business logic ... */
+}
+```
+
+That works, but the chain becomes invisible to anyone reading the command's registration: input rules are mixed in with logic, and you can't see at a glance "this command takes a body that may come from arg / stdin / editor".
+
+With the integration, the chain is part of `CommandConfig`, just like `template`, `hooks`, and `pipe_through`:
+
+```rust
+use standout::cli::{App, CommandContextInput, Output};
+use standout::input::{ArgSource, EditorSource, InputChain, StdinSource};
+
+App::builder()
+    .command_with("create", create, |cfg| {
+        cfg.template("create.jinja")
+            .input("body", InputChain::<String>::new()
+                .try_source(ArgSource::new("body"))
+                .try_source(StdinSource::new())
+                .try_source(EditorSource::new()))
+    })?
+    .build()?;
+
+fn create(_m: &ArgMatches, ctx: &CommandContext) -> HandlerResult<Value> {
+    let body: &String = ctx.input("body")?;     // <-- already resolved
+    /* business logic ... */
+}
+```
+
+The chain runs in the **pre-dispatch** phase — before the handler is called — so handlers always see fully-resolved input. Errors during resolution (validation failure, editor cancelled, …) abort the request before any business logic runs.
+
+---
+
+## Where Resolution Happens
+
+`standout`'s execution pipeline runs hooks in three phases:
+
+```
+parsed CLI args → PRE-DISPATCH → handler → POST-DISPATCH → render → POST-OUTPUT
+```
+
+`.input(name, chain)` is sugar over `.pre_dispatch(...)` — the same hook used for auth checks, request-scoped state, etc. Each `.input(...)` call adds one pre-dispatch hook that:
+
+1. Walks to the deepest subcommand's `ArgMatches` (so chains see the same args the handler does).
+2. Calls `chain.resolve_with_source(matches)`.
+3. Stashes the result in an [`Inputs`](https://docs.rs/standout-input/latest/standout_input/struct.Inputs.html) bag on `ctx.extensions` under `name`.
+
+If resolution returns an error, dispatch stops and the framework reports `Hook error: input \`body\`: <message>`. The handler does not run.
+
+---
+
+## Reading Inputs in the Handler
+
+Bring the [`CommandContextInput`](https://docs.rs/standout/latest/standout/cli/trait.CommandContextInput.html) extension trait into scope and call `.input::<T>(name)`:
+
+```rust
+use standout::cli::{CommandContextInput, Output};
+
+fn create(_m: &ArgMatches, ctx: &CommandContext) -> HandlerResult<Value> {
+    let body: &String = ctx.input("body")?;
+    let force: &bool = ctx.input("force")?;
+
+    /* ... */
+}
+```
+
+The lookup is by `(name, T)`. If the name was never registered, you get a [`MissingInput::NotRegistered`](https://docs.rs/standout-input/latest/standout_input/enum.MissingInput.html) error. If the registered type doesn't match `T`, you get `MissingInput::TypeMismatch`. The error type implements `std::error::Error` and converts cleanly with `?`.
+
+### Inspecting the source
+
+Sometimes you want to know *where* an input came from — for instance, to log "title was read from clipboard" or to alter behavior when input is piped vs. interactive:
+
+```rust
+match ctx.input_source("body") {
+    Some(InputSourceKind::Editor) => log::info!("body composed in editor"),
+    Some(InputSourceKind::Stdin) => log::info!("body piped from stdin"),
+    Some(other) => log::debug!("body came from {other}"),
+    None => unreachable!("body is registered, so it was resolved"),
+}
+```
+
+### Iterating all inputs
+
+For diagnostic output (like `--explain` flags) you can grab the whole bag:
+
+```rust
+if let Some(bag) = ctx.inputs() {
+    for (name, source) in bag.iter_sources() {
+        eprintln!("  {name}: {source}");
+    }
+}
+```
+
+---
+
+## Multiple Inputs
+
+`.input(...)` accumulates. A command can declare any number of named inputs of any types — including multiple inputs of the same type, which the `TypeId`-keyed `ctx.app_state` / raw `ctx.extensions` cannot disambiguate:
+
+```rust
+.command_with("create", create, |cfg| {
+    cfg.template("create.jinja")
+        .input("title", InputChain::<String>::new()
+            .try_source(ArgSource::new("title"))
+            .default("untitled".to_string()))
+        .input("body", InputChain::<String>::new()
+            .try_source(ArgSource::new("body"))
+            .try_source(StdinSource::new())
+            .try_source(EditorSource::new()))
+        .input("force", InputChain::<bool>::new()
+            .try_source(FlagSource::new("force"))
+            .default(false))
+})
+```
+
+Each chain runs in registration order during pre-dispatch. They share the same `Inputs` bag on `ctx.extensions`, so two `String` inputs (`title`, `body`) coexist without colliding.
+
+---
+
+## Validation
+
+Chain-level validation runs as part of `resolve_with_source`. If validation fails on a non-interactive source, the pre-dispatch hook returns an error and dispatch aborts:
+
+```rust
+.input("body", InputChain::<String>::new()
+    .try_source(ArgSource::new("body"))
+    .validate(|s| !s.trim().is_empty(), "body must not be empty"))
+```
+
+If the user runs `mycli create --body "   "`, the framework reports:
+
+```
+Hook error: input `body`: validation failed: body must not be empty
+```
+
+For interactive sources (prompts, editor), validation failure re-prompts instead of aborting — the chain decides the loop. See [Backends](backends.md) for the full validation/retry semantics.
+
+---
+
+## Testing
+
+The framework path composes naturally with `standout-test`:
+
+```rust
+use standout_test::TestHarness;
+
+#[test]
+fn create_uses_arg_when_provided() {
+    let app = build_app();
+    let cmd = my_clap_command();
+
+    let result = TestHarness::new()
+        .text_output()
+        .run(&app, cmd, ["mycli", "create", "--body", "hello"]);
+
+    result.assert_stdout_contains("hello");
+}
+
+#[test]
+fn create_falls_back_to_stdin() {
+    let app = build_app();
+    let cmd = my_clap_command();
+
+    let result = TestHarness::new()
+        .piped_stdin("from pipe\n")
+        .text_output()
+        .run(&app, cmd, ["mycli", "create"]);
+
+    result.assert_stdout_contains("from pipe");
+}
+```
+
+The harness installs `MockStdin` / `MockClipboard` via `standout-input`'s process-global default readers, so `StdinSource::new()` and `ClipboardSource::new()` inside the chain transparently see the mocks. No source code changes are needed to make the chain testable.
+
+For lower-level tests that don't need the harness, you can manipulate the readers directly with [`set_default_stdin_reader`](https://docs.rs/standout-input/latest/standout_input/fn.set_default_stdin_reader.html) and friends; serialize tests that touch them with `#[serial]` from `serial_test`.
+
+---
+
+## Re-exports
+
+`standout` re-exports `standout-input` as `standout::input`, so a single dependency on `standout` is enough:
+
+```toml
+[dependencies]
+standout = "7"
+```
+
+```rust
+use standout::input::{ArgSource, InputChain, StdinSource};
+```
+
+If you want optional backends (`inquire`, etc.), depend on `standout-input` directly to enable the feature flags.
+
+---
+
+## When NOT to Use the Builder Integration
+
+The standalone `chain.resolve(matches)?` form is still the right tool when:
+
+- Input shape depends on already-resolved values. If `--mode` decides which other inputs to ask for, you can't precompute a static chain.
+- You're adopting `standout` incrementally and your handler isn't yet on the framework path.
+- You're using `standout-input` outside the `standout` framework altogether.
+
+In every other case, `.input(...)` keeps the command's input contract visible at registration time, alongside its template and hooks.

--- a/crates/standout-input/docs/topics/framework-integration.md
+++ b/crates/standout-input/docs/topics/framework-integration.md
@@ -62,7 +62,7 @@ parsed CLI args → PRE-DISPATCH → handler → POST-DISPATCH → render → PO
 2. Calls `chain.resolve_with_source(matches)`.
 3. Stashes the result in an [`Inputs`](https://docs.rs/standout-input/latest/standout_input/struct.Inputs.html) bag on `ctx.extensions` under `name`.
 
-If resolution returns an error, dispatch stops and the framework reports `Hook error: input \`body\`: <message>`. The handler does not run.
+If resolution returns an error, dispatch stops and the framework reports `` Hook error: input `body`: <error message> ``. The handler does not run.
 
 ---
 

--- a/crates/standout-input/src/inputs.rs
+++ b/crates/standout-input/src/inputs.rs
@@ -25,6 +25,7 @@
 //! ```
 
 use std::any::{Any, TypeId};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -36,9 +37,13 @@ use crate::collector::{InputSourceKind, ResolvedInput};
 /// while its [`InputSourceKind`] metadata is tracked separately on the
 /// internal entry. Lookups are by `(name, T)` — wrong-type lookups return
 /// `None` rather than panicking.
+///
+/// Names are stored as `Cow<'static, str>` so both string literals and
+/// runtime-generated names (e.g. config-driven command setups) work without
+/// leaking memory.
 #[derive(Default)]
 pub struct Inputs {
-    entries: HashMap<&'static str, Entry>,
+    entries: HashMap<Cow<'static, str>, Entry>,
 }
 
 struct Entry {
@@ -58,17 +63,21 @@ impl Inputs {
 
     /// Insert a resolved input under `name`.
     ///
+    /// `name` accepts anything convertible into `Cow<'static, str>` —
+    /// string literals (`"body"`), owned `String`s, and explicit `Cow`s
+    /// all work.
+    ///
     /// Returns the previous entry's source kind if `name` was already present.
     pub fn insert<T>(
         &mut self,
-        name: &'static str,
+        name: impl Into<Cow<'static, str>>,
         resolved: ResolvedInput<T>,
     ) -> Option<InputSourceKind>
     where
         T: Send + Sync + 'static,
     {
         let prev = self.entries.insert(
-            name,
+            name.into(),
             Entry {
                 type_id: TypeId::of::<T>(),
                 type_name: std::any::type_name::<T>(),
@@ -137,10 +146,10 @@ impl Inputs {
     }
 
     /// Iterate over `(name, source)` pairs.
-    pub fn iter_sources(&self) -> impl Iterator<Item = (&'static str, InputSourceKind)> + '_ {
+    pub fn iter_sources(&self) -> impl Iterator<Item = (&str, InputSourceKind)> + '_ {
         self.entries
             .iter()
-            .map(|(name, entry)| (*name, entry.source))
+            .map(|(name, entry)| (name.as_ref(), entry.source))
     }
 }
 
@@ -149,7 +158,7 @@ impl fmt::Debug for Inputs {
         let mut s = f.debug_struct("Inputs");
         for (name, entry) in &self.entries {
             s.field(
-                name,
+                name.as_ref(),
                 &format_args!("{} from {}", entry.type_name, entry.source),
             );
         }
@@ -236,6 +245,17 @@ mod tests {
             }
             other => panic!("expected TypeMismatch, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn accepts_owned_string_name() {
+        let mut inputs = Inputs::new();
+        let runtime_name: String = format!("input_{}", 42);
+        inputs.insert(runtime_name.clone(), arg("x".to_string()));
+
+        // Look up using a borrowed &str slice of an unrelated owned string —
+        // proves storage by value, not by pointer identity.
+        assert_eq!(inputs.get::<String>(runtime_name.as_str()).unwrap(), "x");
     }
 
     #[test]

--- a/crates/standout-input/src/inputs.rs
+++ b/crates/standout-input/src/inputs.rs
@@ -1,0 +1,306 @@
+//! Storage for resolved inputs, keyed by name.
+//!
+//! [`Inputs`] is a name-keyed, type-safe container for values produced by
+//! [`InputChain`](crate::InputChain) resolution. It exists because
+//! `TypeId`-keyed containers (the common pattern for request-scoped state in
+//! frameworks) cannot disambiguate two inputs of the same type — for example,
+//! a command with both a `body: String` and a `title: String` input.
+//!
+//! Framework integrations resolve each registered chain and stash the result
+//! here under the user-chosen name. Handlers retrieve by `(name, type)`.
+//!
+//! # Example
+//!
+//! ```
+//! use standout_input::{InputSourceKind, Inputs, ResolvedInput};
+//!
+//! let mut inputs = Inputs::new();
+//! inputs.insert(
+//!     "body",
+//!     ResolvedInput { value: "hello".to_string(), source: InputSourceKind::Arg },
+//! );
+//!
+//! let body: &String = inputs.get("body").unwrap();
+//! assert_eq!(body, "hello");
+//! ```
+
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::fmt;
+
+use crate::collector::{InputSourceKind, ResolvedInput};
+
+/// Name-keyed storage for resolved inputs.
+///
+/// Each entry is a `ResolvedInput<T>` boxed as `dyn Any`. Lookups are by
+/// `(name, T)` — wrong-type lookups return `None` rather than panicking.
+#[derive(Default)]
+pub struct Inputs {
+    entries: HashMap<&'static str, Entry>,
+}
+
+struct Entry {
+    type_id: TypeId,
+    type_name: &'static str,
+    source: InputSourceKind,
+    value: Box<dyn Any + Send + Sync>,
+}
+
+impl Inputs {
+    /// Create an empty `Inputs` bag.
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Insert a resolved input under `name`.
+    ///
+    /// Returns the previous entry's source kind if `name` was already present.
+    pub fn insert<T>(
+        &mut self,
+        name: &'static str,
+        resolved: ResolvedInput<T>,
+    ) -> Option<InputSourceKind>
+    where
+        T: Send + Sync + 'static,
+    {
+        let prev = self.entries.insert(
+            name,
+            Entry {
+                type_id: TypeId::of::<T>(),
+                type_name: std::any::type_name::<T>(),
+                source: resolved.source,
+                value: Box::new(resolved.value),
+            },
+        );
+        prev.map(|e| e.source)
+    }
+
+    /// Get a reference to the value stored under `name`, if it exists and has
+    /// type `T`.
+    ///
+    /// Returns `None` if no entry exists or the stored type does not match.
+    pub fn get<T: 'static>(&self, name: &str) -> Option<&T> {
+        let entry = self.entries.get(name)?;
+        if entry.type_id != TypeId::of::<T>() {
+            return None;
+        }
+        entry.value.downcast_ref::<T>()
+    }
+
+    /// Get the value stored under `name`, returning a descriptive error if
+    /// missing or of the wrong type.
+    pub fn get_required<T: 'static>(&self, name: &str) -> Result<&T, MissingInput> {
+        let Some(entry) = self.entries.get(name) else {
+            return Err(MissingInput::NotRegistered {
+                name: name.to_string(),
+            });
+        };
+        if entry.type_id != TypeId::of::<T>() {
+            return Err(MissingInput::TypeMismatch {
+                name: name.to_string(),
+                expected: std::any::type_name::<T>(),
+                actual: entry.type_name,
+            });
+        }
+        entry
+            .value
+            .downcast_ref::<T>()
+            .ok_or_else(|| MissingInput::TypeMismatch {
+                name: name.to_string(),
+                expected: std::any::type_name::<T>(),
+                actual: entry.type_name,
+            })
+    }
+
+    /// Get the [`InputSourceKind`] that provided `name`, if it exists.
+    pub fn source_of(&self, name: &str) -> Option<InputSourceKind> {
+        self.entries.get(name).map(|e| e.source)
+    }
+
+    /// Returns true if `name` has been resolved.
+    pub fn contains(&self, name: &str) -> bool {
+        self.entries.contains_key(name)
+    }
+
+    /// Number of resolved inputs.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns true if no inputs have been resolved.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Iterate over `(name, source)` pairs.
+    pub fn iter_sources(&self) -> impl Iterator<Item = (&'static str, InputSourceKind)> + '_ {
+        self.entries
+            .iter()
+            .map(|(name, entry)| (*name, entry.source))
+    }
+}
+
+impl fmt::Debug for Inputs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("Inputs");
+        for (name, entry) in &self.entries {
+            s.field(
+                name,
+                &format_args!("{} from {}", entry.type_name, entry.source),
+            );
+        }
+        s.finish()
+    }
+}
+
+/// Error returned when a named input is missing or stored under a different type.
+#[derive(Debug, thiserror::Error)]
+pub enum MissingInput {
+    /// No input was registered for the given name.
+    #[error("no input named `{name}` was registered for this command")]
+    NotRegistered {
+        /// The requested input name.
+        name: String,
+    },
+    /// An input is registered but stored under a different type.
+    #[error("input `{name}` is registered as `{actual}`, not `{expected}`")]
+    TypeMismatch {
+        /// The requested input name.
+        name: String,
+        /// The type the caller asked for.
+        expected: &'static str,
+        /// The type actually stored.
+        actual: &'static str,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arg<T>(value: T) -> ResolvedInput<T> {
+        ResolvedInput {
+            value,
+            source: InputSourceKind::Arg,
+        }
+    }
+
+    #[test]
+    fn insert_and_get() {
+        let mut inputs = Inputs::new();
+        inputs.insert("body", arg("hello".to_string()));
+
+        let body: &String = inputs.get("body").unwrap();
+        assert_eq!(body, "hello");
+    }
+
+    #[test]
+    fn get_missing_returns_none() {
+        let inputs = Inputs::new();
+        assert!(inputs.get::<String>("missing").is_none());
+    }
+
+    #[test]
+    fn get_wrong_type_returns_none() {
+        let mut inputs = Inputs::new();
+        inputs.insert("body", arg("hello".to_string()));
+        assert!(inputs.get::<u32>("body").is_none());
+    }
+
+    #[test]
+    fn get_required_reports_missing() {
+        let inputs = Inputs::new();
+        let err = inputs.get_required::<String>("body").unwrap_err();
+        assert!(matches!(err, MissingInput::NotRegistered { .. }));
+        assert!(err.to_string().contains("body"));
+    }
+
+    #[test]
+    fn get_required_reports_type_mismatch() {
+        let mut inputs = Inputs::new();
+        inputs.insert("body", arg("hello".to_string()));
+        let err = inputs.get_required::<u32>("body").unwrap_err();
+        match err {
+            MissingInput::TypeMismatch {
+                ref name,
+                expected,
+                actual,
+            } => {
+                assert_eq!(name, "body");
+                assert!(expected.contains("u32"));
+                assert!(actual.contains("String"));
+            }
+            other => panic!("expected TypeMismatch, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn two_inputs_of_same_type_do_not_collide() {
+        let mut inputs = Inputs::new();
+        inputs.insert("body", arg("the body".to_string()));
+        inputs.insert("title", arg("the title".to_string()));
+
+        assert_eq!(inputs.get::<String>("body").unwrap(), "the body");
+        assert_eq!(inputs.get::<String>("title").unwrap(), "the title");
+    }
+
+    #[test]
+    fn insert_returns_previous_source() {
+        let mut inputs = Inputs::new();
+        assert!(inputs.insert("body", arg("first".to_string())).is_none());
+        let prev = inputs.insert(
+            "body",
+            ResolvedInput {
+                value: "second".to_string(),
+                source: InputSourceKind::Stdin,
+            },
+        );
+        assert_eq!(prev, Some(InputSourceKind::Arg));
+        assert_eq!(inputs.source_of("body"), Some(InputSourceKind::Stdin));
+    }
+
+    #[test]
+    fn source_of_and_contains() {
+        let mut inputs = Inputs::new();
+        assert!(!inputs.contains("body"));
+        inputs.insert("body", arg("x".to_string()));
+        assert!(inputs.contains("body"));
+        assert_eq!(inputs.source_of("body"), Some(InputSourceKind::Arg));
+        assert_eq!(inputs.source_of("missing"), None);
+    }
+
+    #[test]
+    fn iter_sources_yields_all_entries() {
+        let mut inputs = Inputs::new();
+        inputs.insert("body", arg("x".to_string()));
+        inputs.insert(
+            "yes",
+            ResolvedInput {
+                value: true,
+                source: InputSourceKind::Flag,
+            },
+        );
+
+        let mut pairs: Vec<_> = inputs.iter_sources().collect();
+        pairs.sort_by_key(|(name, _)| *name);
+        assert_eq!(
+            pairs,
+            vec![
+                ("body", InputSourceKind::Arg),
+                ("yes", InputSourceKind::Flag)
+            ]
+        );
+    }
+
+    #[test]
+    fn len_and_is_empty() {
+        let mut inputs = Inputs::new();
+        assert!(inputs.is_empty());
+        assert_eq!(inputs.len(), 0);
+        inputs.insert("body", arg("x".to_string()));
+        assert!(!inputs.is_empty());
+        assert_eq!(inputs.len(), 1);
+    }
+}

--- a/crates/standout-input/src/inputs.rs
+++ b/crates/standout-input/src/inputs.rs
@@ -32,8 +32,10 @@ use crate::collector::{InputSourceKind, ResolvedInput};
 
 /// Name-keyed storage for resolved inputs.
 ///
-/// Each entry is a `ResolvedInput<T>` boxed as `dyn Any`. Lookups are by
-/// `(name, T)` — wrong-type lookups return `None` rather than panicking.
+/// Each entry stores the resolved `T` value boxed as `dyn Any + Send + Sync`,
+/// while its [`InputSourceKind`] metadata is tracked separately on the
+/// internal entry. Lookups are by `(name, T)` — wrong-type lookups return
+/// `None` rather than panicking.
 #[derive(Default)]
 pub struct Inputs {
     entries: HashMap<&'static str, Entry>,

--- a/crates/standout-input/src/lib.rs
+++ b/crates/standout-input/src/lib.rs
@@ -52,12 +52,14 @@ mod chain;
 mod collector;
 pub mod env;
 mod error;
+mod inputs;
 pub mod sources;
 
 // Re-export core types
 pub use chain::InputChain;
 pub use collector::{InputCollector, InputSourceKind, ResolvedInput};
 pub use error::InputError;
+pub use inputs::{Inputs, MissingInput};
 
 // Re-export sources at crate root for convenience
 pub use sources::{

--- a/crates/standout/Cargo.toml
+++ b/crates/standout/Cargo.toml
@@ -16,6 +16,7 @@ standout-pipe = { path = "../standout-pipe", version = "7.5.0" }
 standout-bbparser = { version = "7.5.0", path = "../standout-bbparser" }
 standout-macros = { version = "7.5.0", path = "../standout-macros" }
 standout-dispatch = { version = "7.5.0", path = "../standout-dispatch" }
+standout-input = { version = "7.5.0", path = "../standout-input" }
 standout-seeker = { version = "7.5.0", path = "../standout-seeker" }
 
 # Direct dependencies (also used by standout-render, but needed here for cli module)

--- a/crates/standout/Cargo.toml
+++ b/crates/standout/Cargo.toml
@@ -16,7 +16,11 @@ standout-pipe = { path = "../standout-pipe", version = "7.5.0" }
 standout-bbparser = { version = "7.5.0", path = "../standout-bbparser" }
 standout-macros = { version = "7.5.0", path = "../standout-macros" }
 standout-dispatch = { version = "7.5.0", path = "../standout-dispatch" }
-standout-input = { version = "7.5.0", path = "../standout-input" }
+# Heavier input backends (editor — tempfile/which/shell-words; inquire — ~29 deps)
+# stay opt-in via the input-editor / input-inquire features below. simple-prompts
+# is free (no extra deps) and stays on so basic TextPromptSource works out of
+# the box.
+standout-input = { version = "7.5.0", path = "../standout-input", default-features = false, features = ["simple-prompts"] }
 standout-seeker = { version = "7.5.0", path = "../standout-seeker" }
 
 # Direct dependencies (also used by standout-render, but needed here for cli module)
@@ -37,6 +41,12 @@ csv = "1.3"
 [features]
 default = []
 macros = []
+
+# Opt-in input backends. These re-export feature flags from standout-input
+# so that depending on `standout` with `features = ["input-editor"]` is
+# equivalent to depending on `standout-input` with that feature directly.
+input-editor = ["standout-input/editor"]
+input-inquire = ["standout-input/inquire"]
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/standout/src/cli/group.rs
+++ b/crates/standout/src/cli/group.rs
@@ -507,10 +507,19 @@ impl<H> CommandConfig<H> {
     /// Multiple `.input(...)` calls on the same command accumulate; each
     /// registers a pre-dispatch hook that writes into the shared bag, so
     /// commands can declare several named inputs of any types.
-    pub fn input<T>(self, name: &'static str, chain: standout_input::InputChain<T>) -> Self
+    ///
+    /// `name` accepts anything convertible into `Cow<'static, str>` — string
+    /// literals, owned `String`s built at runtime (e.g. from config), and
+    /// explicit `Cow`s all work.
+    pub fn input<T>(
+        self,
+        name: impl Into<std::borrow::Cow<'static, str>>,
+        chain: standout_input::InputChain<T>,
+    ) -> Self
     where
         T: Clone + Send + Sync + 'static,
     {
+        let name = name.into();
         self.pre_dispatch(move |matches, ctx| {
             // Pre-dispatch hooks receive the top-level ArgMatches, but the
             // chain's sources reference args defined on the deepest subcommand
@@ -526,7 +535,7 @@ impl<H> CommandConfig<H> {
                 .extensions
                 .get_mut::<standout_input::Inputs>()
                 .expect("Inputs just inserted");
-            bag.insert(name, resolved);
+            bag.insert(name.clone(), resolved);
             Ok(())
         })
     }

--- a/crates/standout/src/cli/group.rs
+++ b/crates/standout/src/cli/group.rs
@@ -512,7 +512,11 @@ impl<H> CommandConfig<H> {
         T: Clone + Send + Sync + 'static,
     {
         self.pre_dispatch(move |matches, ctx| {
-            let resolved = chain.resolve_with_source(matches).map_err(|e| {
+            // Pre-dispatch hooks receive the top-level ArgMatches, but the
+            // chain's sources reference args defined on the deepest subcommand
+            // (the same matches the handler sees). Resolve against those.
+            let sub_matches = crate::cli::dispatch::get_deepest_matches(matches);
+            let resolved = chain.resolve_with_source(sub_matches).map_err(|e| {
                 crate::cli::hooks::HookError::pre_dispatch(format!("input `{}`: {}", name, e))
             })?;
             if !ctx.extensions.contains::<standout_input::Inputs>() {

--- a/crates/standout/src/cli/group.rs
+++ b/crates/standout/src/cli/group.rs
@@ -479,6 +479,54 @@ impl<H> CommandConfig<H> {
         self
     }
 
+    /// Registers a declarative input chain for this command.
+    ///
+    /// The chain is resolved during pre-dispatch — before the handler runs —
+    /// and the resolved value is stored in an [`Inputs`](standout_input::Inputs)
+    /// bag on `ctx.extensions` under `name`. The handler retrieves it with
+    /// [`CommandContextInput::input`](crate::cli::CommandContextInput::input):
+    ///
+    /// ```ignore
+    /// use standout::cli::{App, CommandContextInput, Output};
+    /// use standout::input::{ArgSource, EditorSource, InputChain, StdinSource};
+    ///
+    /// App::builder()
+    ///     .command_with("create", |_m, ctx| {
+    ///         let body: &String = ctx.input("body")?;
+    ///         Ok(Output::Render(serde_json::json!({ "body": body })))
+    ///     }, |cfg| {
+    ///         cfg.template("create.jinja")
+    ///            .input("body", InputChain::<String>::new()
+    ///                .try_source(ArgSource::new("body"))
+    ///                .try_source(StdinSource::new())
+    ///                .try_source(EditorSource::new()))
+    ///     })?
+    ///     .build()?;
+    /// ```
+    ///
+    /// Multiple `.input(...)` calls on the same command accumulate; each
+    /// registers a pre-dispatch hook that writes into the shared bag, so
+    /// commands can declare several named inputs of any types.
+    pub fn input<T>(self, name: &'static str, chain: standout_input::InputChain<T>) -> Self
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        self.pre_dispatch(move |matches, ctx| {
+            let resolved = chain.resolve_with_source(matches).map_err(|e| {
+                crate::cli::hooks::HookError::pre_dispatch(format!("input `{}`: {}", name, e))
+            })?;
+            if !ctx.extensions.contains::<standout_input::Inputs>() {
+                ctx.extensions.insert(standout_input::Inputs::new());
+            }
+            let bag = ctx
+                .extensions
+                .get_mut::<standout_input::Inputs>()
+                .expect("Inputs just inserted");
+            bag.insert(name, resolved);
+            Ok(())
+        })
+    }
+
     /// Pipes the output to a shell command in passthrough mode.
     ///
     /// The output is sent to the command's stdin, but the original output

--- a/crates/standout/src/cli/handler.rs
+++ b/crates/standout/src/cli/handler.rs
@@ -58,4 +58,59 @@ pub use standout_dispatch::{
     CommandContext, Extensions, FnHandler, Handler, HandlerResult, Output, RunResult,
 };
 
+use standout_input::{InputSourceKind, Inputs, MissingInput};
+
+/// Extension trait for [`CommandContext`] that exposes inputs registered with
+/// [`CommandConfig::input`](crate::cli::CommandConfig::input).
+///
+/// Handlers retrieve named, typed inputs that were resolved by the framework
+/// before the handler ran. This is the read side of the declarative input
+/// API; see [`CommandConfig::input`](crate::cli::CommandConfig::input) for the
+/// registration side.
+///
+/// ```rust,ignore
+/// use standout::cli::{CommandContextInput, Output};
+///
+/// fn handler(_m: &clap::ArgMatches, ctx: &standout::cli::CommandContext) -> standout::cli::HandlerResult<serde_json::Value> {
+///     let body: &String = ctx.input("body")?;
+///     Ok(Output::Render(serde_json::json!({ "body": body })))
+/// }
+/// ```
+pub trait CommandContextInput {
+    /// Returns the resolved value for `name`, or an error if no input with
+    /// that name and type was registered.
+    fn input<T: 'static>(&self, name: &str) -> Result<&T, MissingInput>;
+
+    /// Returns the source that provided `name`, if it was resolved.
+    ///
+    /// Useful for diagnostic output ("body came from stdin") or for branching
+    /// behavior on the source kind.
+    fn input_source(&self, name: &str) -> Option<InputSourceKind>;
+
+    /// Returns the [`Inputs`] bag for this command, if any input chain ran.
+    ///
+    /// Most handlers should prefer [`input`](Self::input); this is for cases
+    /// where the handler needs to iterate over all resolved inputs.
+    fn inputs(&self) -> Option<&Inputs>;
+}
+
+impl CommandContextInput for CommandContext {
+    fn input<T: 'static>(&self, name: &str) -> Result<&T, MissingInput> {
+        match self.extensions.get::<Inputs>() {
+            Some(bag) => bag.get_required::<T>(name),
+            None => Err(MissingInput::NotRegistered {
+                name: name.to_string(),
+            }),
+        }
+    }
+
+    fn input_source(&self, name: &str) -> Option<InputSourceKind> {
+        self.extensions.get::<Inputs>()?.source_of(name)
+    }
+
+    fn inputs(&self) -> Option<&Inputs> {
+        self.extensions.get::<Inputs>()
+    }
+}
+
 // Tests for these types are in the standout-dispatch crate.

--- a/crates/standout/src/cli/mod.rs
+++ b/crates/standout/src/cli/mod.rs
@@ -147,7 +147,9 @@ pub use help::{
 };
 
 // Re-export handler types
-pub use handler::{CommandContext, FnHandler, Handler, HandlerResult, Output, RunResult};
+pub use handler::{
+    CommandContext, CommandContextInput, FnHandler, Handler, HandlerResult, Output, RunResult,
+};
 
 // Re-export hook types
 pub use hooks::{HookError, HookPhase, Hooks, RenderedOutput};

--- a/crates/standout/src/lib.rs
+++ b/crates/standout/src/lib.rs
@@ -310,6 +310,9 @@ pub use standout_macros::{Tabular, TabularRow};
 // Seeker query engine (re-export from standout-seeker)
 pub use standout_seeker as seeker;
 
+// Declarative input collection (re-export from standout-input)
+pub use standout_input as input;
+
 // Seeker derive macro (requires `features = ["macros"]`)
 pub use standout_macros::Seekable;
 

--- a/crates/standout/tests/input_integration.rs
+++ b/crates/standout/tests/input_integration.rs
@@ -1,0 +1,428 @@
+//! Integration tests for the declarative input API on `CommandConfig::input`.
+//!
+//! These tests exercise the full path from `App::builder().command_with(...)
+//! .input(name, chain)` through pre-dispatch resolution into the handler's
+//! `ctx.input::<T>(name)` lookup.
+
+use clap::{Arg, Command};
+use serde_json::json;
+use serial_test::serial;
+use standout::cli::{App, CommandContextInput, Output, RunResult};
+use standout::input::{
+    env::MockStdin, reset_default_stdin_reader, set_default_stdin_reader, ArgSource, FlagSource,
+    InputChain, InputSourceKind, StdinSource,
+};
+use std::sync::Arc;
+
+fn body_command() -> Command {
+    Command::new("test")
+        .subcommand(Command::new("create").arg(Arg::new("body").long("body").short('b')))
+}
+
+#[test]
+fn arg_value_reaches_handler_via_ctx_input() {
+    let app = App::builder()
+        .command_with(
+            "create",
+            |_m, ctx| {
+                let body: &String = ctx.input("body").expect("body should be resolved");
+                Ok(Output::Render(json!({ "echo": body })))
+            },
+            |cfg| {
+                cfg.template("{{ echo }}").input(
+                    "body",
+                    InputChain::<String>::new()
+                        .try_source(ArgSource::new("body"))
+                        .default("FALLBACK".to_string()),
+                )
+            },
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = app.run_to_string(body_command(), vec!["test", "create", "--body", "hello"]);
+    match result {
+        RunResult::Handled(out) => assert_eq!(out, "hello"),
+        other => panic!("expected Handled, got {:?}", other),
+    }
+}
+
+#[test]
+fn default_kicks_in_when_no_source_provides_value() {
+    let app = App::builder()
+        .command_with(
+            "create",
+            |_m, ctx| {
+                let body: &String = ctx.input("body").unwrap();
+                Ok(Output::Render(json!({ "echo": body })))
+            },
+            |cfg| {
+                cfg.template("{{ echo }}").input(
+                    "body",
+                    InputChain::<String>::new()
+                        .try_source(ArgSource::new("body"))
+                        .default("FALLBACK".to_string()),
+                )
+            },
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = app.run_to_string(body_command(), vec!["test", "create"]);
+    match result {
+        RunResult::Handled(out) => assert_eq!(out, "FALLBACK"),
+        other => panic!("expected Handled, got {:?}", other),
+    }
+}
+
+#[test]
+fn input_source_reports_arg_kind() {
+    let app = App::builder()
+        .command_with(
+            "create",
+            |_m, ctx| {
+                let kind = ctx.input_source("body").unwrap();
+                Ok(Output::Render(json!({ "kind": kind.to_string() })))
+            },
+            |cfg| {
+                cfg.template("{{ kind }}").input(
+                    "body",
+                    InputChain::<String>::new()
+                        .try_source(ArgSource::new("body"))
+                        .default("FALLBACK".to_string()),
+                )
+            },
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = app.run_to_string(body_command(), vec!["test", "create", "--body", "x"]);
+    if let RunResult::Handled(out) = result {
+        assert_eq!(out, InputSourceKind::Arg.to_string());
+    } else {
+        panic!("expected Handled, got {:?}", result);
+    }
+}
+
+#[test]
+fn input_source_reports_default_kind_when_falling_back() {
+    let app = App::builder()
+        .command_with(
+            "create",
+            |_m, ctx| {
+                let kind = ctx.input_source("body").unwrap();
+                Ok(Output::Render(json!({ "kind": kind.to_string() })))
+            },
+            |cfg| {
+                cfg.template("{{ kind }}").input(
+                    "body",
+                    InputChain::<String>::new()
+                        .try_source(ArgSource::new("body"))
+                        .default("FALLBACK".to_string()),
+                )
+            },
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = app.run_to_string(body_command(), vec!["test", "create"]);
+    if let RunResult::Handled(out) = result {
+        assert_eq!(out, InputSourceKind::Default.to_string());
+    } else {
+        panic!("expected Handled, got {:?}", result);
+    }
+}
+
+#[test]
+#[serial(stdin)]
+fn stdin_fallback_when_arg_absent() {
+    set_default_stdin_reader(Arc::new(MockStdin::piped("from stdin\n")));
+
+    let app = App::builder()
+        .command_with(
+            "create",
+            |_m, ctx| {
+                let body: &String = ctx.input("body").unwrap();
+                let kind = ctx.input_source("body").unwrap();
+                Ok(Output::Render(json!({
+                    "echo": body,
+                    "kind": kind.to_string(),
+                })))
+            },
+            |cfg| {
+                cfg.template("{{ kind }}: {{ echo }}").input(
+                    "body",
+                    InputChain::<String>::new()
+                        .try_source(ArgSource::new("body"))
+                        .try_source(StdinSource::new())
+                        .default("FALLBACK".to_string()),
+                )
+            },
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = app.run_to_string(body_command(), vec!["test", "create"]);
+    reset_default_stdin_reader();
+
+    if let RunResult::Handled(out) = result {
+        // StdinSource trims trailing newlines.
+        assert_eq!(out, "stdin: from stdin");
+    } else {
+        panic!("expected Handled, got {:?}", result);
+    }
+}
+
+#[test]
+#[serial(stdin)]
+fn arg_wins_over_stdin_when_both_available() {
+    // No stdin reader override is needed; with arg present, stdin source must
+    // not be reached. The MockStdin terminal mode avoids accidentally reading
+    // real stdin if precedence is wrong.
+    set_default_stdin_reader(Arc::new(MockStdin::terminal()));
+
+    let app = App::builder()
+        .command_with(
+            "create",
+            |_m, ctx| {
+                let body: &String = ctx.input("body").unwrap();
+                let kind = ctx.input_source("body").unwrap();
+                Ok(Output::Render(json!({
+                    "echo": body,
+                    "kind": kind.to_string(),
+                })))
+            },
+            |cfg| {
+                cfg.template("{{ kind }}: {{ echo }}").input(
+                    "body",
+                    InputChain::<String>::new()
+                        .try_source(ArgSource::new("body"))
+                        .try_source(StdinSource::new())
+                        .default("FALLBACK".to_string()),
+                )
+            },
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = app.run_to_string(body_command(), vec!["test", "create", "--body", "from arg"]);
+    reset_default_stdin_reader();
+
+    if let RunResult::Handled(out) = result {
+        assert_eq!(out, "argument: from arg");
+    } else {
+        panic!("expected Handled, got {:?}", result);
+    }
+}
+
+#[test]
+fn multiple_named_inputs_of_same_type_do_not_collide() {
+    let cmd = Command::new("test").subcommand(
+        Command::new("create")
+            .arg(Arg::new("body").long("body"))
+            .arg(Arg::new("title").long("title")),
+    );
+
+    let app = App::builder()
+        .command_with(
+            "create",
+            |_m, ctx| {
+                let body: &String = ctx.input("body").unwrap();
+                let title: &String = ctx.input("title").unwrap();
+                Ok(Output::Render(json!({
+                    "body": body,
+                    "title": title,
+                })))
+            },
+            |cfg| {
+                cfg.template("{{ title }} | {{ body }}")
+                    .input(
+                        "body",
+                        InputChain::<String>::new()
+                            .try_source(ArgSource::new("body"))
+                            .default("nobody".to_string()),
+                    )
+                    .input(
+                        "title",
+                        InputChain::<String>::new()
+                            .try_source(ArgSource::new("title"))
+                            .default("untitled".to_string()),
+                    )
+            },
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = app.run_to_string(
+        cmd,
+        vec![
+            "test",
+            "create",
+            "--body",
+            "the body",
+            "--title",
+            "the title",
+        ],
+    );
+    if let RunResult::Handled(out) = result {
+        assert_eq!(out, "the title | the body");
+    } else {
+        panic!("expected Handled, got {:?}", result);
+    }
+}
+
+#[test]
+fn mixed_types_string_and_bool_coexist() {
+    let cmd = Command::new("test").subcommand(
+        Command::new("create")
+            .arg(Arg::new("body").long("body"))
+            .arg(
+                Arg::new("force")
+                    .long("force")
+                    .action(clap::ArgAction::SetTrue),
+            ),
+    );
+
+    let app = App::builder()
+        .command_with(
+            "create",
+            |_m, ctx| {
+                let body: &String = ctx.input("body").unwrap();
+                let force: &bool = ctx.input("force").unwrap();
+                Ok(Output::Render(json!({
+                    "body": body,
+                    "force": force,
+                })))
+            },
+            |cfg| {
+                cfg.template("body={{ body }} force={{ force }}")
+                    .input(
+                        "body",
+                        InputChain::<String>::new()
+                            .try_source(ArgSource::new("body"))
+                            .default("default".to_string()),
+                    )
+                    .input(
+                        "force",
+                        InputChain::<bool>::new()
+                            .try_source(FlagSource::new("force"))
+                            .default(false),
+                    )
+            },
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = app.run_to_string(cmd, vec!["test", "create", "--body", "x", "--force"]);
+    if let RunResult::Handled(out) = result {
+        assert_eq!(out, "body=x force=true");
+    } else {
+        panic!("expected Handled, got {:?}", result);
+    }
+}
+
+#[test]
+fn validation_failure_aborts_before_handler() {
+    let app = App::builder()
+        .command_with(
+            "create",
+            |_m, _ctx| -> standout::cli::HandlerResult<serde_json::Value> {
+                panic!("handler must not run when pre-dispatch validation fails");
+            },
+            |cfg| {
+                cfg.template("{{ echo }}").input(
+                    "body",
+                    InputChain::<String>::new()
+                        .try_source(ArgSource::new("body"))
+                        .validate(|s| !s.trim().is_empty(), "body must not be empty"),
+                )
+            },
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = app.run_to_string(body_command(), vec!["test", "create", "--body", "   "]);
+    let out = match result {
+        RunResult::Handled(s) => s,
+        other => panic!("expected Handled, got {:?}", other),
+    };
+    assert!(out.starts_with("Hook error:"), "unexpected output: {out}");
+    assert!(out.contains("body"), "error should name the input: {out}");
+    assert!(
+        out.contains("must not be empty"),
+        "error should surface validator message: {out}"
+    );
+}
+
+#[test]
+fn handler_asking_for_unregistered_input_gets_missing_input_error() {
+    let app = App::builder()
+        .command_with(
+            "create",
+            |_m, ctx| {
+                // Ask for a name we never registered.
+                let err = ctx.input::<String>("nonexistent").unwrap_err();
+                Ok(Output::Render(json!({ "error": err.to_string() })))
+            },
+            |cfg| {
+                cfg.template("{{ error }}").input(
+                    "body",
+                    InputChain::<String>::new()
+                        .try_source(ArgSource::new("body"))
+                        .default("x".to_string()),
+                )
+            },
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = app.run_to_string(body_command(), vec!["test", "create"]);
+    if let RunResult::Handled(out) = result {
+        assert!(out.contains("nonexistent"), "got: {out}");
+        assert!(out.contains("no input"), "got: {out}");
+    } else {
+        panic!("expected Handled, got {:?}", result);
+    }
+}
+
+#[test]
+fn type_mismatch_lookup_returns_descriptive_error() {
+    let app = App::builder()
+        .command_with(
+            "create",
+            |_m, ctx| {
+                // Stored as String, asked as u32.
+                let err = ctx.input::<u32>("body").unwrap_err();
+                Ok(Output::Render(json!({ "error": err.to_string() })))
+            },
+            |cfg| {
+                cfg.template("{{ error }}").input(
+                    "body",
+                    InputChain::<String>::new()
+                        .try_source(ArgSource::new("body"))
+                        .default("x".to_string()),
+                )
+            },
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = app.run_to_string(body_command(), vec!["test", "create"]);
+    if let RunResult::Handled(out) = result {
+        assert!(out.contains("body"), "got: {out}");
+        assert!(out.contains("u32"), "got: {out}");
+    } else {
+        panic!("expected Handled, got {:?}", result);
+    }
+}

--- a/crates/standout/tests/input_integration.rs
+++ b/crates/standout/tests/input_integration.rs
@@ -19,6 +19,29 @@ fn body_command() -> Command {
         .subcommand(Command::new("create").arg(Arg::new("body").long("body").short('b')))
 }
 
+/// RAII guard that installs a stdin reader on construction and resets it
+/// on drop — including on panic, so a failing assertion or panic inside
+/// the dispatcher cannot leak the override into the next test.
+struct StdinGuard;
+
+impl StdinGuard {
+    fn piped(content: &str) -> Self {
+        set_default_stdin_reader(Arc::new(MockStdin::piped(content)));
+        Self
+    }
+
+    fn terminal() -> Self {
+        set_default_stdin_reader(Arc::new(MockStdin::terminal()));
+        Self
+    }
+}
+
+impl Drop for StdinGuard {
+    fn drop(&mut self) {
+        reset_default_stdin_reader();
+    }
+}
+
 #[test]
 fn arg_value_reaches_handler_via_ctx_input() {
     let app = App::builder()
@@ -140,7 +163,7 @@ fn input_source_reports_default_kind_when_falling_back() {
 #[test]
 #[serial(stdin)]
 fn stdin_fallback_when_arg_absent() {
-    set_default_stdin_reader(Arc::new(MockStdin::piped("from stdin\n")));
+    let _stdin = StdinGuard::piped("from stdin\n");
 
     let app = App::builder()
         .command_with(
@@ -168,7 +191,6 @@ fn stdin_fallback_when_arg_absent() {
         .unwrap();
 
     let result = app.run_to_string(body_command(), vec!["test", "create"]);
-    reset_default_stdin_reader();
 
     if let RunResult::Handled(out) = result {
         // StdinSource trims trailing newlines.
@@ -181,10 +203,10 @@ fn stdin_fallback_when_arg_absent() {
 #[test]
 #[serial(stdin)]
 fn arg_wins_over_stdin_when_both_available() {
-    // No stdin reader override is needed; with arg present, stdin source must
-    // not be reached. The MockStdin terminal mode avoids accidentally reading
-    // real stdin if precedence is wrong.
-    set_default_stdin_reader(Arc::new(MockStdin::terminal()));
+    // With arg present, stdin source must not be reached. The MockStdin
+    // terminal mode avoids accidentally reading real stdin if precedence is
+    // wrong.
+    let _stdin = StdinGuard::terminal();
 
     let app = App::builder()
         .command_with(
@@ -212,7 +234,6 @@ fn arg_wins_over_stdin_when_both_available() {
         .unwrap();
 
     let result = app.run_to_string(body_command(), vec!["test", "create", "--body", "from arg"]);
-    reset_default_stdin_reader();
 
     if let RunResult::Handled(out) = result {
         assert_eq!(out, "argument: from arg");

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -32,6 +32,15 @@
 
 ---
 
+# Input (standout-input)
+
+- [Introduction to Input](./crates/input/guides/intro-to-input.md)
+- [Input Sources](./crates/input/topics/input-sources.md)
+- [Backends](./crates/input/topics/backends.md)
+- [Framework Integration](./crates/input/topics/framework-integration.md)
+
+---
+
 # Framework Topics
 
 - [Output Modes](./topics/output-modes.md)

--- a/docs/guides/intro-to-standout.md
+++ b/docs/guides/intro-to-standout.md
@@ -681,28 +681,41 @@ See [Output Piping](../crates/standout-pipe/docs/topics/piping.md) for the full 
 
 ## Bonus: Declarative Input Collection
 
-Need to accept input from CLI arguments, piped stdin, environment variables, or interactive prompts? `standout-input` provides declarative input chains:
+Need to accept input from CLI arguments, piped stdin, environment variables, or interactive prompts? `standout-input` provides declarative input chains, and the `App` builder integrates them as a first-class part of command configuration:
 
 ```rust
-use standout_input::{InputChain, ArgSource, StdinSource, EnvSource, EditorSource};
+use standout::cli::{App, CommandContextInput, Output};
+use standout::input::{ArgSource, EditorSource, EnvSource, InputChain, StdinSource};
 
-// Try each source in order until one provides input
-let body = InputChain::<String>::new()
-    .try_source(ArgSource::new("body"))           // 1. --body argument
-    .try_source(StdinSource::new())                // 2. Piped stdin
-    .try_source(EnvSource::new("PR_BODY"))         // 3. Environment variable
-    .try_source(EditorSource::new().extension(".md"))  // 4. Open editor
-    .validate(|s| !s.is_empty(), "Body cannot be empty")
-    .resolve(&matches)?;
+App::builder()
+    .command_with("create", create, |cfg| {
+        cfg.template("create.jinja")
+            .input("body", InputChain::<String>::new()
+                .try_source(ArgSource::new("body"))           // 1. --body argument
+                .try_source(StdinSource::new())                // 2. Piped stdin
+                .try_source(EnvSource::new("PR_BODY"))         // 3. Environment variable
+                .try_source(EditorSource::new().extension(".md"))  // 4. Open editor
+                .validate(|s| !s.is_empty(), "Body cannot be empty"))
+    })?
+    .build()?;
+
+fn create(_m: &ArgMatches, ctx: &CommandContext) -> HandlerResult<Value> {
+    // The chain has already been resolved before the handler runs.
+    let body: &String = ctx.input("body")?;
+    /* business logic ... */
+}
 ```
 
 Features:
 - **Declarative priority**: Source order is explicit in the chain
-- **Testable**: All sources accept mocks for CI-safe testing
+- **Framework-integrated**: `.input(name, chain)` registers the chain alongside `template`, `hooks`, and `pipe_*`; resolution happens in pre-dispatch
+- **Testable**: All sources accept mocks for CI-safe testing (the `TestHarness` from `standout-test` wires them automatically)
 - **Validated**: Chain-level validation with retry support for interactive sources
 - **Feature-gated**: Control dependencies (editor, prompts, inquire TUI)
 
-See [Introduction to Input](../crates/input/guides/intro-to-input.md) for the full guide.
+The chain still works standalone via `chain.resolve(&matches)?` for cases where input shape depends on already-resolved values.
+
+See [Introduction to Input](../crates/input/guides/intro-to-input.md) and [Framework Integration](../crates/input/topics/framework-integration.md) for the full guide.
 
 Aside from exposing the library primitives, Standout leverages best-in-breed crates like MiniJinja and console::Style under the hood. The lock-in is really negligible: you can use Standout's BB parser or swap it, manually dispatch handlers, and use the renderers directly in your clap dispatch.
 


### PR DESCRIPTION
## Summary

Phase 3 of the `standout-input` work: wire it into the `App` builder so input chains become a first-class part of command config (alongside `template`, `hooks`, and `pipe_*`), and close the documentation gaps that were keeping the crate's pages out of the rendered book.

Before this PR, `standout-input` shipped at v7.5.0 with all sources and chains, but only `standout-test` consumed it. Handlers using the framework had to call `chain.resolve(&matches)?` imperatively, and the crate's docs lived on disk but were not listed in `docs/SUMMARY.md`.

## What's new

```rust
use standout::cli::{App, CommandContextInput, Output};
use standout::input::{ArgSource, EditorSource, InputChain, StdinSource};

App::builder()
    .command_with("create", create, |cfg| {
        cfg.template("create.jinja")
            .input("body", InputChain::<String>::new()
                .try_source(ArgSource::new("body"))
                .try_source(StdinSource::new())
                .try_source(EditorSource::new()))
    })?
    .build()?;

fn create(_m: &ArgMatches, ctx: &CommandContext) -> HandlerResult<Value> {
    let body: &String = ctx.input("body")?;   // resolved before handler ran
    /* ... */
}
```

Mechanism: `.input(name, chain)` is sugar over `.pre_dispatch(...)`. Resolution happens once per dispatch and the value lands in a name-keyed `Inputs` bag on `ctx.extensions`. The bag is needed because `ctx.extensions` is `TypeId`-keyed and cannot disambiguate two `String` inputs (e.g. `body` + `title`).

## Commits (granular for review)

1. `feat(standout-input): add Inputs storage type for named, typed values` — pure data type, 10 unit tests
2. `feat(standout): wire standout-input into the App builder` — `.input()` method, `CommandContextInput` trait, `standout::input` re-export
3. `test(standout): integration tests for builder .input() API` — 11 end-to-end tests + small fix to resolve against deepest `ArgMatches`
4. `docs(standout-input): add framework-integration topic` — new ~220-line page walking through the full pattern
5. `docs: list standout-input section in mdBook SUMMARY` — fixes the long-standing nav gap
6. `docs(standout): show framework-integrated input pattern in intro` — updates the bonus section in `intro-to-standout.md`
7. `chore(changelog): note standout-input framework integration` — entry under `[Unreleased]`

## Test plan

- [x] `cargo test -p standout-input` — 91 unit + 18 integration + 2 doc tests pass
- [x] `cargo test -p standout` — full suite including the new 11 integration tests pass
- [x] `cargo clippy --lib -- -D warnings` clean for both crates
- [x] `cargo fmt --check` clean
- [x] `mdbook build` — book builds without warnings; new "Input (standout-input)" section reachable from nav

## Out of scope

- The `#[handler]` macro `#[input(fallback = "editor")]` attribute. Listed as Future in the original design doc; not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)