### PR TITLE
Add .prompt() shortcut + interactive-flows guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Heavier input backends are opt-in via standout features.** `standout` depends on `standout-input` with `default-features = false` and only enables `simple-prompts` (free, no extra deps) by default. Users who want the editor backend or inquire's TUI prompts add `features = ["input-editor"]` or `features = ["input-inquire"]` to their `standout` dependency. This preserves the "minimal by default" promise of `standout-input` — a default `standout` install no longer pulls `tempfile`, `which`, or `shell-words` transitively.
 
+- **`.prompt()` shortcut on every interactive input source.** `InquireText`, `InquireConfirm`, `InquireSelect<T>`, `InquireMultiSelect<T>`, `InquirePassword`, `InquireEditor`, `TextPromptSource`, `ConfirmPromptSource`, and `EditorSource` now expose an inherent `prompt() -> Result<T, InputError>` method that bypasses the chain machinery and the `&clap::ArgMatches` parameter the `InputCollector` trait requires. Intended for wizard / setup helper / REPL flows that drive standout themselves and have no clap parser involved:
+
+  ```rust
+  use standout::input::{InquireSelect, InquireText};
+
+  let pack = InquireText::new("Pack name:").help("a-z0-9-").prompt()?;
+  let env  = InquireSelect::new("Environment:", vec!["dev", "staging", "prod"]).prompt()?;
+  ```
+
+  `Ok(None)` from the underlying `collect` (typically empty submission) maps to `InputError::NoInput`; cancellation maps to `InputError::PromptCancelled`. The `InputCollector` impls and chain behavior are unchanged.
+
+- **New "Interactive Flows" topic** (`docs/crates/input/topics/interactive-flows.md`) walks through composing the new `.prompt()` API with a user-owned step graph and standout's `Renderer` / `Theme` to build wizards. The introduction guide gains a "Standalone Prompts" section that links into the new topic.
+
 ## [7.5.0] - 2026-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **New "Interactive Flows" topic** (`docs/crates/input/topics/interactive-flows.md`) walks through composing the new `.prompt()` API with a user-owned step graph and standout's `Renderer` / `Theme` to build wizards. The introduction guide gains a "Standalone Prompts" section that links into the new topic.
 
+- **Wizard handlers are testable in process via `PromptResponder`.** Every interactive source's `.prompt()` shortcut now consults a process-global responder before doing any TTY work. Tests install a `ScriptedResponder` with a typed queue of answers; production wizard code is unchanged:
+
+  ```rust
+  use standout_input::{PromptResponse, ScriptedResponder};
+  use std::sync::Arc;
+
+  let result = TestHarness::new()
+      .prompts(Arc::new(ScriptedResponder::new([
+          PromptResponse::text("buy milk"),  // first text prompt
+          PromptResponse::Bool(true),        // first confirm
+          PromptResponse::Choice(2),         // first select -> options[2]
+      ])))
+      .run(&app, cmd, ["mycli", "setup"]);
+  ```
+
+  Open prompts (`Text`/`Password`/`Editor`) take a `Text(String)`; finite-choice prompts (`Confirm`/`Select`/`MultiSelect`) take a `Bool` / `Choice(usize)` / `Choices(Vec<usize>)`. Position-based responses are deliberate: a `Choice(2)` test keeps working when "Production" gets renamed to "Live". `ScriptedResponder` panics on kind mismatch so a wizard-step reorder fails loudly. `Cancel` and `Skip` cover the abort and re-ask paths.
+
+  New public API: `PromptResponder` trait, `ScriptedResponder`, `PromptKind`, `PromptContext`, `PromptResponse` (in `standout_input`); `set_default_prompt_responder` / `reset_default_prompt_responder`; `TestHarness::prompts(...)` (in `standout-test`). The "Testing Wizards" section in the Interactive Flows topic documents the pattern; the Testing guide and topic cross-link it.
+
+  This closes the testability gap that the `.prompt()` shortcut alone left open — the inquire adapters were previously untestable in CI without a real PTY.
+
 ## [7.5.0] - 2026-04-17
 
 ### Added

--- a/crates/standout-input/docs/guides/intro-to-input.md
+++ b/crates/standout-input/docs/guides/intro-to-input.md
@@ -218,7 +218,7 @@ let proceed: bool = InquireConfirm::new("Continue?")
     .prompt()?;
 ```
 
-`prompt()` returns `Result<T, InputError>` directly — no `Option` to unwrap. Empty submissions map to [`InputError::NoInput`], cancellation (Esc / Ctrl+C / Ctrl+D) maps to `InputError::PromptCancelled`, so a re-ask loop is just `match` on the error.
+`prompt()` returns `Result<T, InputError>` directly — no `Option` to unwrap. Stdin not being a TTY *or* an empty submission both map to [`InputError::NoInput`], so a re-ask loop is just `match` on the error. User cancellation is reported as a backend-specific variant (`PromptCancelled` for prompts, `EditorCancelled` for editors); see the [Interactive Flows topic](../topics/interactive-flows.md) for the full table.
 
 Available on every interactive source:
 

--- a/crates/standout-input/docs/guides/intro-to-input.md
+++ b/crates/standout-input/docs/guides/intro-to-input.md
@@ -198,6 +198,41 @@ See [Backends](../topics/backends.md) for full documentation on each source.
 
 ---
 
+## Standalone Prompts (No Chain)
+
+Chains shine for CLI commands that need fallback between sources. For interactive flows that drive standout themselves — wizards, REPLs, setup helpers — every interactive source has a `.prompt()` shortcut that skips the chain machinery and the `&ArgMatches` plumbing entirely:
+
+```rust
+use standout_input::{InquireConfirm, InquireSelect, InquireText};
+
+let pack: String = InquireText::new("Pack name:")
+    .help("a-z0-9-")
+    .prompt()?;
+
+let env: String = InquireSelect::new("Environment:", vec!["dev", "staging", "prod"])
+    .prompt()?
+    .to_string();
+
+let proceed: bool = InquireConfirm::new("Continue?")
+    .default(true)
+    .prompt()?;
+```
+
+`prompt()` returns `Result<T, InputError>` directly — no `Option` to unwrap. Empty submissions map to [`InputError::NoInput`], cancellation (Esc / Ctrl+C / Ctrl+D) maps to `InputError::PromptCancelled`, so a re-ask loop is just `match` on the error.
+
+Available on every interactive source:
+
+| Source | Returns |
+|--------|---------|
+| `TextPromptSource`, `ConfirmPromptSource` | `Result<String, _>`, `Result<bool, _>` |
+| `EditorSource` | `Result<String, _>` |
+| `InquireText`, `InquireConfirm`, `InquirePassword`, `InquireEditor` | as above |
+| `InquireSelect<T>`, `InquireMultiSelect<T>` | `Result<T, _>`, `Result<Vec<T>, _>` |
+
+The `InputCollector` impls are unchanged — these sources still work in chains exactly as before. See [Interactive Flows](../topics/interactive-flows.md) for a full wizard walkthrough that pairs `.prompt()` with standout's renderer.
+
+---
+
 ## Common Patterns
 
 ### The `gh pr create` Pattern

--- a/crates/standout-input/docs/topics/interactive-flows.md
+++ b/crates/standout-input/docs/topics/interactive-flows.md
@@ -211,6 +211,75 @@ You wrote ~50 lines of glue and got: themed dynamic text per step, polished TUI 
 
 ---
 
+## Testing Wizards
+
+A wizard built on `.prompt()` is fully testable in process — no real TTY, no `expectrl` subprocess. Every interactive source consults a [`PromptResponder`](https://docs.rs/standout-input/latest/standout_input/trait.PromptResponder.html) before it touches stdin; in tests you install a `ScriptedResponder` and the production wizard code is unchanged.
+
+```rust
+use serial_test::serial;
+use standout_input::{PromptResponse, ScriptedResponder};
+use standout_test::TestHarness;
+use std::sync::Arc;
+
+#[test]
+#[serial]
+fn setup_wizard_creates_pack_and_picks_environment() {
+    let result = TestHarness::new()
+        .prompts(Arc::new(ScriptedResponder::new([
+            PromptResponse::text("foo"),     // pack name
+            PromptResponse::Bool(true),      // confirm dirty
+            PromptResponse::Choice(2),       // env: dev=0, staging=1, prod=2 -> "prod"
+        ])))
+        .run(&app(), command(), ["mycli", "setup"]);
+
+    result.assert_success();
+    result.assert_stdout_contains("Created pack `foo` in prod");
+}
+```
+
+Two design choices to keep tests honest:
+
+- **Open prompts** (`InquireText`, `InquirePassword`, `InquireEditor`, `TextPromptSource`, `EditorSource`) take `PromptResponse::Text("...")` — the answer *is* the value.
+- **Finite-choice prompts** take a *position*, not a label. `Choice(2)` picks `options[2]` from whatever the wizard passed to `InquireSelect::new`. Renaming `"Production"` to `"Live"` in the option list doesn't break a test that picked index 2 — the wizard logic is unchanged, only copy moved. Same for `Confirm`: assert on the bool, not on `"y"`/`"yes"`.
+
+`ScriptedResponder` validates each response against the prompt kind the source actually asked for. A wizard reorder bug — e.g., a `Confirm` step swapped to land where a `Text` was expected — fails the test loudly with the position, the prompt kind, and the queued response, rather than producing a silently wrong assertion three steps later.
+
+Two kind-agnostic responses cover the cancel and skip branches:
+
+```rust
+PromptResponse::Cancel  // -> Err(InputError::PromptCancelled) inside the wizard
+PromptResponse::Skip    // -> Err(InputError::NoInput)        — same path as "no TTY"
+```
+
+Use them to test the wizard's abort and re-ask logic without involving real signal handling.
+
+For lower-level tests that don't need the harness, install the responder directly:
+
+```rust
+use std::sync::Arc;
+use standout_input::{
+    set_default_prompt_responder, reset_default_prompt_responder,
+    ScriptedResponder, PromptResponse,
+};
+
+#[test]
+#[serial(prompt_responder)]
+fn pack_name_validation_re_asks_on_invalid() {
+    set_default_prompt_responder(Arc::new(ScriptedResponder::new([
+        PromptResponse::text("BadName!"),  // first try, rejected by validator
+        PromptResponse::text("good-name"), // re-ask, accepted
+    ])));
+
+    assert_eq!(prompt_pack_name(&Ctx::fresh()).unwrap(), Answer::Text("good-name".into()));
+
+    reset_default_prompt_responder();
+}
+```
+
+This serializes on the `prompt_responder` axis (the global override is process-wide, like stdin / clipboard). The harness handles the install + reset for you when used as `.prompts(...)`.
+
+---
+
 ## When to Reach for the Framework Instead
 
 If your interactive flow is launched as a subcommand of an otherwise-normal CLI app (e.g. `mycli setup`), you can still use `App::builder()` for everything *outside* the wizard — argument parsing, help rendering, the other commands. Just have the `setup` handler call your wizard `run()` function. The handler itself produces `Output::Silent` (or a small summary) and lets the wizard own its own stdout while it runs. See [Framework Integration](framework-integration.md) for the broader CLI integration story.

--- a/crates/standout-input/docs/topics/interactive-flows.md
+++ b/crates/standout-input/docs/topics/interactive-flows.md
@@ -106,9 +106,12 @@ let proceed = InquireConfirm::new("Continue?")
 ```
 
 Behavior:
-- Esc / Ctrl+C / Ctrl+D → `InputError::PromptCancelled`
-- Empty submission → `InputError::NoInput`
+- Stdin not a TTY *or* empty submission → `InputError::NoInput`
 - Otherwise → the typed value
+- User cancellation is **backend-specific**:
+  - `Inquire*` prompts: Esc / Ctrl+C → `InputError::PromptCancelled`
+  - `TextPromptSource` / `ConfirmPromptSource`: EOF (Ctrl+D) → `InputError::PromptCancelled`; Ctrl+C terminates the process the same way it does for any line-buffered read
+  - `EditorSource` (with `require_save`): closing the editor without saving → `InputError::EditorCancelled`
 
 A re-ask on bad input is a single `match`:
 

