### PR TITLE
Fix flaky .prompt() shortcut tests by serializing on prompt_responder key

### DIFF
--- a/crates/standout-input/src/sources/editor.rs
+++ b/crates/standout-input/src/sources/editor.rs
@@ -488,8 +488,22 @@ mod tests {
     // The happy path with the mock runner is covered by the existing
     // editor_collects_content / editor_failure / editor_no_editor_error tests
     // on collect(), which prompt() delegates to once the TTY gate passes.
+    //
+    // Every test that calls .prompt() shares one #[serial] axis
+    // (`prompt_responder`) because the global responder override is
+    // process-wide; without serialization a responder installed by a
+    // parallel responder-using test would leak into these vanilla
+    // shortcut tests.
+
+    use crate::{
+        reset_default_prompt_responder, set_default_prompt_responder, PromptResponse,
+        ScriptedResponder,
+    };
+    use serial_test::serial;
+    use std::sync::Arc;
 
     #[test]
+    #[serial(prompt_responder)]
     fn editor_prompt_shortcut_returns_no_input_in_non_tty() {
         let source = EditorSource::with_runner(MockEditorRunner::with_result("hello"));
         let err = source.prompt().unwrap_err();
@@ -497,6 +511,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(prompt_responder)]
     fn editor_prompt_shortcut_no_input_when_no_editor_detected() {
         // No TTY *and* no editor — both fail is_available, so NoInput either way.
         let source = EditorSource::with_runner(MockEditorRunner::no_editor());
@@ -505,13 +520,6 @@ mod tests {
     }
 
     // === .prompt() via PromptResponder ===
-
-    use crate::{
-        reset_default_prompt_responder, set_default_prompt_responder, PromptResponse,
-        ScriptedResponder,
-    };
-    use serial_test::serial;
-    use std::sync::Arc;
 
     struct ResponderGuard;
     impl ResponderGuard {

--- a/crates/standout-input/src/sources/prompt.rs
+++ b/crates/standout-input/src/sources/prompt.rs
@@ -572,8 +572,22 @@ mod tests {
     }
 
     // === .prompt() shortcut ===
+    //
+    // Every test that calls .prompt() shares one #[serial] axis
+    // (`prompt_responder`) because the global responder override is
+    // process-wide; without serialization a responder installed by a
+    // parallel responder-using test would leak into these vanilla
+    // shortcut tests.
+
+    use crate::{
+        reset_default_prompt_responder, set_default_prompt_responder, PromptResponse,
+        ScriptedResponder,
+    };
+    use serial_test::serial;
+    use std::sync::Arc;
 
     #[test]
+    #[serial(prompt_responder)]
     fn text_prompt_shortcut_returns_value() {
         let source =
             TextPromptSource::with_terminal("Name: ", MockTerminal::with_response("Carol"));
@@ -582,6 +596,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(prompt_responder)]
     fn text_prompt_shortcut_maps_empty_to_no_input() {
         let source = TextPromptSource::with_terminal("Name: ", MockTerminal::with_response("   "));
         let err = source.prompt().unwrap_err();
@@ -589,6 +604,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(prompt_responder)]
     fn text_prompt_shortcut_propagates_cancel() {
         let source = TextPromptSource::with_terminal("Name: ", MockTerminal::eof());
         let err = source.prompt().unwrap_err();
@@ -596,6 +612,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(prompt_responder)]
     fn text_prompt_shortcut_skips_when_not_terminal() {
         // .prompt() should still surface NoInput when the underlying source
         // declines (e.g. no TTY) — the wizard caller can decide what to do.
@@ -605,6 +622,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(prompt_responder)]
     fn confirm_prompt_shortcut_returns_value() {
         let source =
             ConfirmPromptSource::with_terminal("Proceed?", MockTerminal::with_response("y"));
@@ -613,6 +631,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(prompt_responder)]
     fn confirm_prompt_shortcut_propagates_cancel() {
         let source = ConfirmPromptSource::with_terminal("Proceed?", MockTerminal::eof());
         let err = source.prompt().unwrap_err();
@@ -620,6 +639,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(prompt_responder)]
     fn confirm_prompt_shortcut_uses_default_on_empty() {
         let source =
             ConfirmPromptSource::with_terminal("Proceed?", MockTerminal::with_response(""))
@@ -629,13 +649,6 @@ mod tests {
     }
 
     // === .prompt() via PromptResponder ===
-
-    use crate::{
-        reset_default_prompt_responder, set_default_prompt_responder, PromptResponse,
-        ScriptedResponder,
-    };
-    use serial_test::serial;
-    use std::sync::Arc;
 
     struct ResponderGuard;
     impl ResponderGuard {


### PR DESCRIPTION
## Summary

Hotfix for an intermittent test failure surfaced by running `cargo test --workspace` on `main` after #125 + #126 landed:

```
test sources::prompt::tests::text_prompt_shortcut_returns_value ... FAILED
test sources::prompt::tests::text_prompt_shortcut_maps_empty_to_no_input ... FAILED
```

## Root cause

PR #125 added vanilla `.prompt()` shortcut tests on `TextPromptSource`, `ConfirmPromptSource`, and `EditorSource` with no `#[serial]` attribute. PR #126 added `inquire_*_via_responder` tests under `#[serial(prompt_responder)]`. The two sets ran on different `serial_test` axes — keyed-vs-unkeyed don't synchronize — so the responder-installing tests could run *concurrently* with the shortcut tests. When that happened, the shortcut test's `.prompt()` call hit the global responder, popped an unexpected response off the queue (panic) or got the wrong return shape (assert failure).

The race only manifests with `--all-features` (so the inquire tests are compiled) and only when the cargo scheduler picks one of each in the same parallel batch — which is why per-PR pre-commit didn't catch it.

## Fix

Every test that calls `.prompt()` now uses `#[serial(prompt_responder)]`, same key as the responder-installing tests. The vanilla shortcut tests don't install a responder themselves; the serialization is purely defensive against parallel responder tests leaking the global override.

## Test plan

- [x] `cargo test -p standout-input --all-features --lib` — 131 pass, was failing 1–2 intermittently before
- [x] `cargo test --workspace` — full suite green
- [x] Pre-commit hook (cargo check / fmt / clippy / lib tests / integration tests) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)