--- a/crates/standout-input/docs/topics/interactive-flows.md
+++ b/crates/standout-input/docs/topics/interactive-flows.md
@@ -1,0 +1,213 @@
+# Interactive Flows
+
+This page is for apps that drive an interactive shell themselves — wizards, setup helpers, REPLs, anything that asks one question, reacts, asks the next. `standout` does not own the driver loop; you do. What it does provide is the two ingredients each step needs:
+
+1. **Dynamic, themed text** for the step body — same `Renderer` + `Theme` you use for normal command output.
+2. **Prompts** that work without a `&clap::ArgMatches` — every interactive source in `standout::input` exposes a `.prompt()` shortcut.
+
+Composing those with a ~30-line step graph you own gives you the full pattern.
+
+---
+
+## The Step Graph You Own
+
+Standout is deliberately not opinionated about flow control. A small, hand-rolled state machine is the right tool — you get loops, jumps, early exit, branching on side-effect output, all in idiomatic Rust:
+
+```rust
+use std::collections::HashMap;
+
+enum Next {
+    Go(&'static str),  // jump to a step (also used to re-ask)
+    Done,
+    Quit,
+}
+
+struct Step {
+    render: fn(&Ctx, &Renderer) -> String,
+    prompt: fn(&Ctx) -> Result<Answer, FlowError>,
+    branch: fn(Answer, &mut Ctx) -> Next,
+}
+
+struct Ctx { /* whatever your wizard accumulates */ }
+enum Answer { Text(String), Bool(bool), Choice(usize) }
+
+fn run(steps: &HashMap<&str, Step>, mut ctx: Ctx, r: &Renderer) -> Result<(), FlowError> {
+    let mut cur = "intro";
+    loop {
+        let step = &steps[cur];
+        println!("{}", (step.render)(&ctx, r));
+        let answer = (step.prompt)(&ctx)?;
+        match (step.branch)(answer, &mut ctx) {
+            Next::Go(next) => cur = next,
+            Next::Done => return Ok(()),
+            Next::Quit => return Err(FlowError::Cancelled),
+        }
+    }
+}
+```
+
+That's the whole driver. From here on we focus on what each step looks like.
+
+---
+
+## A Step in Detail
+
+### Render
+
+Every step's body is a registered template, rendered against `Ctx`. Templates can use the full styling system: colors, adaptive themes, tags, `{% if %}` / `{% for %}`. The same machinery your CLI commands already use.
+
+```rust
+// One-time setup, before the loop
+let theme = Theme::default()
+    .add("title", Style::new().bold().cyan())
+    .add("path",  Style::new().green());
+let mut renderer = Renderer::new(theme)?;
+renderer.add_template("pick_pack", PICK_PACK_TPL)?;
+
+// Inside the step's render fn
+fn render_pick_pack(ctx: &Ctx, r: &Renderer) -> String {
+    r.render("pick_pack", ctx).expect("template")
+}
+```
+
+The body of `pick_pack` template is just a normal standout template:
+
+```jinja
+[title]Choose a pack[/title]
+
+Found [count]{{ packs | length }}[/count] packs in [path]{{ root }}[/path]:
+{% for p in packs %}
+  - {{ p.name }}{% if p.recommended %} [hint](recommended)[/hint]{% endif %}
+{% endfor %}
+```
+
+Use `embed_templates!` for static templates so the wizard ships with no runtime file dependencies.
+
+### Prompt
+
+Every interactive source exposes `.prompt()`. No `&ArgMatches`, no chain — just call it:
+
+```rust
+use standout::input::{InquireSelect, InquireText, InquireConfirm};
+
+// Free-form text
+let pack = InquireText::new("Pack name:")
+    .help("a-z0-9-")
+    .prompt()?;                       // Result<String, InputError>
+
+// Pick from options
+let env = InquireSelect::new("Environment:", vec!["dev", "staging", "prod"])
+    .prompt()?;                       // Result<&'static str, _>
+
+// Yes/no
+let proceed = InquireConfirm::new("Continue?")
+    .default(true)
+    .prompt()?;                       // Result<bool, _>
+```
+
+Behavior:
+- Esc / Ctrl+C / Ctrl+D → `InputError::PromptCancelled`
+- Empty submission → `InputError::NoInput`
+- Otherwise → the typed value
+
+A re-ask on bad input is a single `match`:
+
+```rust
+fn prompt_pack_name(_ctx: &Ctx) -> Result<Answer, FlowError> {
+    loop {
+        let pack = InquireText::new("Pack name:").prompt()?;
+        if valid_pack_name(&pack) {
+            return Ok(Answer::Text(pack));
+        }
+        // Could render an error template here for context
+        eprintln!("Pack names must be lowercase a-z, 0-9, '-'.");
+    }
+}
+```
+
+Same idea for `EditorSource` if a step opens an editor:
+
+```rust
+let body = EditorSource::new()
+    .extension(".md")
+    .initial_content("# Pack notes\n\n")
+    .prompt()?;
+```
+
+### Branch
+
+Pure user code. The branch decides the next step from the answer plus any side-effects you ran:
+
+```rust
+fn branch_pick_pack(answer: Answer, ctx: &mut Ctx) -> Next {
+    let Answer::Text(pack) = answer else { return Next::Quit };
+    ctx.pack = Some(pack.clone());
+    match read_status(&ctx.root, &pack) {
+        Ok(s) if s.dirty => Next::Go("confirm_dirty"),
+        Ok(_) => Next::Go("apply"),
+        Err(_) => Next::Go("setup_help"),
+    }
+}
+```
+
+---
+
+## Restart Later
+
+"Run the wizard again next week" is just `run(&steps, Ctx::fresh(), &renderer)`. If you want to resume mid-flow with previously collected state, make `Ctx` `Serialize`/`Deserialize`, persist on each branch, and pass `cur` and `Ctx` into `run`. Standout doesn't standardize a checkpoint format — but every piece of `Ctx` is your data, so serde is fine.
+
+---
+
+## Section Framing (cliclack-style)
+
+`cliclack` ships nice `intro`/`outro`/`note`/`log` helpers for visual pacing. Standout doesn't ship equivalents, but the pattern is two lines of template:
+
+```jinja
+{# templates/note.jinja #}
+[note_marker]●[/note_marker] [note_title]{{ title }}[/note_title]
+{{ body }}
+```
+
+```rust
+fn note(r: &Renderer, title: &str, body: &str) {
+    let v = serde_json::json!({ "title": title, "body": body });
+    println!("{}", r.render("note", &v).unwrap());
+}
+```
+
+Style `note_marker` and `note_title` in your theme — adaptive light/dark falls out for free.
+
+---
+
+## Putting It Together
+
+```rust
+use std::collections::HashMap;
+use standout::{Renderer, Theme};
+use standout::input::{InquireConfirm, InquireSelect, InquireText};
+
+fn main() -> anyhow::Result<()> {
+    let mut renderer = Renderer::new(theme())?;
+    register_templates(&mut renderer)?;
+
+    let steps: HashMap<&str, Step> = HashMap::from([
+        ("intro",        Step { render: render_intro,     prompt: noop_prompt,     branch: |_, _| Next::Go("pick_pack") }),
+        ("pick_pack",    Step { render: render_pick_pack, prompt: prompt_pack,     branch: branch_pick_pack }),
+        ("confirm_dirty",Step { render: render_dirty,     prompt: prompt_confirm,  branch: branch_dirty }),
+        ("apply",        Step { render: render_apply,     prompt: noop_prompt,     branch: |_, _| Next::Done }),
+        ("setup_help",   Step { render: render_help,      prompt: noop_prompt,     branch: |_, _| Next::Done }),
+    ]);
+
+    let ctx = Ctx::fresh();
+    run(&steps, ctx, &renderer)?;
+    Ok(())
+}
+```
+
+You wrote ~50 lines of glue and got: themed dynamic text per step, polished TUI prompts, branching, looping, re-ask, restart. That's the deal: standout owns the *I/O quality*, you own the *flow shape*.
+
+---
+
+## When to Reach for the Framework Instead
+
+If your interactive flow is launched as a subcommand of an otherwise-normal CLI app (e.g. `mycli setup`), you can still use `App::builder()` for everything *outside* the wizard — argument parsing, help rendering, the other commands. Just have the `setup` handler call your wizard `run()` function. The handler itself produces `Output::Silent` (or a small summary) and lets the wizard own its own stdout while it runs. See [Framework Integration](framework-integration.md) for the broader CLI integration story.

--- a/crates/standout-input/src/collector.rs
+++ b/crates/standout-input/src/collector.rs
@@ -92,6 +92,24 @@ pub trait InputCollector<T>: Send + Sync {
     }
 }
 
+/// Returns a process-wide static [`ArgMatches`] with no arguments.
+///
+/// Used by the `.prompt()` shortcuts on interactive sources, which need to
+/// satisfy `InputCollector::collect`'s `&ArgMatches` parameter even when no
+/// CLI parser is involved (the typical case for wizard/REPL flows that own
+/// their own driver). Initialized lazily on first call and reused thereafter.
+#[allow(dead_code)] // Becomes used once `.prompt()` shortcuts land on each source.
+pub(crate) fn empty_matches() -> &'static ArgMatches {
+    use std::sync::OnceLock;
+    static MATCHES: OnceLock<ArgMatches> = OnceLock::new();
+    MATCHES.get_or_init(|| {
+        clap::Command::new("__standout_input_prompt__")
+            .no_binary_name(true)
+            .try_get_matches_from(std::iter::empty::<&str>())
+            .expect("empty command always parses with no args")
+    })
+}
+
 /// Information about how input was resolved.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedInput<T> {

--- a/crates/standout-input/src/collector.rs
+++ b/crates/standout-input/src/collector.rs
@@ -98,7 +98,7 @@ pub trait InputCollector<T>: Send + Sync {
 /// satisfy `InputCollector::collect`'s `&ArgMatches` parameter even when no
 /// CLI parser is involved (the typical case for wizard/REPL flows that own
 /// their own driver). Initialized lazily on first call and reused thereafter.
-#[allow(dead_code)] // Becomes used once `.prompt()` shortcuts land on each source.
+#[cfg(any(feature = "editor", feature = "simple-prompts", feature = "inquire"))]
 pub(crate) fn empty_matches() -> &'static ArgMatches {
     use std::sync::OnceLock;
     static MATCHES: OnceLock<ArgMatches> = OnceLock::new();

--- a/crates/standout-input/src/lib.rs
+++ b/crates/standout-input/src/lib.rs
@@ -53,6 +53,7 @@ mod collector;
 pub mod env;
 mod error;
 mod inputs;
+mod responder;
 pub mod sources;
 
 // Re-export core types
@@ -60,6 +61,10 @@ pub use chain::InputChain;
 pub use collector::{InputCollector, InputSourceKind, ResolvedInput};
 pub use error::InputError;
 pub use inputs::{Inputs, MissingInput};
+pub use responder::{
+    reset_default_prompt_responder, set_default_prompt_responder, PromptContext, PromptKind,
+    PromptResponder, PromptResponse, ScriptedResponder,
+};
 
 // Re-export sources at crate root for convenience
 pub use sources::{

--- a/crates/standout-input/src/responder.rs
+++ b/crates/standout-input/src/responder.rs
@@ -25,8 +25,9 @@
 //! [`Editor`](PromptKind::Editor)) take a `String`, since the value *is* the
 //! free-form answer.
 //!
-//! See the [Testing Wizards](https://docs.rs/standout-input/latest/) section
-//! of the Interactive Flows topic for a full example.
+//! See the "Testing Wizards" section in the
+//! [Interactive Flows topic](../../docs/topics/interactive-flows.md) for a
+//! full example.
 
 use std::sync::Arc;
 
@@ -211,16 +212,18 @@ impl PromptResponder for ScriptedResponder {
             }
         }
 
-        if let PromptResponse::Choice(i) = response {
+        // Range-check by reference so we don't move the response we're
+        // about to return.
+        if let PromptResponse::Choice(i) = &response {
             let n = ctx.options.unwrap_or(0);
             assert!(
-                i < n,
+                *i < n,
                 "ScriptedResponder: Choice({i}) is out of range for select prompt \
                  with {n} option(s) ({:?})",
                 ctx.message
             );
         }
-        if let PromptResponse::Choices(ref indices) = response {
+        if let PromptResponse::Choices(indices) = &response {
             let n = ctx.options.unwrap_or(0);
             for &i in indices {
                 assert!(
@@ -507,6 +510,12 @@ mod tests {
         let _ = r.respond(ctx(PromptKind::Text, None));
     }
 
+    // current_prompt_responder() is only compiled when at least one
+    // prompt-producing feature is enabled, so the test that exercises it
+    // shares the same cfg gate. Under --no-default-features the install /
+    // reset path is unobservable from the public API, so there's no test
+    // to write.
+    #[cfg(any(feature = "editor", feature = "simple-prompts", feature = "inquire"))]
     #[test]
     #[serial(prompt_responder)]
     fn install_and_reset_default_responder() {

--- a/crates/standout-input/src/responder.rs
+++ b/crates/standout-input/src/responder.rs
@@ -272,9 +272,138 @@ pub fn reset_default_prompt_responder() {
 ///
 /// Used by source `.prompt()` implementations to decide whether to short-
 /// circuit through the responder or fall through to the real backend.
-#[allow(dead_code)] // Becomes used once .prompt() implementations are wired in (next commit).
+#[cfg(any(feature = "editor", feature = "simple-prompts", feature = "inquire"))]
 pub(crate) fn current_prompt_responder() -> Option<SharedResponder> {
     RESPONDER_OVERRIDE.lock().unwrap().clone()
+}
+
+/// Helper used by source `.prompt()` shortcuts that return a free-form
+/// `String` (text / password / editor prompts).
+///
+/// If a responder is installed, dispatches and maps `Text(s) -> Ok(s)`,
+/// `Cancel -> PromptCancelled`, `Skip -> NoInput`. Returns `Ok(None)` (i.e.
+/// "fall through to the real backend") when no responder is installed, so
+/// the caller can use the original `is_available` + `collect` path.
+///
+/// `Bool` / `Choice` / `Choices` responses against an open prompt panic
+/// via `ScriptedResponder`'s validation in production tests.
+#[cfg(any(feature = "editor", feature = "simple-prompts", feature = "inquire"))]
+pub(crate) fn intercept_text(
+    kind: PromptKind,
+    message: &str,
+) -> Result<Option<String>, crate::InputError> {
+    let Some(responder) = current_prompt_responder() else {
+        return Ok(None);
+    };
+    let response = responder.respond(PromptContext {
+        kind,
+        message,
+        options: None,
+    });
+    match response {
+        PromptResponse::Text(s) => Ok(Some(s)),
+        PromptResponse::Cancel => Err(crate::InputError::PromptCancelled),
+        PromptResponse::Skip => Err(crate::InputError::NoInput),
+        other => panic!(
+            "PromptResponder returned {other:?} for a `{kind}` prompt; \
+             expected Text / Cancel / Skip"
+        ),
+    }
+}
+
+/// Helper for `.prompt()` shortcuts that return a `bool`
+/// ([`InquireConfirm`](crate::InquireConfirm),
+/// [`ConfirmPromptSource`](crate::ConfirmPromptSource)).
+#[cfg(any(feature = "simple-prompts", feature = "inquire"))]
+pub(crate) fn intercept_bool(
+    kind: PromptKind,
+    message: &str,
+) -> Result<Option<bool>, crate::InputError> {
+    let Some(responder) = current_prompt_responder() else {
+        return Ok(None);
+    };
+    let response = responder.respond(PromptContext {
+        kind,
+        message,
+        options: None,
+    });
+    match response {
+        PromptResponse::Bool(b) => Ok(Some(b)),
+        PromptResponse::Cancel => Err(crate::InputError::PromptCancelled),
+        PromptResponse::Skip => Err(crate::InputError::NoInput),
+        other => panic!(
+            "PromptResponder returned {other:?} for a `{kind}` prompt; \
+             expected Bool / Cancel / Skip"
+        ),
+    }
+}
+
+/// Helper for [`InquireSelect`](crate::InquireSelect)::prompt(). Returns
+/// the selected *index* into the source's options vector; the caller
+/// performs the `options[i].clone()` so the typed `T` flows out.
+#[cfg(feature = "inquire")]
+pub(crate) fn intercept_choice(
+    message: &str,
+    n: usize,
+) -> Result<Option<usize>, crate::InputError> {
+    let Some(responder) = current_prompt_responder() else {
+        return Ok(None);
+    };
+    let response = responder.respond(PromptContext {
+        kind: PromptKind::Select,
+        message,
+        options: Some(n),
+    });
+    match response {
+        PromptResponse::Choice(i) => {
+            assert!(
+                i < n,
+                "PromptResponder returned Choice({i}) for select prompt with {n} option(s)"
+            );
+            Ok(Some(i))
+        }
+        PromptResponse::Cancel => Err(crate::InputError::PromptCancelled),
+        PromptResponse::Skip => Err(crate::InputError::NoInput),
+        other => panic!(
+            "PromptResponder returned {other:?} for a `select` prompt; \
+             expected Choice / Cancel / Skip"
+        ),
+    }
+}
+
+/// Helper for [`InquireMultiSelect`](crate::InquireMultiSelect)::prompt().
+/// Returns the selected indices.
+#[cfg(feature = "inquire")]
+pub(crate) fn intercept_choices(
+    message: &str,
+    n: usize,
+) -> Result<Option<Vec<usize>>, crate::InputError> {
+    let Some(responder) = current_prompt_responder() else {
+        return Ok(None);
+    };
+    let response = responder.respond(PromptContext {
+        kind: PromptKind::MultiSelect,
+        message,
+        options: Some(n),
+    });
+    match response {
+        PromptResponse::Choices(indices) => {
+            for &i in &indices {
+                assert!(
+                    i < n,
+                    "PromptResponder returned Choices containing {i} for multi-select \
+                     prompt with {n} option(s)"
+                );
+            }
+            Ok(Some(indices))
+        }
+        PromptResponse::Cancel => Err(crate::InputError::PromptCancelled),
+        PromptResponse::Skip => Err(crate::InputError::NoInput),
+        other => panic!(
+            "PromptResponder returned {other:?} for a `multi-select` prompt; \
+             expected Choices / Cancel / Skip"
+        ),
+    }
 }
 
 #[cfg(test)]

--- a/crates/standout-input/src/responder.rs
+++ b/crates/standout-input/src/responder.rs
@@ -1,0 +1,390 @@
+//! Test injection for interactive prompts.
+//!
+//! Wizard / setup-helper / REPL flows that build on the `.prompt()` shortcut
+//! on every interactive source ([`InquireText`](crate::InquireText),
+//! [`InquireSelect`](crate::InquireSelect), [`TextPromptSource`](crate::TextPromptSource),
+//! and friends) are otherwise untestable in process — the inquire backends
+//! reach for raw stdin and the simple-prompts and editor sources need a TTY.
+//!
+//! [`PromptResponder`] is the test seam: every `.prompt()` call consults a
+//! process-global responder first, and falls through to the real backend
+//! only when none is installed. Tests install a [`ScriptedResponder`] with
+//! a queue of typed [`PromptResponse`] values; the production wizard code
+//! is unchanged.
+//!
+//! # Why responses are typed by *kind*, not by message text
+//!
+//! For finite-choice prompts ([`Select`](PromptKind::Select),
+//! [`MultiSelect`](PromptKind::MultiSelect), [`Confirm`](PromptKind::Confirm))
+//! the response is the *position* (or boolean) — never the option's display
+//! label. Renaming "Production" to "Live" doesn't break a test that picked
+//! `Choice(2)`. Same for confirm: a test asserts on `true`/`false`, not on
+//! the prompt copy.
+//!
+//! Open prompts ([`Text`](PromptKind::Text), [`Password`](PromptKind::Password),
+//! [`Editor`](PromptKind::Editor)) take a `String`, since the value *is* the
+//! free-form answer.
+//!
+//! See the [Testing Wizards](https://docs.rs/standout-input/latest/) section
+//! of the Interactive Flows topic for a full example.
+
+use std::sync::Arc;
+
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+/// The kind of prompt being responded to.
+///
+/// The interactive source passes its kind to the responder; the responder
+/// returns a [`PromptResponse`]. A scripted responder uses the kind to
+/// validate that the next queued response matches what the source actually
+/// asked for, panicking with a descriptive message on mismatch (a wizard-
+/// reorder bug surfaces at the test, not as a silent wrong-data assert
+/// downstream).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptKind {
+    /// Free-form text input ([`InquireText`](crate::InquireText),
+    /// [`TextPromptSource`](crate::TextPromptSource)).
+    Text,
+    /// Masked password input ([`InquirePassword`](crate::InquirePassword)).
+    Password,
+    /// Editor-based multi-line input ([`EditorSource`](crate::EditorSource),
+    /// [`InquireEditor`](crate::InquireEditor)).
+    Editor,
+    /// Yes/no ([`InquireConfirm`](crate::InquireConfirm),
+    /// [`ConfirmPromptSource`](crate::ConfirmPromptSource)).
+    Confirm,
+    /// Single selection from a list ([`InquireSelect`](crate::InquireSelect)).
+    Select,
+    /// Multi-selection from a list ([`InquireMultiSelect`](crate::InquireMultiSelect)).
+    MultiSelect,
+}
+
+impl std::fmt::Display for PromptKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Text => write!(f, "text"),
+            Self::Password => write!(f, "password"),
+            Self::Editor => write!(f, "editor"),
+            Self::Confirm => write!(f, "confirm"),
+            Self::Select => write!(f, "select"),
+            Self::MultiSelect => write!(f, "multi-select"),
+        }
+    }
+}
+
+/// Context the source passes to a [`PromptResponder`].
+///
+/// Includes everything a smart responder might want: the prompt kind, the
+/// human-facing message (for diagnostic / advanced matching), and — for
+/// finite-choice prompts — the size of the option list so a `Choice(i)`
+/// response can be range-checked.
+#[derive(Debug, Clone, Copy)]
+pub struct PromptContext<'a> {
+    /// What kind of prompt is asking.
+    pub kind: PromptKind,
+    /// The human-facing prompt message (e.g. `"Pack name:"`).
+    ///
+    /// Mostly useful for diagnostics in panic messages and for advanced
+    /// responders that want to match on text. Position-based scripted
+    /// responders don't need to consult it.
+    pub message: &'a str,
+    /// Size of the option list, for `Select` / `MultiSelect`. `None` for
+    /// open prompts and confirm.
+    pub options: Option<usize>,
+}
+
+/// A response a [`PromptResponder`] can return.
+#[derive(Debug, Clone)]
+pub enum PromptResponse {
+    /// Free-form text answer for [`Text`](PromptKind::Text),
+    /// [`Password`](PromptKind::Password), and
+    /// [`Editor`](PromptKind::Editor) prompts.
+    Text(String),
+    /// Boolean answer for [`Confirm`](PromptKind::Confirm) prompts.
+    Bool(bool),
+    /// Index of the chosen option for [`Select`](PromptKind::Select) prompts.
+    /// Must be `< options` or the source will panic.
+    Choice(usize),
+    /// Indices of the chosen options for [`MultiSelect`](PromptKind::MultiSelect).
+    /// Each must be `< options`.
+    Choices(Vec<usize>),
+    /// Surface this prompt as user cancellation
+    /// ([`InputError::PromptCancelled`](crate::InputError::PromptCancelled)).
+    Cancel,
+    /// Surface this prompt as "no input"
+    /// ([`InputError::NoInput`](crate::InputError::NoInput)) — the same path
+    /// the source takes when stdin is not a TTY.
+    Skip,
+}
+
+impl PromptResponse {
+    /// Convenience constructor for a text response.
+    pub fn text(s: impl Into<String>) -> Self {
+        Self::Text(s.into())
+    }
+
+    /// Convenience constructor for a multi-select response.
+    pub fn choices(indices: impl IntoIterator<Item = usize>) -> Self {
+        Self::Choices(indices.into_iter().collect())
+    }
+
+    /// Returns the kind this response is *valid* for, if any. `Cancel` and
+    /// `Skip` are always valid, so they return `None`.
+    pub(crate) fn expected_kind(&self) -> Option<&'static [PromptKind]> {
+        match self {
+            Self::Text(_) => Some(&[PromptKind::Text, PromptKind::Password, PromptKind::Editor]),
+            Self::Bool(_) => Some(&[PromptKind::Confirm]),
+            Self::Choice(_) => Some(&[PromptKind::Select]),
+            Self::Choices(_) => Some(&[PromptKind::MultiSelect]),
+            Self::Cancel | Self::Skip => None,
+        }
+    }
+}
+
+/// Test seam for the `.prompt()` shortcut on interactive sources.
+///
+/// When a responder is installed via [`set_default_prompt_responder`],
+/// every `prompt()` call routes through it instead of opening a real prompt.
+/// Implement this trait for custom dispatch logic, or use the bundled
+/// [`ScriptedResponder`].
+pub trait PromptResponder: Send + Sync {
+    /// Produce a response for the given prompt.
+    fn respond(&self, ctx: PromptContext<'_>) -> PromptResponse;
+}
+
+/// A position-based scripted responder.
+///
+/// Built from a queue of [`PromptResponse`] values. Each call to
+/// [`respond`](PromptResponder::respond) pops the next response and
+/// validates that its kind is compatible with the prompt the source
+/// actually asked for; if not, it panics with a message that names the
+/// position, the prompt kind, and the response kind.
+///
+/// This makes wizard-reorder bugs surface as test failures at the offending
+/// step rather than as silent wrong-data assertions later.
+///
+/// ```
+/// use standout_input::{ScriptedResponder, PromptResponse};
+///
+/// let responder = ScriptedResponder::new([
+///     PromptResponse::text("buy milk"),
+///     PromptResponse::Bool(true),
+///     PromptResponse::Choice(2),
+/// ]);
+/// ```
+pub struct ScriptedResponder {
+    queue: Mutex<std::collections::VecDeque<PromptResponse>>,
+}
+
+impl ScriptedResponder {
+    /// Create a scripted responder from a sequence of responses.
+    pub fn new(responses: impl IntoIterator<Item = PromptResponse>) -> Self {
+        Self {
+            queue: Mutex::new(responses.into_iter().collect()),
+        }
+    }
+
+    /// Number of responses still queued.
+    pub fn remaining(&self) -> usize {
+        self.queue.lock().unwrap().len()
+    }
+}
+
+impl PromptResponder for ScriptedResponder {
+    fn respond(&self, ctx: PromptContext<'_>) -> PromptResponse {
+        let response = self.queue.lock().unwrap().pop_front().unwrap_or_else(|| {
+            panic!(
+                "ScriptedResponder ran out of responses; \
+                 next prompt was a `{}` prompt with message {:?}",
+                ctx.kind, ctx.message
+            )
+        });
+
+        if let Some(allowed) = response.expected_kind() {
+            if !allowed.contains(&ctx.kind) {
+                panic!(
+                    "ScriptedResponder kind mismatch: expected response for `{}` prompt \
+                     ({:?}), but got {:?}",
+                    ctx.kind, ctx.message, response
+                );
+            }
+        }
+
+        if let PromptResponse::Choice(i) = response {
+            let n = ctx.options.unwrap_or(0);
+            assert!(
+                i < n,
+                "ScriptedResponder: Choice({i}) is out of range for select prompt \
+                 with {n} option(s) ({:?})",
+                ctx.message
+            );
+        }
+        if let PromptResponse::Choices(ref indices) = response {
+            let n = ctx.options.unwrap_or(0);
+            for &i in indices {
+                assert!(
+                    i < n,
+                    "ScriptedResponder: Choices contains {i}, out of range for \
+                     multi-select prompt with {n} option(s) ({:?})",
+                    ctx.message
+                );
+            }
+        }
+
+        response
+    }
+}
+
+impl std::fmt::Debug for ScriptedResponder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScriptedResponder")
+            .field("remaining", &self.remaining())
+            .finish()
+    }
+}
+
+// ============================================================================
+// Process-global responder override
+// ============================================================================
+
+type SharedResponder = Arc<dyn PromptResponder>;
+
+static RESPONDER_OVERRIDE: Lazy<Mutex<Option<SharedResponder>>> = Lazy::new(|| Mutex::new(None));
+
+/// Installs a process-global [`PromptResponder`] that every `.prompt()` call
+/// on an interactive source will route through until
+/// [`reset_default_prompt_responder`] is called.
+///
+/// Intended for test harnesses; the `standout-test` crate's
+/// `TestHarness::prompts(...)` wires this automatically. Tests using it must
+/// run serially (e.g. via `#[serial]`) because the override is process-global.
+pub fn set_default_prompt_responder(responder: SharedResponder) {
+    *RESPONDER_OVERRIDE.lock().unwrap() = Some(responder);
+}
+
+/// Clears the override installed by [`set_default_prompt_responder`].
+pub fn reset_default_prompt_responder() {
+    *RESPONDER_OVERRIDE.lock().unwrap() = None;
+}
+
+/// Returns a clone of the currently installed responder, if any.
+///
+/// Used by source `.prompt()` implementations to decide whether to short-
+/// circuit through the responder or fall through to the real backend.
+#[allow(dead_code)] // Becomes used once .prompt() implementations are wired in (next commit).
+pub(crate) fn current_prompt_responder() -> Option<SharedResponder> {
+    RESPONDER_OVERRIDE.lock().unwrap().clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn ctx(kind: PromptKind, options: Option<usize>) -> PromptContext<'static> {
+        PromptContext {
+            kind,
+            message: "test prompt",
+            options,
+        }
+    }
+
+    #[test]
+    fn scripted_responder_returns_in_order() {
+        let r = ScriptedResponder::new([
+            PromptResponse::text("first"),
+            PromptResponse::Bool(true),
+            PromptResponse::Choice(1),
+        ]);
+        assert!(
+            matches!(r.respond(ctx(PromptKind::Text, None)), PromptResponse::Text(s) if s == "first")
+        );
+        assert!(matches!(
+            r.respond(ctx(PromptKind::Confirm, None)),
+            PromptResponse::Bool(true)
+        ));
+        assert!(matches!(
+            r.respond(ctx(PromptKind::Select, Some(3))),
+            PromptResponse::Choice(1)
+        ));
+        assert_eq!(r.remaining(), 0);
+    }
+
+    #[test]
+    fn cancel_and_skip_are_kind_agnostic() {
+        let r = ScriptedResponder::new([PromptResponse::Cancel, PromptResponse::Skip]);
+        // Cancel is fine for any kind
+        assert!(matches!(
+            r.respond(ctx(PromptKind::Select, Some(2))),
+            PromptResponse::Cancel
+        ));
+        // Skip too
+        assert!(matches!(
+            r.respond(ctx(PromptKind::Confirm, None)),
+            PromptResponse::Skip
+        ));
+    }
+
+    #[test]
+    fn text_response_works_for_all_open_kinds() {
+        let r = ScriptedResponder::new([
+            PromptResponse::text("a"),
+            PromptResponse::text("b"),
+            PromptResponse::text("c"),
+        ]);
+        assert!(matches!(
+            r.respond(ctx(PromptKind::Text, None)),
+            PromptResponse::Text(_)
+        ));
+        assert!(matches!(
+            r.respond(ctx(PromptKind::Password, None)),
+            PromptResponse::Text(_)
+        ));
+        assert!(matches!(
+            r.respond(ctx(PromptKind::Editor, None)),
+            PromptResponse::Text(_)
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "kind mismatch")]
+    fn scripted_responder_panics_on_kind_mismatch() {
+        let r = ScriptedResponder::new([PromptResponse::text("oops")]);
+        // Confirm prompt with a Text response — wizard order changed and
+        // the test should fail loudly here, not 3 lines later.
+        let _ = r.respond(ctx(PromptKind::Confirm, None));
+    }
+
+    #[test]
+    #[should_panic(expected = "out of range")]
+    fn scripted_responder_panics_on_out_of_range_choice() {
+        let r = ScriptedResponder::new([PromptResponse::Choice(5)]);
+        let _ = r.respond(ctx(PromptKind::Select, Some(3)));
+    }
+
+    #[test]
+    #[should_panic(expected = "out of range")]
+    fn scripted_responder_panics_on_out_of_range_multiselect() {
+        let r = ScriptedResponder::new([PromptResponse::choices([0, 7])]);
+        let _ = r.respond(ctx(PromptKind::MultiSelect, Some(3)));
+    }
+
+    #[test]
+    #[should_panic(expected = "ran out of responses")]
+    fn scripted_responder_panics_when_exhausted() {
+        let r = ScriptedResponder::new([PromptResponse::text("only")]);
+        let _ = r.respond(ctx(PromptKind::Text, None));
+        let _ = r.respond(ctx(PromptKind::Text, None));
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn install_and_reset_default_responder() {
+        assert!(current_prompt_responder().is_none());
+        set_default_prompt_responder(Arc::new(ScriptedResponder::new([])));
+        assert!(current_prompt_responder().is_some());
+        reset_default_prompt_responder();
+        assert!(current_prompt_responder().is_none());
+    }
+}

--- a/crates/standout-input/src/sources/editor.rs
+++ b/crates/standout-input/src/sources/editor.rs
@@ -224,7 +224,21 @@ impl<R: EditorRunner + 'static> EditorSource<R> {
     /// this source). User cancellation is reported as
     /// [`InputError::EditorCancelled`] when `require_save` is set and the
     /// user exits without saving.
+    ///
+    /// Routes through any installed
+    /// [`PromptResponder`](crate::PromptResponder), so wizard tests can
+    /// supply the editor's "saved" content directly without launching
+    /// `$EDITOR`.
     pub fn prompt(&self) -> Result<String, InputError> {
+        if let Some(value) = crate::responder::intercept_text(
+            crate::PromptKind::Editor,
+            // EditorSource has no user-facing "message" — use the file
+            // extension as the diagnostic hint so panic messages still
+            // identify which editor source failed.
+            &self.extension,
+        )? {
+            return Ok(value);
+        }
         let matches = crate::collector::empty_matches();
         if !self.is_available(matches) {
             return Err(InputError::NoInput);

--- a/crates/standout-input/src/sources/editor.rs
+++ b/crates/standout-input/src/sources/editor.rs
@@ -503,4 +503,48 @@ mod tests {
         let err = source.prompt().unwrap_err();
         assert!(matches!(err, InputError::NoInput));
     }
+
+    // === .prompt() via PromptResponder ===
+
+    use crate::{
+        reset_default_prompt_responder, set_default_prompt_responder, PromptResponse,
+        ScriptedResponder,
+    };
+    use serial_test::serial;
+    use std::sync::Arc;
+
+    struct ResponderGuard;
+    impl ResponderGuard {
+        fn install(responder: ScriptedResponder) -> Self {
+            set_default_prompt_responder(Arc::new(responder));
+            Self
+        }
+    }
+    impl Drop for ResponderGuard {
+        fn drop(&mut self) {
+            reset_default_prompt_responder();
+        }
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn editor_prompt_routes_through_responder_without_launching_editor() {
+        let _g = ResponderGuard::install(ScriptedResponder::new([PromptResponse::text(
+            "edited body",
+        )]));
+        // Even with a no-editor mock runner, the responder gate runs first
+        // and wins — the editor is never launched in tests.
+        let source = EditorSource::with_runner(MockEditorRunner::no_editor());
+        let value = source.prompt().unwrap();
+        assert_eq!(value, "edited body");
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn editor_prompt_responder_cancel_propagates() {
+        let _g = ResponderGuard::install(ScriptedResponder::new([PromptResponse::Cancel]));
+        let source = EditorSource::with_runner(MockEditorRunner::no_editor());
+        let err = source.prompt().unwrap_err();
+        assert!(matches!(err, InputError::PromptCancelled));
+    }
 }

--- a/crates/standout-input/src/sources/editor.rs
+++ b/crates/standout-input/src/sources/editor.rs
@@ -219,13 +219,17 @@ impl<R: EditorRunner + 'static> EditorSource<R> {
     /// it skips the chain machinery (no `&ArgMatches` to plumb through) and
     /// is intended for wizard or REPL flows that drive standout themselves.
     ///
-    /// Returns the editor content on success, or an [`InputError`] if no
-    /// editor is available, the editor failed, or `require_save` is set and
-    /// the user closed without saving. If `require_save` is unset and the
-    /// editor exits with empty content, [`InputError::NoInput`] is returned.
+    /// Returns [`InputError::NoInput`] if stdin is not a TTY or no editor
+    /// can be detected (the same conditions under which a chain would skip
+    /// this source). User cancellation is reported as
+    /// [`InputError::EditorCancelled`] when `require_save` is set and the
+    /// user exits without saving.
     pub fn prompt(&self) -> Result<String, InputError> {
-        self.collect(crate::collector::empty_matches())?
-            .ok_or(InputError::NoInput)
+        let matches = crate::collector::empty_matches();
+        if !self.is_available(matches) {
+            return Err(InputError::NoInput);
+        }
+        self.collect(matches)?.ok_or(InputError::NoInput)
     }
 }
 
@@ -464,25 +468,25 @@ mod tests {
     }
 
     // === .prompt() shortcut ===
+    //
+    // EditorSource::is_available checks std::io::stdin().is_terminal() directly,
+    // so under `cargo test` (no TTY) prompt() always short-circuits to NoInput.
+    // The happy path with the mock runner is covered by the existing
+    // editor_collects_content / editor_failure / editor_no_editor_error tests
+    // on collect(), which prompt() delegates to once the TTY gate passes.
 
     #[test]
-    fn editor_prompt_shortcut_returns_content() {
+    fn editor_prompt_shortcut_returns_no_input_in_non_tty() {
         let source = EditorSource::with_runner(MockEditorRunner::with_result("hello"));
-        let value = source.prompt().unwrap();
-        assert_eq!(value, "hello");
+        let err = source.prompt().unwrap_err();
+        assert!(matches!(err, InputError::NoInput));
     }
 
     #[test]
-    fn editor_prompt_shortcut_propagates_no_editor() {
+    fn editor_prompt_shortcut_no_input_when_no_editor_detected() {
+        // No TTY *and* no editor — both fail is_available, so NoInput either way.
         let source = EditorSource::with_runner(MockEditorRunner::no_editor());
         let err = source.prompt().unwrap_err();
-        assert!(matches!(err, InputError::NoEditor));
-    }
-
-    #[test]
-    fn editor_prompt_shortcut_propagates_failure() {
-        let source = EditorSource::with_runner(MockEditorRunner::failure("editor crashed"));
-        let err = source.prompt().unwrap_err();
-        assert!(matches!(err, InputError::EditorFailed(_)));
+        assert!(matches!(err, InputError::NoInput));
     }
 }

--- a/crates/standout-input/src/sources/editor.rs
+++ b/crates/standout-input/src/sources/editor.rs
@@ -212,6 +212,23 @@ impl<R: EditorRunner> EditorSource<R> {
     }
 }
 
+impl<R: EditorRunner + 'static> EditorSource<R> {
+    /// Open the editor and return the saved content.
+    ///
+    /// This is the standalone counterpart to [`InputCollector::collect`]:
+    /// it skips the chain machinery (no `&ArgMatches` to plumb through) and
+    /// is intended for wizard or REPL flows that drive standout themselves.
+    ///
+    /// Returns the editor content on success, or an [`InputError`] if no
+    /// editor is available, the editor failed, or `require_save` is set and
+    /// the user closed without saving. If `require_save` is unset and the
+    /// editor exits with empty content, [`InputError::NoInput`] is returned.
+    pub fn prompt(&self) -> Result<String, InputError> {
+        self.collect(crate::collector::empty_matches())?
+            .ok_or(InputError::NoInput)
+    }
+}
+
 impl<R: EditorRunner + 'static> InputCollector<String> for EditorSource<R> {
     fn name(&self) -> &'static str {
         "editor"

--- a/crates/standout-input/src/sources/editor.rs
+++ b/crates/standout-input/src/sources/editor.rs
@@ -462,4 +462,27 @@ mod tests {
         let result = source.collect(&empty_matches());
         assert!(matches!(result, Err(InputError::NoEditor)));
     }
+
+    // === .prompt() shortcut ===
+
+    #[test]
+    fn editor_prompt_shortcut_returns_content() {
+        let source = EditorSource::with_runner(MockEditorRunner::with_result("hello"));
+        let value = source.prompt().unwrap();
+        assert_eq!(value, "hello");
+    }
+
+    #[test]
+    fn editor_prompt_shortcut_propagates_no_editor() {
+        let source = EditorSource::with_runner(MockEditorRunner::no_editor());
+        let err = source.prompt().unwrap_err();
+        assert!(matches!(err, InputError::NoEditor));
+    }
+
+    #[test]
+    fn editor_prompt_shortcut_propagates_failure() {
+        let source = EditorSource::with_runner(MockEditorRunner::failure("editor crashed"));
+        let err = source.prompt().unwrap_err();
+        assert!(matches!(err, InputError::EditorFailed(_)));
+    }
 }

--- a/crates/standout-input/src/sources/inquire_adapters.rs
+++ b/crates/standout-input/src/sources/inquire_adapters.rs
@@ -84,7 +84,17 @@ impl InquireText {
     /// to plumb through. Returns [`InputError::PromptCancelled`] on Esc /
     /// Ctrl+C, and [`InputError::NoInput`] if stdin is not a TTY or the
     /// user submits empty input.
+    ///
+    /// In tests, install a [`PromptResponder`](crate::PromptResponder) via
+    /// [`set_default_prompt_responder`](crate::set_default_prompt_responder)
+    /// (or the `TestHarness::prompts(...)` builder) to intercept this call
+    /// without touching the production wizard code.
     pub fn prompt(&self) -> Result<String, InputError> {
+        if let Some(value) =
+            crate::responder::intercept_text(crate::PromptKind::Text, &self.message)?
+        {
+            return Ok(value);
+        }
         let matches = crate::collector::empty_matches();
         if !self.is_available(matches) {
             return Err(InputError::NoInput);
@@ -175,8 +185,15 @@ impl InquireConfirm {
     /// Standalone counterpart to [`InputCollector::collect`] for wizard /
     /// REPL flows that drive standout themselves. Returns
     /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
-    /// [`InputError::NoInput`] if stdin is not a TTY.
+    /// [`InputError::NoInput`] if stdin is not a TTY. Routes through any
+    /// installed [`PromptResponder`](crate::PromptResponder) so wizard
+    /// tests can script the answer.
     pub fn prompt(&self) -> Result<bool, InputError> {
+        if let Some(value) =
+            crate::responder::intercept_bool(crate::PromptKind::Confirm, &self.message)?
+        {
+            return Ok(value);
+        }
         let matches = crate::collector::empty_matches();
         if !self.is_available(matches) {
             return Err(InputError::NoInput);
@@ -266,7 +283,15 @@ impl<T: Display + Clone + Send + Sync + 'static> InquireSelect<T> {
     /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
     /// [`InputError::NoInput`] if stdin is not a TTY or the option list
     /// is empty.
+    ///
+    /// Routes through any installed
+    /// [`PromptResponder`](crate::PromptResponder); a scripted test
+    /// returns a `PromptResponse::Choice(i)` and the source clones
+    /// `options[i]`.
     pub fn prompt(&self) -> Result<T, InputError> {
+        if let Some(i) = crate::responder::intercept_choice(&self.message, self.options.len())? {
+            return Ok(self.options[i].clone());
+        }
         let matches = crate::collector::empty_matches();
         if !self.is_available(matches) {
             return Err(InputError::NoInput);
@@ -374,7 +399,17 @@ impl<T: Display + Clone + Send + Sync + 'static> InquireMultiSelect<T> {
     /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
     /// [`InputError::NoInput`] if stdin is not a TTY or the option list
     /// is empty.
+    ///
+    /// Routes through any installed
+    /// [`PromptResponder`](crate::PromptResponder); a scripted test
+    /// returns a `PromptResponse::Choices([..])` and the source clones
+    /// the corresponding entries from `options`.
     pub fn prompt(&self) -> Result<Vec<T>, InputError> {
+        if let Some(indices) =
+            crate::responder::intercept_choices(&self.message, self.options.len())?
+        {
+            return Ok(indices.iter().map(|&i| self.options[i].clone()).collect());
+        }
         let matches = crate::collector::empty_matches();
         if !self.is_available(matches) {
             return Err(InputError::NoInput);
@@ -505,8 +540,14 @@ impl InquirePassword {
     /// REPL flows that drive standout themselves. Returns
     /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
     /// [`InputError::NoInput`] if stdin is not a TTY or the user submits
-    /// empty input.
+    /// empty input. Routes through any installed
+    /// [`PromptResponder`](crate::PromptResponder).
     pub fn prompt(&self) -> Result<String, InputError> {
+        if let Some(value) =
+            crate::responder::intercept_text(crate::PromptKind::Password, &self.message)?
+        {
+            return Ok(value);
+        }
         let matches = crate::collector::empty_matches();
         if !self.is_available(matches) {
             return Err(InputError::NoInput);
@@ -613,8 +654,14 @@ impl InquireEditor {
     /// REPL flows that drive standout themselves. Returns
     /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
     /// [`InputError::NoInput`] if stdin is not a TTY or the user submits
-    /// empty content.
+    /// empty content. Routes through any installed
+    /// [`PromptResponder`](crate::PromptResponder).
     pub fn prompt(&self) -> Result<String, InputError> {
+        if let Some(value) =
+            crate::responder::intercept_text(crate::PromptKind::Editor, &self.message)?
+        {
+            return Ok(value);
+        }
         let matches = crate::collector::empty_matches();
         if !self.is_available(matches) {
             return Err(InputError::NoInput);

--- a/crates/standout-input/src/sources/inquire_adapters.rs
+++ b/crates/standout-input/src/sources/inquire_adapters.rs
@@ -800,4 +800,132 @@ mod tests {
         assert_eq!(source.name(), "editor");
         assert!(source.can_retry());
     }
+
+    // === .prompt() via PromptResponder ===
+    //
+    // Inquire sources can't be unit-tested with a real terminal in CI, but
+    // an installed PromptResponder short-circuits each .prompt() before any
+    // raw-mode work happens. These tests cover the prompt() shortcut
+    // end-to-end via the scripted responder. They share one #[serial] axis
+    // (`prompt_responder`) because the override is process-global.
+
+    use crate::{
+        reset_default_prompt_responder, set_default_prompt_responder, PromptResponse,
+        ScriptedResponder,
+    };
+    use serial_test::serial;
+    use std::sync::Arc;
+
+    /// RAII guard so a panicking test still resets the global responder.
+    struct ResponderGuard;
+    impl ResponderGuard {
+        fn install(responder: ScriptedResponder) -> Self {
+            set_default_prompt_responder(Arc::new(responder));
+            Self
+        }
+    }
+    impl Drop for ResponderGuard {
+        fn drop(&mut self) {
+            reset_default_prompt_responder();
+        }
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn inquire_text_prompt_via_responder() {
+        let _g = ResponderGuard::install(ScriptedResponder::new([PromptResponse::text("Bob")]));
+        let value = InquireText::new("Name?").prompt().unwrap();
+        assert_eq!(value, "Bob");
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn inquire_text_prompt_cancel_via_responder() {
+        let _g = ResponderGuard::install(ScriptedResponder::new([PromptResponse::Cancel]));
+        let err = InquireText::new("Name?").prompt().unwrap_err();
+        assert!(matches!(err, InputError::PromptCancelled));
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn inquire_text_prompt_skip_via_responder() {
+        let _g = ResponderGuard::install(ScriptedResponder::new([PromptResponse::Skip]));
+        let err = InquireText::new("Name?").prompt().unwrap_err();
+        assert!(matches!(err, InputError::NoInput));
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn inquire_confirm_prompt_via_responder() {
+        let _g = ResponderGuard::install(ScriptedResponder::new([
+            PromptResponse::Bool(true),
+            PromptResponse::Bool(false),
+        ]));
+        assert!(InquireConfirm::new("Yes?").prompt().unwrap());
+        assert!(!InquireConfirm::new("Yes?").prompt().unwrap());
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn inquire_select_prompt_via_responder_returns_typed_value() {
+        let _g = ResponderGuard::install(ScriptedResponder::new([PromptResponse::Choice(2)]));
+        let env: &'static str = InquireSelect::new("Env:", vec!["dev", "staging", "prod"])
+            .prompt()
+            .unwrap();
+        assert_eq!(env, "prod");
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn inquire_select_prompt_cancel_via_responder() {
+        let _g = ResponderGuard::install(ScriptedResponder::new([PromptResponse::Cancel]));
+        let err = InquireSelect::new("Env:", vec!["dev", "prod"])
+            .prompt()
+            .unwrap_err();
+        assert!(matches!(err, InputError::PromptCancelled));
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn inquire_multiselect_prompt_via_responder_returns_typed_values() {
+        let _g = ResponderGuard::install(ScriptedResponder::new([PromptResponse::choices([0, 2])]));
+        let picks: Vec<&'static str> = InquireMultiSelect::new("Pick:", vec!["a", "b", "c", "d"])
+            .prompt()
+            .unwrap();
+        assert_eq!(picks, vec!["a", "c"]);
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn inquire_password_prompt_via_responder() {
+        let _g = ResponderGuard::install(ScriptedResponder::new([PromptResponse::text("hunter2")]));
+        let value = InquirePassword::new("Pwd:").prompt().unwrap();
+        assert_eq!(value, "hunter2");
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn inquire_editor_prompt_via_responder() {
+        let _g = ResponderGuard::install(ScriptedResponder::new([PromptResponse::text(
+            "edited content",
+        )]));
+        let value = InquireEditor::new("Notes:").prompt().unwrap();
+        assert_eq!(value, "edited content");
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn responder_advances_through_multi_step_wizard() {
+        let _g = ResponderGuard::install(ScriptedResponder::new([
+            PromptResponse::text("foo"),
+            PromptResponse::Bool(true),
+            PromptResponse::Choice(1),
+        ]));
+        assert_eq!(InquireText::new("Name:").prompt().unwrap(), "foo");
+        assert!(InquireConfirm::new("OK?").prompt().unwrap());
+        let env: &'static str = InquireSelect::new("Env:", vec!["dev", "prod"])
+            .prompt()
+            .unwrap();
+        assert_eq!(env, "prod");
+    }
 }

--- a/crates/standout-input/src/sources/inquire_adapters.rs
+++ b/crates/standout-input/src/sources/inquire_adapters.rs
@@ -76,6 +76,17 @@ impl InquireText {
         self.help_message = Some(help.into());
         self
     }
+
+    /// Show the prompt and return the entered value.
+    ///
+    /// Standalone counterpart to [`InputCollector::collect`] for wizard /
+    /// REPL flows that drive standout themselves and have no `&ArgMatches`
+    /// to plumb through. Returns [`InputError::PromptCancelled`] on Esc /
+    /// Ctrl+C, and [`InputError::NoInput`] if the user submits empty input.
+    pub fn prompt(&self) -> Result<String, InputError> {
+        self.collect(crate::collector::empty_matches())?
+            .ok_or(InputError::NoInput)
+    }
 }
 
 impl InputCollector<String> for InquireText {
@@ -154,6 +165,16 @@ impl InquireConfirm {
         self.help_message = Some(help.into());
         self
     }
+
+    /// Show the prompt and return the user's yes/no answer.
+    ///
+    /// Standalone counterpart to [`InputCollector::collect`] for wizard /
+    /// REPL flows that drive standout themselves. Returns
+    /// [`InputError::PromptCancelled`] on Esc / Ctrl+C.
+    pub fn prompt(&self) -> Result<bool, InputError> {
+        self.collect(crate::collector::empty_matches())?
+            .ok_or(InputError::NoInput)
+    }
 }
 
 impl InputCollector<bool> for InquireConfirm {
@@ -228,6 +249,17 @@ impl<T: Display + Clone + Send + Sync + 'static> InquireSelect<T> {
     pub fn page_size(mut self, size: usize) -> Self {
         self.page_size = size;
         self
+    }
+
+    /// Show the selection prompt and return the chosen option.
+    ///
+    /// Standalone counterpart to [`InputCollector::collect`] for wizard /
+    /// REPL flows that drive standout themselves. Returns
+    /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
+    /// [`InputError::NoInput`] if the option list is empty.
+    pub fn prompt(&self) -> Result<T, InputError> {
+        self.collect(crate::collector::empty_matches())?
+            .ok_or(InputError::NoInput)
     }
 }
 
@@ -321,6 +353,17 @@ impl<T: Display + Clone + Send + Sync + 'static> InquireMultiSelect<T> {
     pub fn max_selections(mut self, max: usize) -> Self {
         self.max_selections = Some(max);
         self
+    }
+
+    /// Show the multi-selection prompt and return the chosen options.
+    ///
+    /// Standalone counterpart to [`InputCollector::collect`] for wizard /
+    /// REPL flows that drive standout themselves. Returns
+    /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
+    /// [`InputError::NoInput`] if the option list is empty.
+    pub fn prompt(&self) -> Result<Vec<T>, InputError> {
+        self.collect(crate::collector::empty_matches())?
+            .ok_or(InputError::NoInput)
     }
 }
 
@@ -439,6 +482,17 @@ impl InquirePassword {
         self.confirmation = Some(message.into());
         self
     }
+
+    /// Show the password prompt and return the entered value.
+    ///
+    /// Standalone counterpart to [`InputCollector::collect`] for wizard /
+    /// REPL flows that drive standout themselves. Returns
+    /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
+    /// [`InputError::NoInput`] if the user submits empty input.
+    pub fn prompt(&self) -> Result<String, InputError> {
+        self.collect(crate::collector::empty_matches())?
+            .ok_or(InputError::NoInput)
+    }
 }
 
 impl InputCollector<String> for InquirePassword {
@@ -531,6 +585,17 @@ impl InquireEditor {
     pub fn render_config(mut self, config: RenderConfig<'static>) -> Self {
         self.render_config = Some(config);
         self
+    }
+
+    /// Show the editor prompt (press 'e' to open) and return the saved text.
+    ///
+    /// Standalone counterpart to [`InputCollector::collect`] for wizard /
+    /// REPL flows that drive standout themselves. Returns
+    /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
+    /// [`InputError::NoInput`] if the user submits empty content.
+    pub fn prompt(&self) -> Result<String, InputError> {
+        self.collect(crate::collector::empty_matches())?
+            .ok_or(InputError::NoInput)
     }
 }
 

--- a/crates/standout-input/src/sources/inquire_adapters.rs
+++ b/crates/standout-input/src/sources/inquire_adapters.rs
@@ -82,10 +82,14 @@ impl InquireText {
     /// Standalone counterpart to [`InputCollector::collect`] for wizard /
     /// REPL flows that drive standout themselves and have no `&ArgMatches`
     /// to plumb through. Returns [`InputError::PromptCancelled`] on Esc /
-    /// Ctrl+C, and [`InputError::NoInput`] if the user submits empty input.
+    /// Ctrl+C, and [`InputError::NoInput`] if stdin is not a TTY or the
+    /// user submits empty input.
     pub fn prompt(&self) -> Result<String, InputError> {
-        self.collect(crate::collector::empty_matches())?
-            .ok_or(InputError::NoInput)
+        let matches = crate::collector::empty_matches();
+        if !self.is_available(matches) {
+            return Err(InputError::NoInput);
+        }
+        self.collect(matches)?.ok_or(InputError::NoInput)
     }
 }
 
@@ -170,10 +174,14 @@ impl InquireConfirm {
     ///
     /// Standalone counterpart to [`InputCollector::collect`] for wizard /
     /// REPL flows that drive standout themselves. Returns
-    /// [`InputError::PromptCancelled`] on Esc / Ctrl+C.
+    /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
+    /// [`InputError::NoInput`] if stdin is not a TTY.
     pub fn prompt(&self) -> Result<bool, InputError> {
-        self.collect(crate::collector::empty_matches())?
-            .ok_or(InputError::NoInput)
+        let matches = crate::collector::empty_matches();
+        if !self.is_available(matches) {
+            return Err(InputError::NoInput);
+        }
+        self.collect(matches)?.ok_or(InputError::NoInput)
     }
 }
 
@@ -256,10 +264,14 @@ impl<T: Display + Clone + Send + Sync + 'static> InquireSelect<T> {
     /// Standalone counterpart to [`InputCollector::collect`] for wizard /
     /// REPL flows that drive standout themselves. Returns
     /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
-    /// [`InputError::NoInput`] if the option list is empty.
+    /// [`InputError::NoInput`] if stdin is not a TTY or the option list
+    /// is empty.
     pub fn prompt(&self) -> Result<T, InputError> {
-        self.collect(crate::collector::empty_matches())?
-            .ok_or(InputError::NoInput)
+        let matches = crate::collector::empty_matches();
+        if !self.is_available(matches) {
+            return Err(InputError::NoInput);
+        }
+        self.collect(matches)?.ok_or(InputError::NoInput)
     }
 }
 
@@ -360,10 +372,14 @@ impl<T: Display + Clone + Send + Sync + 'static> InquireMultiSelect<T> {
     /// Standalone counterpart to [`InputCollector::collect`] for wizard /
     /// REPL flows that drive standout themselves. Returns
     /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
-    /// [`InputError::NoInput`] if the option list is empty.
+    /// [`InputError::NoInput`] if stdin is not a TTY or the option list
+    /// is empty.
     pub fn prompt(&self) -> Result<Vec<T>, InputError> {
-        self.collect(crate::collector::empty_matches())?
-            .ok_or(InputError::NoInput)
+        let matches = crate::collector::empty_matches();
+        if !self.is_available(matches) {
+            return Err(InputError::NoInput);
+        }
+        self.collect(matches)?.ok_or(InputError::NoInput)
     }
 }
 
@@ -488,10 +504,14 @@ impl InquirePassword {
     /// Standalone counterpart to [`InputCollector::collect`] for wizard /
     /// REPL flows that drive standout themselves. Returns
     /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
-    /// [`InputError::NoInput`] if the user submits empty input.
+    /// [`InputError::NoInput`] if stdin is not a TTY or the user submits
+    /// empty input.
     pub fn prompt(&self) -> Result<String, InputError> {
-        self.collect(crate::collector::empty_matches())?
-            .ok_or(InputError::NoInput)
+        let matches = crate::collector::empty_matches();
+        if !self.is_available(matches) {
+            return Err(InputError::NoInput);
+        }
+        self.collect(matches)?.ok_or(InputError::NoInput)
     }
 }
 
@@ -592,10 +612,14 @@ impl InquireEditor {
     /// Standalone counterpart to [`InputCollector::collect`] for wizard /
     /// REPL flows that drive standout themselves. Returns
     /// [`InputError::PromptCancelled`] on Esc / Ctrl+C, and
-    /// [`InputError::NoInput`] if the user submits empty content.
+    /// [`InputError::NoInput`] if stdin is not a TTY or the user submits
+    /// empty content.
     pub fn prompt(&self) -> Result<String, InputError> {
-        self.collect(crate::collector::empty_matches())?
-            .ok_or(InputError::NoInput)
+        let matches = crate::collector::empty_matches();
+        if !self.is_available(matches) {
+            return Err(InputError::NoInput);
+        }
+        self.collect(matches)?.ok_or(InputError::NoInput)
     }
 }
 

--- a/crates/standout-input/src/sources/prompt.rs
+++ b/crates/standout-input/src/sources/prompt.rs
@@ -627,4 +627,46 @@ mod tests {
         let value = source.prompt().unwrap();
         assert!(value);
     }
+
+    // === .prompt() via PromptResponder ===
+
+    use crate::{
+        reset_default_prompt_responder, set_default_prompt_responder, PromptResponse,
+        ScriptedResponder,
+    };
+    use serial_test::serial;
+    use std::sync::Arc;
+
+    struct ResponderGuard;
+    impl ResponderGuard {
+        fn install(responder: ScriptedResponder) -> Self {
+            set_default_prompt_responder(Arc::new(responder));
+            Self
+        }
+    }
+    impl Drop for ResponderGuard {
+        fn drop(&mut self) {
+            reset_default_prompt_responder();
+        }
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn text_prompt_routes_through_responder_even_without_tty() {
+        // The non-terminal MockTerminal would normally return NoInput from
+        // prompt(); the responder gate runs *first*, so the responder wins.
+        let _g = ResponderGuard::install(ScriptedResponder::new([PromptResponse::text("Ada")]));
+        let source = TextPromptSource::with_terminal("Name: ", MockTerminal::non_terminal());
+        let value = source.prompt().unwrap();
+        assert_eq!(value, "Ada");
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn confirm_prompt_routes_through_responder() {
+        let _g = ResponderGuard::install(ScriptedResponder::new([PromptResponse::Bool(false)]));
+        let source = ConfirmPromptSource::with_terminal("OK?", MockTerminal::non_terminal());
+        let value = source.prompt().unwrap();
+        assert!(!value);
+    }
 }

--- a/crates/standout-input/src/sources/prompt.rs
+++ b/crates/standout-input/src/sources/prompt.rs
@@ -102,7 +102,9 @@ impl<T: TerminalIO + 'static> TextPromptSource<T> {
     ///
     /// Standalone counterpart to [`InputCollector::collect`] for wizard /
     /// REPL flows that drive standout themselves and have no `&ArgMatches`
-    /// to plumb through. Returns the entered text on success.
+    /// to plumb through. Returns the entered text on success. Routes
+    /// through any installed
+    /// [`PromptResponder`](crate::PromptResponder).
     ///
     /// Errors:
     /// - [`InputError::PromptCancelled`] on EOF (Ctrl+D)
@@ -110,6 +112,11 @@ impl<T: TerminalIO + 'static> TextPromptSource<T> {
     ///   submits empty input
     /// - [`InputError::PromptFailed`] on terminal I/O failure
     pub fn prompt(&self) -> Result<String, InputError> {
+        if let Some(value) =
+            crate::responder::intercept_text(crate::PromptKind::Text, &self.prompt)?
+        {
+            return Ok(value);
+        }
         let matches = crate::collector::empty_matches();
         if !self.is_available(matches) {
             return Err(InputError::NoInput);
@@ -227,7 +234,8 @@ impl<T: TerminalIO + 'static> ConfirmPromptSource<T> {
     ///
     /// Standalone counterpart to [`InputCollector::collect`] for wizard /
     /// REPL flows that drive standout themselves and have no `&ArgMatches`
-    /// to plumb through.
+    /// to plumb through. Routes through any installed
+    /// [`PromptResponder`](crate::PromptResponder).
     ///
     /// Errors:
     /// - [`InputError::PromptCancelled`] on EOF (Ctrl+D)
@@ -237,6 +245,11 @@ impl<T: TerminalIO + 'static> ConfirmPromptSource<T> {
     ///   that isn't a y/yes/n/no variant
     /// - [`InputError::PromptFailed`] on terminal I/O failure
     pub fn prompt(&self) -> Result<bool, InputError> {
+        if let Some(value) =
+            crate::responder::intercept_bool(crate::PromptKind::Confirm, &self.prompt)?
+        {
+            return Ok(value);
+        }
         let matches = crate::collector::empty_matches();
         if !self.is_available(matches) {
             return Err(InputError::NoInput);

--- a/crates/standout-input/src/sources/prompt.rs
+++ b/crates/standout-input/src/sources/prompt.rs
@@ -106,11 +106,15 @@ impl<T: TerminalIO + 'static> TextPromptSource<T> {
     ///
     /// Errors:
     /// - [`InputError::PromptCancelled`] on EOF (Ctrl+D)
-    /// - [`InputError::NoInput`] if the user submits empty input
+    /// - [`InputError::NoInput`] if stdin is not a TTY *or* the user
+    ///   submits empty input
     /// - [`InputError::PromptFailed`] on terminal I/O failure
     pub fn prompt(&self) -> Result<String, InputError> {
-        self.collect(crate::collector::empty_matches())?
-            .ok_or(InputError::NoInput)
+        let matches = crate::collector::empty_matches();
+        if !self.is_available(matches) {
+            return Err(InputError::NoInput);
+        }
+        self.collect(matches)?.ok_or(InputError::NoInput)
     }
 }
 
@@ -227,11 +231,17 @@ impl<T: TerminalIO + 'static> ConfirmPromptSource<T> {
     ///
     /// Errors:
     /// - [`InputError::PromptCancelled`] on EOF (Ctrl+D)
-    /// - [`InputError::NoInput`] if the prompt source declines (e.g. no TTY)
+    /// - [`InputError::NoInput`] if stdin is not a TTY, *or* if the user
+    ///   submits an empty line and no [`default`](Self::default) was set
+    /// - [`InputError::ValidationFailed`] if the user enters something
+    ///   that isn't a y/yes/n/no variant
     /// - [`InputError::PromptFailed`] on terminal I/O failure
     pub fn prompt(&self) -> Result<bool, InputError> {
-        self.collect(crate::collector::empty_matches())?
-            .ok_or(InputError::NoInput)
+        let matches = crate::collector::empty_matches();
+        if !self.is_available(matches) {
+            return Err(InputError::NoInput);
+        }
+        self.collect(matches)?.ok_or(InputError::NoInput)
     }
 }
 

--- a/crates/standout-input/src/sources/prompt.rs
+++ b/crates/standout-input/src/sources/prompt.rs
@@ -97,6 +97,23 @@ impl<T: TerminalIO> TextPromptSource<T> {
     }
 }
 
+impl<T: TerminalIO + 'static> TextPromptSource<T> {
+    /// Prompt the user for text and return the entered value.
+    ///
+    /// Standalone counterpart to [`InputCollector::collect`] for wizard /
+    /// REPL flows that drive standout themselves and have no `&ArgMatches`
+    /// to plumb through. Returns the entered text on success.
+    ///
+    /// Errors:
+    /// - [`InputError::PromptCancelled`] on EOF (Ctrl+D)
+    /// - [`InputError::NoInput`] if the user submits empty input
+    /// - [`InputError::PromptFailed`] on terminal I/O failure
+    pub fn prompt(&self) -> Result<String, InputError> {
+        self.collect(crate::collector::empty_matches())?
+            .ok_or(InputError::NoInput)
+    }
+}
+
 impl<T: TerminalIO + 'static> InputCollector<String> for TextPromptSource<T> {
     fn name(&self) -> &'static str {
         "prompt"
@@ -198,6 +215,23 @@ impl<T: TerminalIO> ConfirmPromptSource<T> {
     pub fn default(mut self, default: bool) -> Self {
         self.default = Some(default);
         self
+    }
+}
+
+impl<T: TerminalIO + 'static> ConfirmPromptSource<T> {
+    /// Prompt the user for a yes/no answer and return the resolved boolean.
+    ///
+    /// Standalone counterpart to [`InputCollector::collect`] for wizard /
+    /// REPL flows that drive standout themselves and have no `&ArgMatches`
+    /// to plumb through.
+    ///
+    /// Errors:
+    /// - [`InputError::PromptCancelled`] on EOF (Ctrl+D)
+    /// - [`InputError::NoInput`] if the prompt source declines (e.g. no TTY)
+    /// - [`InputError::PromptFailed`] on terminal I/O failure
+    pub fn prompt(&self) -> Result<bool, InputError> {
+        self.collect(crate::collector::empty_matches())?
+            .ok_or(InputError::NoInput)
     }
 }
 

--- a/crates/standout-input/src/sources/prompt.rs
+++ b/crates/standout-input/src/sources/prompt.rs
@@ -547,4 +547,61 @@ mod tests {
             ConfirmPromptSource::with_terminal("Proceed?", MockTerminal::with_response("y"));
         assert!(source.can_retry());
     }
+
+    // === .prompt() shortcut ===
+
+    #[test]
+    fn text_prompt_shortcut_returns_value() {
+        let source =
+            TextPromptSource::with_terminal("Name: ", MockTerminal::with_response("Carol"));
+        let value = source.prompt().unwrap();
+        assert_eq!(value, "Carol");
+    }
+
+    #[test]
+    fn text_prompt_shortcut_maps_empty_to_no_input() {
+        let source = TextPromptSource::with_terminal("Name: ", MockTerminal::with_response("   "));
+        let err = source.prompt().unwrap_err();
+        assert!(matches!(err, InputError::NoInput));
+    }
+
+    #[test]
+    fn text_prompt_shortcut_propagates_cancel() {
+        let source = TextPromptSource::with_terminal("Name: ", MockTerminal::eof());
+        let err = source.prompt().unwrap_err();
+        assert!(matches!(err, InputError::PromptCancelled));
+    }
+
+    #[test]
+    fn text_prompt_shortcut_skips_when_not_terminal() {
+        // .prompt() should still surface NoInput when the underlying source
+        // declines (e.g. no TTY) — the wizard caller can decide what to do.
+        let source = TextPromptSource::with_terminal("Name: ", MockTerminal::non_terminal());
+        let err = source.prompt().unwrap_err();
+        assert!(matches!(err, InputError::NoInput));
+    }
+
+    #[test]
+    fn confirm_prompt_shortcut_returns_value() {
+        let source =
+            ConfirmPromptSource::with_terminal("Proceed?", MockTerminal::with_response("y"));
+        let value = source.prompt().unwrap();
+        assert!(value);
+    }
+
+    #[test]
+    fn confirm_prompt_shortcut_propagates_cancel() {
+        let source = ConfirmPromptSource::with_terminal("Proceed?", MockTerminal::eof());
+        let err = source.prompt().unwrap_err();
+        assert!(matches!(err, InputError::PromptCancelled));
+    }
+
+    #[test]
+    fn confirm_prompt_shortcut_uses_default_on_empty() {
+        let source =
+            ConfirmPromptSource::with_terminal("Proceed?", MockTerminal::with_response(""))
+                .default(true);
+        let value = source.prompt().unwrap();
+        assert!(value);
+    }
 }

--- a/crates/standout-test/src/lib.rs
+++ b/crates/standout-test/src/lib.rs
@@ -50,8 +50,9 @@ use clap::Command;
 use standout::cli::{App, RunResult};
 use standout_input::env::{MockClipboard, MockStdin};
 use standout_input::{
-    reset_default_clipboard_reader, reset_default_stdin_reader, set_default_clipboard_reader,
-    set_default_stdin_reader,
+    reset_default_clipboard_reader, reset_default_prompt_responder, reset_default_stdin_reader,
+    set_default_clipboard_reader, set_default_prompt_responder, set_default_stdin_reader,
+    PromptResponder,
 };
 use standout_render::{
     reset_environment_detectors, set_color_capability_detector, set_terminal_width_detector,
@@ -91,6 +92,7 @@ pub struct TestHarness {
     output_flag_name: String,
     stdin: StdinMode,
     clipboard: Option<String>,
+    prompts: Option<Arc<dyn PromptResponder>>,
 }
 
 impl TestHarness {
@@ -109,6 +111,7 @@ impl TestHarness {
             output_flag_name: "output".to_string(),
             stdin: StdinMode::Inherit,
             clipboard: None,
+            prompts: None,
         }
     }
 
@@ -220,6 +223,40 @@ impl TestHarness {
     /// `ClipboardSource::new()` will read it.
     pub fn clipboard(mut self, content: impl Into<String>) -> Self {
         self.clipboard = Some(content.into());
+        self
+    }
+
+    // --- interactive prompts --------------------------------------------------
+
+    /// Installs a [`PromptResponder`](standout_input::PromptResponder) that
+    /// every `.prompt()` call on a [`standout_input`] interactive source
+    /// will route through during the run.
+    ///
+    /// Use this to test wizard / setup / REPL flows that call
+    /// `InquireText::new(...).prompt()`, `InquireSelect::new(...).prompt()`,
+    /// etc., without launching real prompts. The
+    /// [`ScriptedResponder`](standout_input::ScriptedResponder) bundled with
+    /// `standout-input` covers the common case:
+    ///
+    /// ```ignore
+    /// use standout_input::{PromptResponse, ScriptedResponder};
+    /// use std::sync::Arc;
+    ///
+    /// let result = TestHarness::new()
+    ///     .prompts(Arc::new(ScriptedResponder::new([
+    ///         PromptResponse::text("buy milk"),       // first text prompt
+    ///         PromptResponse::Bool(true),             // first confirm
+    ///         PromptResponse::Choice(2),              // first select -> options[2]
+    ///     ])))
+    ///     .run(&app, cmd, ["mycli", "setup"]);
+    /// ```
+    ///
+    /// The responder is installed via
+    /// [`set_default_prompt_responder`](standout_input::set_default_prompt_responder)
+    /// for the duration of the run and reset on drop, matching the
+    /// stdin / clipboard pattern.
+    pub fn prompts(mut self, responder: Arc<dyn PromptResponder>) -> Self {
+        self.prompts = Some(responder);
         self
     }
 
@@ -394,6 +431,10 @@ impl TestHarness {
             set_default_clipboard_reader(Arc::new(MockClipboard::with_content(content)));
             restore.reset_clipboard = true;
         }
+        if let Some(responder) = self.prompts.take() {
+            set_default_prompt_responder(responder);
+            restore.reset_prompts = true;
+        }
 
         // 5. Argv: append --<flag>=<mode> if an output mode was forced.
         let mut argv: Vec<OsString> = args.into_iter().map(|a| a.into()).collect();
@@ -470,6 +511,7 @@ struct RestoreState {
     reset_env_detectors: bool,
     reset_stdin: bool,
     reset_clipboard: bool,
+    reset_prompts: bool,
 }
 
 impl Drop for RestoreState {
@@ -491,6 +533,9 @@ impl Drop for RestoreState {
         }
         if self.reset_clipboard {
             reset_default_clipboard_reader();
+        }
+        if self.reset_prompts {
+            reset_default_prompt_responder();
         }
     }
 }

--- a/crates/standout-test/tests/harness.rs
+++ b/crates/standout-test/tests/harness.rs
@@ -190,6 +190,127 @@ fn clipboard_reaches_handler() {
     result.assert_stdout_eq("clipboard-content");
 }
 
+/// Drives a tiny three-step "wizard" handler from the harness, scripting
+/// every response. The handler talks to the simple-prompt sources via
+/// `.prompt()`; the responder intercepts each call before any TTY is touched.
+#[test]
+#[serial]
+fn scripted_prompts_drive_a_wizard_handler() {
+    use standout_input::{
+        ConfirmPromptSource, PromptResponse, ScriptedResponder, TextPromptSource,
+    };
+    use std::sync::Arc;
+
+    let app = App::builder()
+        .command(
+            "wizard",
+            |_m, _ctx| {
+                let name = TextPromptSource::new("Name: ").prompt().unwrap();
+                let proceed = ConfirmPromptSource::new("Continue? ").prompt().unwrap();
+                let title = TextPromptSource::new("Title: ").prompt().unwrap();
+                Ok(Output::Render(json!({
+                    "name": name,
+                    "proceed": proceed,
+                    "title": title,
+                })))
+            },
+            "{{ name }}/{{ proceed }}/{{ title }}",
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let cmd = Command::new("app").subcommand(Command::new("wizard"));
+    let responder = Arc::new(ScriptedResponder::new([
+        PromptResponse::text("Ada"),
+        PromptResponse::Bool(true),
+        PromptResponse::text("Engineer"),
+    ]));
+
+    let result = TestHarness::new()
+        .prompts(responder)
+        .run(&app, cmd, vec!["app", "wizard"]);
+
+    result.assert_stdout_eq("Ada/true/Engineer");
+}
+
+/// Scripted Cancel surfaces as PromptCancelled inside the handler — the
+/// handler propagates it however it wants (here, a fixed "cancelled" body).
+#[test]
+#[serial]
+fn scripted_cancel_propagates_to_handler() {
+    use standout_input::{PromptResponse, ScriptedResponder, TextPromptSource};
+    use std::sync::Arc;
+
+    let app = App::builder()
+        .command(
+            "wizard",
+            |_m, _ctx| {
+                let body = match TextPromptSource::new("Name: ").prompt() {
+                    Ok(name) => format!("ok:{name}"),
+                    Err(e) => format!("err:{e}"),
+                };
+                Ok(Output::Render(json!({ "body": body })))
+            },
+            "{{ body }}",
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let cmd = Command::new("app").subcommand(Command::new("wizard"));
+    let responder = Arc::new(ScriptedResponder::new([PromptResponse::Cancel]));
+
+    let result = TestHarness::new()
+        .prompts(responder)
+        .run(&app, cmd, vec!["app", "wizard"]);
+
+    result.assert_stdout_contains("err:");
+    result.assert_stdout_contains("cancelled");
+}
+
+/// Confirms the responder is reset on `TestResult` drop — a second harness
+/// run with no `.prompts(...)` falls back to the real backend (which under
+/// `cargo test` means no TTY, so prompt() returns NoInput).
+#[test]
+#[serial]
+fn responder_is_reset_between_runs() {
+    use standout_input::{PromptResponse, ScriptedResponder, TextPromptSource};
+    use std::sync::Arc;
+
+    let app = App::builder()
+        .command(
+            "wizard",
+            |_m, _ctx| {
+                let body = match TextPromptSource::new("Name: ").prompt() {
+                    Ok(name) => format!("ok:{name}"),
+                    Err(e) => format!("err:{e}"),
+                };
+                Ok(Output::Render(json!({ "body": body })))
+            },
+            "{{ body }}",
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+    let cmd = Command::new("app").subcommand(Command::new("wizard"));
+
+    // First run: scripted responder, gets the value.
+    let first = TestHarness::new()
+        .prompts(Arc::new(ScriptedResponder::new([PromptResponse::text(
+            "Ada",
+        )])))
+        .run(&app, cmd.clone(), vec!["app", "wizard"]);
+    first.assert_stdout_eq("ok:Ada");
+    drop(first); // ensure restore runs before the next harness builds
+
+    // Second run: no .prompts(...). The responder should be cleared, so
+    // prompt() falls through to TextPromptSource's no-TTY path and returns
+    // NoInput.
+    let second = TestHarness::new().run(&app, cmd, vec!["app", "wizard"]);
+    second.assert_stdout_contains("err:");
+}
+
 #[test]
 #[serial]
 fn fixture_files_are_materialized_in_cwd() {

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -38,6 +38,7 @@
 - [Input Sources](./crates/input/topics/input-sources.md)
 - [Backends](./crates/input/topics/backends.md)
 - [Framework Integration](./crates/input/topics/framework-integration.md)
+- [Interactive Flows](./crates/input/topics/interactive-flows.md)
 
 ---
 

--- a/docs/guides/intro-to-testing.md
+++ b/docs/guides/intro-to-testing.md
@@ -249,7 +249,32 @@ Same story for the system clipboard:
 
 `ClipboardSource::new()` returns the mock content; no shelling out to `pbpaste` / `xclip`.
 
-### 4.5 Terminal state
+### 4.5 Interactive prompts (wizards)
+
+Apps that drive their own interactive shell — wizards, setup helpers, REPLs — call `InquireText::new(...).prompt()`, `InquireSelect::new(...).prompt()`, etc. Without a seam those calls need a real TTY and become level-3 territory. With `.prompts(...)`, the harness intercepts every prompt at the boundary so a wizard handler is fully testable in process:
+
+```rust
+use standout_input::{PromptResponse, ScriptedResponder};
+use std::sync::Arc;
+
+#[test]
+#[serial]
+fn setup_wizard_completes_with_scripted_answers() {
+    let result = TestHarness::new()
+        .prompts(Arc::new(ScriptedResponder::new([
+            PromptResponse::text("foo"),     // pack name
+            PromptResponse::Bool(true),      // confirm
+            PromptResponse::Choice(2),       // env -> options[2]
+        ])))
+        .run(&app, cmd, ["mycli", "setup"]);
+
+    result.assert_stdout_contains("created pack `foo`");
+}
+```
+
+Open prompts (`Text`/`Password`/`Editor`) take `PromptResponse::Text(...)`; finite-choice prompts (`Confirm`/`Select`/`MultiSelect`) take a `Bool`/`Choice(usize)`/`Choices(Vec<usize>)`. Position-based responses make tests resilient to copy changes: `Choice(2)` keeps working when "Production" is renamed to "Live". `ScriptedResponder` panics on kind mismatch, so a wizard-step reorder fails loudly. See [Interactive Flows → Testing Wizards](../crates/input/topics/interactive-flows.md#testing-wizards) for the full pattern.
+
+### 4.6 Terminal state
 
 Three orthogonal knobs, all routed through Phase 1's environment detectors:
 
@@ -263,7 +288,7 @@ Three orthogonal knobs, all routed through Phase 1's environment detectors:
 
 Useful for snapshot testing: pin the width, turn off color, and the rendered string is deterministic across developer machines and CI.
 
-### 4.6 Forcing an output mode
+### 4.7 Forcing an output mode
 
 Sometimes you want to assert on structured output regardless of what the user's `--output` flag would have chosen. Instead of manually appending `--output=json` to argv:
 
@@ -447,6 +472,13 @@ TestHarness::new()
 
     // clipboard (same)
     .clipboard("content")
+
+    // interactive prompts (routed through standout-input's PromptResponder)
+    .prompts(Arc::new(ScriptedResponder::new([
+        PromptResponse::text("answer"),
+        PromptResponse::Bool(true),
+        PromptResponse::Choice(2),     // -> options[2]
+    ])))
 
     // execute
     .run(&app, cmd, ["binname", "subcommand", "--flag"])

--- a/docs/topics/testing.md
+++ b/docs/topics/testing.md
@@ -50,6 +50,7 @@ Argument parsing is clap's responsibility, and clap has an extensive test suite 
 - Terminal detectors: width, TTY, color capability
 - Stdin reader (process-global override consulted by `StdinSource::new()`)
 - Clipboard reader (same mechanism for `ClipboardSource::new()`)
+- Interactive prompt responder (process-global override consulted by every interactive source's `.prompt()` shortcut, so wizard handlers are testable in process — see [Interactive Flows → Testing Wizards](../crates/input/topics/interactive-flows.md#testing-wizards))
 - Forced `OutputMode` (injected as `--output=<mode>` into argv)
 
 A `RestoreState` held inside the returned `TestResult` runs on drop — on both normal exit and panic unwind — and tears down every override, so a failing assertion never leaks state into sibling tests. Two nuances worth knowing:
@@ -100,6 +101,28 @@ reset_default_stdin_reader();
 Handlers that use `StdinSource::new()` / `ClipboardSource::new()` / `read_if_piped()` pick up the mock transparently — no handler refactor needed.
 
 Handlers that need per-instance control keep using `StdinSource::with_reader(MockStdin::piped(...))` as before.
+
+### `standout-input` prompt responder
+
+The `.prompt()` shortcut on every interactive source (`InquireText`, `InquireSelect`, `TextPromptSource`, `EditorSource`, …) consults a process-global [`PromptResponder`](https://docs.rs/standout-input/latest/standout_input/trait.PromptResponder.html) before opening any real prompt. Install one to make wizard handlers testable in-process:
+
+```rust
+use std::sync::Arc;
+use standout_input::{
+    set_default_prompt_responder, reset_default_prompt_responder,
+    ScriptedResponder, PromptResponse,
+};
+
+set_default_prompt_responder(Arc::new(ScriptedResponder::new([
+    PromptResponse::text("buy milk"),
+    PromptResponse::Bool(true),
+    PromptResponse::Choice(2),       // -> options[2] for an InquireSelect
+])));
+// ... run test ...
+reset_default_prompt_responder();
+```
+
+Open prompts (`Text`/`Password`/`Editor`) take a `Text(String)`; finite-choice prompts (`Confirm`/`Select`/`MultiSelect`) take a `Bool` / `Choice(usize)` / `Choices(Vec<usize>)`. Position-based responses are deliberate: a test that picked `Choice(2)` keeps working when you rename `"Production"` to `"Live"`. `ScriptedResponder` panics on kind mismatch so a wizard reorder fails loudly. `PromptResponse::Cancel` and `PromptResponse::Skip` are kind-agnostic and let tests cover the abort and re-ask paths without real signal handling. See [Interactive Flows](../crates/input/topics/interactive-flows.md) for the wizard-shape walkthrough and `TestHarness::prompts(...)` for the harness-level wiring.
 
 ### Env vars and cwd
 

--- a/docs/topics/testing.md
+++ b/docs/topics/testing.md
@@ -106,21 +106,35 @@ Handlers that need per-instance control keep using `StdinSource::with_reader(Moc
 
 The `.prompt()` shortcut on every interactive source (`InquireText`, `InquireSelect`, `TextPromptSource`, `EditorSource`, …) consults a process-global [`PromptResponder`](https://docs.rs/standout-input/latest/standout_input/trait.PromptResponder.html) before opening any real prompt. Install one to make wizard handlers testable in-process:
 
+The override is process-global, so tests installing it directly must (a) carry a `#[serial(prompt_responder)]` attribute and (b) reset on every exit path including panics — either via an RAII guard or by preferring the harness, which handles both:
+
 ```rust
 use std::sync::Arc;
+use serial_test::serial;
 use standout_input::{
     set_default_prompt_responder, reset_default_prompt_responder,
     ScriptedResponder, PromptResponse,
 };
 
-set_default_prompt_responder(Arc::new(ScriptedResponder::new([
-    PromptResponse::text("buy milk"),
-    PromptResponse::Bool(true),
-    PromptResponse::Choice(2),       // -> options[2] for an InquireSelect
-])));
-// ... run test ...
-reset_default_prompt_responder();
+struct ResponderGuard;
+impl Drop for ResponderGuard {
+    fn drop(&mut self) { reset_default_prompt_responder(); }
+}
+
+#[test]
+#[serial(prompt_responder)]
+fn pack_name_re_asks_on_invalid() {
+    set_default_prompt_responder(Arc::new(ScriptedResponder::new([
+        PromptResponse::text("BadName!"),  // rejected by validator
+        PromptResponse::text("good-name"), // accepted on re-ask
+    ])));
+    let _guard = ResponderGuard; // resets even if assertions panic
+
+    // ... call the wizard step under test, assert, etc ...
+}
 ```
+
+Most tests should reach for `TestHarness::prompts(...)` instead — the harness's `RestoreState` runs `reset_default_prompt_responder()` on drop just like it does for stdin and clipboard, so the boilerplate disappears.
 
 Open prompts (`Text`/`Password`/`Editor`) take a `Text(String)`; finite-choice prompts (`Confirm`/`Select`/`MultiSelect`) take a `Bool` / `Choice(usize)` / `Choices(Vec<usize>)`. Position-based responses are deliberate: a test that picked `Choice(2)` keeps working when you rename `"Production"` to `"Live"`. `ScriptedResponder` panics on kind mismatch so a wizard reorder fails loudly. `PromptResponse::Cancel` and `PromptResponse::Skip` are kind-agnostic and let tests cover the abort and re-ask paths without real signal handling. See [Interactive Flows](../crates/input/topics/interactive-flows.md) for the wizard-shape walkthrough and `TestHarness::prompts(...)` for the harness-level wiring.
 


### PR DESCRIPTION
## Summary

Adds the standalone `.prompt()` shortcut on every interactive `standout-input` source so apps that drive their own interactive shell — wizards, setup helpers, REPLs — can call prompts without the chain machinery or a `&clap::ArgMatches`. Pairs the API change with a new "Interactive Flows" topic page that walks through composing it with standout's `Renderer` to build a wizard.

This is the follow-up to the conversation about wizard-style apps where the user owns a small step-graph driver and wants to leverage standout for everything else (themed dynamic text + polished prompts).

## Before / after

```rust
// Before: had to fake a clap ArgMatches or bypass standout-input
let m = clap::Command::new("wizard").try_get_matches_from(["wizard"])?;
let pack = InquireText::new("Pack name:").collect(&m)?
    .ok_or(anyhow!("empty"))?;

// After
let pack = InquireText::new("Pack name:").help("a-z0-9-").prompt()?;
```

## What's in the diff

| Commit | What |
|---|---|
| `feat(standout-input): add empty_matches helper for one-shot prompts` | OnceLock-backed static `&'static ArgMatches` so `.prompt()` doesn't allocate per call. Feature-gated to compile only when at least one prompt-producing feature is enabled. |
| `feat(standout-input): add .prompt() shortcut on interactive sources` | Inherent `prompt() -> Result<T, InputError>` on `EditorSource`, `TextPromptSource`, `ConfirmPromptSource`, and the six `Inquire*` adapters. Pure delegation to existing `collect`; chain behavior untouched. |
| `test(standout-input): cover .prompt() shortcut on mockable sources` | 9 new unit tests on the sources with mock backends (Editor + simple-prompts). Verifies value mapping, `Ok(None) → InputError::NoInput`, `EOF → PromptCancelled`, `default()` honored on empty submission. |
| `docs(standout-input): show standalone .prompt() usage in intro guide` | New "Standalone Prompts (No Chain)" section in `intro-to-input.md` with a code sample and a table of every source that exposes `.prompt()`. |
| `docs(standout-input): add interactive-flows topic` | ~220-line topic walking through user-owned step graphs, per-step render/prompt/branch shape, re-ask loops, side-effect-driven branching, restart-with-serialized-`Ctx`, cliclack-style note framing via templates. Listed in `docs/SUMMARY.md`. |
| `chore(changelog): note .prompt() shortcut and interactive-flows guide` | `[Unreleased]` entry. |

## Test plan

- [x] `cargo test -p standout-input --all-features` — 110 unit + 18 integration tests pass (9 new)
- [x] `cargo build -p standout-input --no-default-features` — clean (helper is feature-gated)
- [x] `cargo build -p standout-input --all-features` — clean
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `mdbook build` — no warnings; new "Interactive Flows" page reachable in nav

## Out of scope

Inquire-backed sources can't be unit-tested without a real TTY, so they're tested by inspection — `prompt()` is pure delegation to existing `collect` paths covered by the chain tests. A `standout::flow` driver module is also out of scope (per earlier discussion: docs first, promote only if multiple apps end up copying the same 30-line driver verbatim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)