### PR TITLE
feat(todo-example): add complete worked-example crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ members = [
     "crates/standout-pipe",
     "crates/standout-seeker",
     "crates/standout-test",
+    "crates/todo-example",
 ]

--- a/crates/todo-example/Cargo.toml
+++ b/crates/todo-example/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "todo-example"
+version = "0.1.0"
+edition = "2021"
+description = "A complete worked example of a Standout-based CLI app"
+license = "MIT"
+publish = false
+
+[[bin]]
+name = "tdoo"
+path = "src/main.rs"
+
+[dependencies]
+standout = { path = "../standout", version = "7.5.0" }
+standout-macros = { path = "../standout-macros", version = "7.5.0" }
+standout-dispatch = { path = "../standout-dispatch", version = "7.5.0" }
+standout-input = { path = "../standout-input", version = "7.5.0", default-features = false, features = ["simple-prompts"] }
+
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+
+[dev-dependencies]
+standout-test = { path = "../standout-test", version = "7.5.0" }
+serial_test = "3"
+tempfile = "3"

--- a/crates/todo-example/README.md
+++ b/crates/todo-example/README.md
@@ -1,0 +1,256 @@
+# Todo: a worked example of a Standout app
+
+A small but real CLI built on [Standout](https://standout.magik.works/). Three commands (`add`, `list`, `done`), a JSON-backed store, file templates with adaptive CSS, an InputChain on `add`, a post-dispatch hook for audit logging, and end-to-end tests that exercise the whole pipeline in-process.
+
+This is meant to be read top-to-bottom with the source open beside it. Each section explains *what* a file does and *why* it's shaped that way — and points out the options you'd toggle for a different app.
+
+```text
+crates/todo-example/
+├── Cargo.toml
+├── README.md                 (this file)
+├── src/
+│   ├── lib.rs                App wiring: builder, commands, hooks, InputChain
+│   ├── main.rs               Thin shell: load store, build app, run
+│   ├── handlers.rs           Pure functions returning data
+│   ├── store.rs              JSON-backed, Mutex-guarded TodoStore
+│   ├── templates/
+│   │   ├── add.jinja
+│   │   ├── done.jinja
+│   │   └── list.jinja
+│   └── styles/
+│       └── todo.css
+└── tests/
+    └── integration.rs        Full-pipeline tests via TestHarness
+```
+
+## Cargo.toml
+
+```toml
+[dependencies]
+standout = { path = "../standout" }
+standout-macros = { path = "../standout-macros" }     # for #[handler]
+standout-dispatch = { path = "../standout-dispatch" }  # used by macro-emitted code
+standout-input = { path = "../standout-input", default-features = false, features = ["simple-prompts"] }
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+
+[dev-dependencies]
+standout-test = { path = "../standout-test" }
+serial_test = "3"
+tempfile = "3"
+```
+
+A few notes:
+
+- `standout-input` has heavier optional backends (`editor` opens `$EDITOR`; `inquire` pulls in a TUI prompt library). `simple-prompts` is enough for `--title` + piped stdin and pulls in nothing extra.
+- `standout-dispatch` only appears here because the `#[handler]` macro emits `::standout_dispatch::…` paths in user crates. (In a published-version setup this is just `standout-dispatch = "7"`.)
+- `standout-test` and `serial_test` are dev-only. The harness mutates process-global state, so its tests must be `#[serial]`.
+
+## `src/store.rs` — the domain
+
+A 70-line JSON-backed store. Mutex inside, `&self` outside, so handlers can stay pure (`fn list(&self)`, `fn add(&self, ...)`) and `app_state` can hand out a shared reference.
+
+In a real app this would be a SQLite handle, a service client, etc. The shape doesn't change — handlers receive a `&Store` and call methods on it.
+
+> **Option:** you could also keep state as a plain `struct` and pass it through `App::builder()` as an `FnMut` closure capturing `&mut store`. Standout supports that natively (no `Arc<Mutex>`); see the "Mutable Handlers" section of the Standout intro guide. We use interior mutability here because it pairs more cleanly with the `#[handler]` macro and `app_state`.
+
+## `src/handlers.rs` — pure functions returning data
+
+This is where Standout's central design rule shows up: handlers return data; the framework renders it.
+
+```rust
+#[handler]
+pub fn list(
+    #[flag] all: bool,
+    #[ctx] ctx: &CommandContext,
+) -> Result<Output<TodoListResult>, anyhow::Error> {
+    let store = ctx.app_state.get_required::<TodoStore>()?;
+    let mut todos = store.list();
+    if !all { todos.retain(|t| !t.done); }
+    let total = todos.len();
+    Ok(Output::Render(TodoListResult { todos, total }))
+}
+```
+
+What's going on here:
+
+- `#[handler]` is a proc macro that turns this into a normal Standout handler. It generates `list__handler(matches, ctx)` next to your function and handles the `m.get_flag("all")` / `m.get_one::<u32>("id")` plumbing for you. The original function is preserved, so a unit test can call `list(true, &ctx)` directly.
+- `#[flag]` → `bool` (e.g. `--all`); `#[arg]` → required positional or `Option<T>` for optional, or `Vec<T>` for multiple; `#[ctx]` → `&CommandContext`. `#[matches]` is the escape hatch when you need raw `&ArgMatches`.
+- The return type is `Result<Output<T>, anyhow::Error>`, which is exactly what `HandlerResult<T>` expands to. Returning `Output::Render(value)` hands `value` to the renderer; `Output::Silent` skips rendering; `Output::Binary { data, filename }` writes raw bytes.
+
+> **Option:** the `#[handler]` macro can be skipped — you can write `pub fn list(matches: &ArgMatches, ctx: &CommandContext) -> HandlerResult<…>` directly. The `#[derive(Dispatch)]` macro on a clap `Subcommand` enum then auto-wires variants to handlers by name. We use the explicit `App::builder().command_with(…)` form here so we can attach an InputChain to one specific command — see `lib.rs`.
+
+`add` shows the InputChain integration. The handler body has no idea where the title came from:
+
+```rust
+#[handler]
+pub fn add(#[ctx] ctx: &CommandContext) -> Result<Output<TodoActionResult>, anyhow::Error> {
+    let title: &String = ctx.input("title")?;
+    /* ... */
+}
+```
+
+The chain is registered in `lib.rs` and resolved in pre-dispatch — by the time the handler runs, the value is sitting in `ctx.extensions`.
+
+## `src/templates/` — content, declaratively
+
+Three templates, one per command. Standout's templating is MiniJinja with two extras:
+
+- **BBCode-style style tags**: `[stylename]content[/stylename]` wrap text in a style defined in the stylesheet. Tags can be nested, and they're stripped automatically in non-styled output modes (text, JSON, etc.).
+- **Tabular filters** like `col(width, align=…, truncate=…)` pad/truncate values to a column width. `col("fill", width=N)` fills remaining space.
+
+`list.jinja` is the only one that uses `col`:
+
+```jinja
+[title]Your Todos[/title] [muted]({{ total }})[/muted]
+{% if total == 0 %}
+[muted]Nothing here yet. Add one with `tdoo add "<title>"`.[/muted]
+{%- else %}
+{% for todo in todos -%}
+{%- set status = "done" if todo.done else "pending" -%}
+[index]{{ ("#" ~ todo.id) | col(4, align="right") }}[/index]  [{{ status }}]{{ todo.title | col(40, truncate="end") }}[/{{ status }}]
+{% endfor -%}
+{%- endif %}
+```
+
+Two patterns worth pointing out:
+
+- `[{{ status }}]…[/{{ status }}]` lets a value drive the style — `done` items get the `.done` style, `pending` items get `.pending`. This is the canonical way to express conditional styling without `{% if %}` chains.
+- `col(4, align="right")` and `col(40, truncate="end")` give us a real columnar layout for free. For something more elaborate (full `#[derive(Tabular)]` on the row type with the framework's `list-view` template handling layout for you) see the [Tabular guide](https://standout.magik.works/topics/tabular.html). For a list of three columns this is plenty.
+
+> **Option:** Standout also accepts inline template *strings* via `App::builder().command(name, handler, "template body here")`. Files are the canonical form because they get diff-friendly version control, IDE syntax highlighting, hot reload in debug builds, and a place for non-engineers to edit copy.
+
+## `src/styles/todo.css` — adaptive theming
+
+Standout reads CSS, not a custom DSL, and supports `@media (prefers-color-scheme: …)` for light/dark adaptation.
+
+```css
+.title { color: cyan; font-weight: bold; }
+.done  { color: gray; text-decoration: line-through; }
+.pending { font-weight: bold; }
+
+@media (prefers-color-scheme: light) {
+    .pending { color: black; }
+    .title   { color: blue; }
+}
+@media (prefers-color-scheme: dark) {
+    .pending { color: white; }
+}
+```
+
+Standout picks light vs dark from `$COLORFGBG` and other terminal signals at runtime; the same binary reskins itself per terminal.
+
+> **Option:** YAML stylesheets work too (`themes/foo.yaml`, with the same `light:` / `dark:` keys), but CSS is the recommended surface. A class can also use theme-relative colors like `cube(60%, 20%, 0%)` — see the [Styling guide](https://standout.magik.works/topics/rendering-system.html).
+
+The filename is the theme name. `todo.css` → theme `"todo"`, activated via `.default_theme("todo")` on the App builder.
+
+## `src/lib.rs` — App wiring
+
+The actual Standout configuration lives here. `main.rs` is just `build_app(store).run(cli, args)` — the lib boundary lets the integration tests build the same `App` the binary builds.
+
+```rust
+let app = App::builder()
+    .app_state(store)
+    .templates(embed_templates!("src/templates"))
+    .styles(embed_styles!("src/styles"))
+    .default_theme("todo")
+    .command_with("add", handlers::add__handler, |cfg| {
+        cfg.template("add.jinja")
+            .input(
+                "title",
+                InputChain::<String>::new()
+                    .try_source(ArgSource::new("title"))
+                    .try_source(StdinSource::new())
+                    .validate(|s| !s.trim().is_empty(), "title cannot be empty"),
+            )
+            .post_dispatch(audit_hook)
+    })?
+    .command_with("list", handlers::list__handler, |cfg| {
+        cfg.template("list.jinja")
+    })?
+    .command_with("done", handlers::done__handler, |cfg| {
+        cfg.template("done.jinja").post_dispatch(audit_hook)
+    })?
+    .build()?;
+```
+
+Reading top-down:
+
+- **`app_state(store)`**: a process-lifetime injection slot keyed by type. Handlers reach it with `ctx.app_state.get_required::<TodoStore>()`. Multiple `app_state(...)` calls are fine, one per type.
+- **`embed_templates!("src/templates")` / `embed_styles!("src/styles")`**: walk those directories at compile time and embed the contents in the binary. In debug builds the original paths are also watched so edits to `.jinja` / `.css` show up without recompiling.
+- **`default_theme("todo")`**: pick a stylesheet by basename. Without this, the framework's built-in default theme is used.
+- **`command_with(path, handler, configure)`**: register a leaf handler with extra config. The handler is the `*__handler` function the macro generates. The configure closure receives a `CommandConfig` that exposes `.template(...)`, `.input(...)`, `.pre_dispatch(...)`, `.post_dispatch(...)`, `.post_output(...)`, `.pipe_to(...)`, `.pipe_through(...)`, `.pipe_to_clipboard()`.
+- **`.input("title", chain)`**: register a declarative input chain. The chain is resolved in pre-dispatch and the value lands in `ctx.extensions`, reachable through `ctx.input::<String>("title")`. Chain sources tried in order: `ArgSource`, `StdinSource`, `EnvSource`, `EditorSource` (with `editor` feature), `ClipboardSource`, `TextPromptSource`, etc. `.default(value)` provides a fallback; `.validate(predicate, msg)` gates the resolved value.
+- **`.post_dispatch(audit_hook)`**: a function-shaped hook that runs after the handler returns and before rendering. It receives the handler's output as `serde_json::Value` and returns a (possibly modified) value. Pre-dispatch hooks can mutate `ctx.extensions`; post-output hooks can transform the rendered text. See the audit-hook implementation at the bottom of `lib.rs`.
+
+> **Option:** for many commands without per-command config, the typing-saving form is `#[derive(Dispatch)]` on a clap `Subcommand` enum + `App::builder().commands(Commands::dispatch_config())`. That auto-maps each variant to `handlers::{snake_case}` and uses templates named after the command. Per-variant attributes (`#[dispatch(template = "…", post_dispatch = …, pipe_to_clipboard, …)]`) cover most needs. We use `command_with` here because we wanted one `.input()` chain — that's not (yet) expressible as a variant attribute.
+
+## `tests/integration.rs` — the test harness
+
+Standout's testability claim is that you can drive the full pipeline — clap parsing, dispatch, hooks, rendering — entirely in-process, with controlled env vars / stdin / clipboard / fixtures. `standout-test::TestHarness` is the bundled API.
+
+```rust
+#[test]
+#[serial]
+fn add_reads_title_from_piped_stdin_when_arg_is_absent() {
+    let (app, _dir) = fresh_app();
+
+    let added = TestHarness::new()
+        .no_color()
+        .piped_stdin("ship the docs\n")
+        .run(&app, cli_command(), ["tdoo", "add"]);
+
+    added.assert_success();
+    added.assert_stdout_contains("ship the docs");
+}
+```
+
+What's covered:
+
+- `TestHarness::new()` — empty builder, no overrides until `.run(...)`.
+- `.no_color()` — strip ANSI from rendered output for stable string comparisons.
+- `.piped_stdin(content)` — simulate `echo content | tdoo add`. The InputChain's `StdinSource` picks this up.
+- `.env("KEY", "value")` / `.env_remove("KEY")` — set or unset for the run; restored on drop. Used in the audit-hook test to point `TODO_AUDIT_LOG` at a tempfile.
+- `.fixture(path, content)` — write a file into a tempdir and `chdir` there. Useful when the app reads config or data from cwd-relative paths.
+- `.clipboard(content)` — mock clipboard read.
+- `.terminal_width(n)` / `.no_color()` / `.is_tty()` — control the rendering environment.
+- `.run(&app, cmd, argv)` — execute the pipeline. Returns a `TestResult` with `assert_success()`, `assert_stdout_contains(s)`, `assert_stdout_eq(s)`, and `.stdout() -> &str` for custom checks.
+
+Every override is restored on drop, including on panic. Because they touch process-global state, **every TestHarness test must be `#[serial]`** (re-exported as `standout_test::serial`).
+
+The test file is small (about 130 lines) but covers seven distinct scenarios — empty-state rendering, the JSON output mode, the InputChain validator firing, the audit hook side effect, the round-trip through the store, etc. None of them spawn a subprocess.
+
+> **Option:** for tests that just need to assert on a handler's *data* (not the rendered output), call the original `list(true, &ctx)` function directly — `#[handler]` keeps the original function callable. That's the lowest-friction unit-test path. `TestHarness` is for end-to-end checks that need to verify the templating, output mode, or environment behavior.
+
+## Trying it
+
+```bash
+# Default store path is $HOME/.todos.json — override per-run with $TODO_FILE.
+TODO_FILE=/tmp/tdoo.json cargo run -p todo-example -- add --title "buy milk"
+TODO_FILE=/tmp/tdoo.json cargo run -p todo-example -- list
+TODO_FILE=/tmp/tdoo.json cargo run -p todo-example -- done 1
+TODO_FILE=/tmp/tdoo.json cargo run -p todo-example -- list --all
+
+# Pipe input.
+echo "write tests" | TODO_FILE=/tmp/tdoo.json cargo run -p todo-example -- add
+
+# Free output modes.
+TODO_FILE=/tmp/tdoo.json cargo run -p todo-example -- list --output json
+TODO_FILE=/tmp/tdoo.json cargo run -p todo-example -- list --output yaml
+TODO_FILE=/tmp/tdoo.json cargo run -p todo-example -- list --output text
+
+# Run the test suite (every test is #[serial], all in-process).
+cargo test -p todo-example
+```
+
+## What this example does *not* show
+
+A few things deliberately left out to keep this small:
+
+- **`#[derive(Dispatch)]`** on a clap subcommand enum. That's the lower-boilerplate pattern when you have many commands without per-command config. See `crates/standout/tests/dispatch_derive.rs` for the reference.
+- **`#[derive(Tabular)]` + the framework's `list-view` template**. We used the `col` Jinja filter directly because it's more legible for a three-column layout. For richer tables (variable widths, headers, fractional units), see the [Tabular guide](https://standout.magik.works/topics/tabular.html).
+- **Output piping** (`pipe_to("tee /tmp/log")`, `pipe_through("jq")`, `pipe_to_clipboard()`). All three are one method call on `cfg` inside `command_with`; we just didn't have a sensible domain reason to wire one up.
+- **Topics-based help** — Standout supports rich `--help` topics for long-form docs. See the [Topics guide](https://standout.magik.works/topics/topics-system.html).
+- **`standout-seeker`**, the search/select layer — see the Seeker guide if you want it; it's intentionally separate.

--- a/crates/todo-example/src/handlers.rs
+++ b/crates/todo-example/src/handlers.rs
@@ -1,0 +1,72 @@
+//! Pure handlers. They return data; the framework renders it.
+//!
+//! Each handler uses the `#[handler]` macro, which extracts CLI args from
+//! `ArgMatches` so the body can be written as a normal Rust function. The
+//! original function is preserved alongside the generated `*__handler`
+//! wrapper, so unit tests in `#[cfg(test)]` can call it directly.
+
+#![allow(non_snake_case)]
+
+use crate::store::{Todo, TodoStore};
+use serde::Serialize;
+use standout::cli::{CommandContext, CommandContextInput, Output};
+use standout_macros::handler;
+
+#[derive(Serialize)]
+pub struct TodoListResult {
+    pub todos: Vec<Todo>,
+    pub total: usize,
+}
+
+#[derive(Serialize)]
+pub struct TodoActionResult {
+    pub message: String,
+    pub todo: Todo,
+}
+
+// `#[ctx]` gives us read-only access to the CommandContext. `app_state` is
+// where the TodoStore lives — registered once at App-build time.
+// `#[flag]` and `#[arg]` map to clap flags/positional args; the macro takes
+// care of the `m.get_flag(...) / m.get_one::<T>(...)` plumbing.
+
+#[handler]
+pub fn list(
+    #[flag] all: bool,
+    #[ctx] ctx: &CommandContext,
+) -> Result<Output<TodoListResult>, anyhow::Error> {
+    let store = ctx.app_state.get_required::<TodoStore>()?;
+    let mut todos = store.list();
+    if !all {
+        todos.retain(|t| !t.done);
+    }
+    let total = todos.len();
+    Ok(Output::Render(TodoListResult { todos, total }))
+}
+
+// `add` reads its title from a declarative input chain registered in
+// `main.rs`: `--title <T>` first, falling back to piped stdin. The chain is
+// resolved during pre-dispatch and the value lands in `ctx.extensions`,
+// reachable through `ctx.input::<String>("title")`.
+#[handler]
+pub fn add(#[ctx] ctx: &CommandContext) -> Result<Output<TodoActionResult>, anyhow::Error> {
+    let title: &String = ctx.input("title")?;
+    let store = ctx.app_state.get_required::<TodoStore>()?;
+    let todo = store.add(title.clone())?;
+    Ok(Output::Render(TodoActionResult {
+        message: format!("Added #{}", todo.id),
+        todo,
+    }))
+}
+
+#[handler]
+pub fn done(
+    #[arg] id: u32,
+    #[ctx] ctx: &CommandContext,
+) -> Result<Output<TodoActionResult>, anyhow::Error> {
+    let store = ctx.app_state.get_required::<TodoStore>()?;
+    let todo = store.mark_done(id)?;
+    Ok(Output::Render(TodoActionResult {
+        message: format!("Marked #{} done", todo.id),
+        todo,
+    }))
+}

--- a/crates/todo-example/src/handlers.rs
+++ b/crates/todo-example/src/handlers.rs
@@ -44,9 +44,9 @@ pub fn list(
 }
 
 // `add` reads its title from a declarative input chain registered in
-// `main.rs`: `--title <T>` first, falling back to piped stdin. The chain is
-// resolved during pre-dispatch and the value lands in `ctx.extensions`,
-// reachable through `ctx.input::<String>("title")`.
+// `build_app` in `src/lib.rs`: `--title <T>` first, falling back to piped
+// stdin. The chain is resolved during pre-dispatch and the value lands in
+// `ctx.extensions`, reachable through `ctx.input::<String>("title")`.
 #[handler]
 pub fn add(#[ctx] ctx: &CommandContext) -> Result<Output<TodoActionResult>, anyhow::Error> {
     let title: &String = ctx.input("title")?;

--- a/crates/todo-example/src/lib.rs
+++ b/crates/todo-example/src/lib.rs
@@ -1,0 +1,121 @@
+//! `tdoo` library surface — exposed so integration tests can build the
+//! same `App` the binary builds and run it through `standout-test`.
+
+use anyhow::Result;
+use clap::{ArgMatches, CommandFactory, Parser, Subcommand};
+use serde_json::Value as JsonValue;
+use standout::cli::hooks::HookError;
+use standout::cli::{App, CommandContext};
+use standout::input::{ArgSource, InputChain, StdinSource};
+use standout::{embed_styles, embed_templates};
+
+pub mod handlers;
+pub mod store;
+
+pub use store::TodoStore;
+
+#[derive(Parser)]
+#[command(name = "tdoo", about = "A tiny todo list — the Standout sample app")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+// We use plain clap-derive here. Standout has a `#[derive(Dispatch)]` that
+// auto-wires variants to handlers by name; we skip it because we want to
+// register `add` with a custom input chain (see below) and showcase the
+// explicit `command_with` form too.
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Add a new todo. Title comes from --title or piped stdin.
+    Add {
+        #[arg(short, long)]
+        title: Option<String>,
+    },
+    /// List todos. By default only pending ones; pass --all for everything.
+    List {
+        #[arg(short, long)]
+        all: bool,
+    },
+    /// Mark a todo done.
+    Done { id: u32 },
+}
+
+pub fn build_app(store: TodoStore) -> Result<App> {
+    let app = App::builder()
+        // app_state is a process-lifetime injection slot. Handlers reach it
+        // via `ctx.app_state.get_required::<TodoStore>()`.
+        .app_state(store)
+        // `embed_templates!` walks the directory at compile time; the
+        // resulting bundle is embedded in the binary, but in debug builds
+        // the framework also watches the original path for hot reload.
+        .templates(embed_templates!("src/templates"))
+        .styles(embed_styles!("src/styles"))
+        // Style file is `todo.css`, so the theme name is `todo`. Without
+        // this call the framework's built-in default theme is used instead.
+        .default_theme("todo")
+        // `command_with` (rather than `.command`) lets us attach config —
+        // here, an InputChain for `add` and a post-dispatch audit hook for
+        // mutations. The handler comes from `#[handler]` on the function:
+        // the macro generates `add__handler` next to `add`.
+        .command_with("add", handlers::add__handler, |cfg| {
+            cfg.template("add.jinja")
+                .input(
+                    "title",
+                    InputChain::<String>::new()
+                        .try_source(ArgSource::new("title"))
+                        .try_source(StdinSource::new())
+                        .validate(|s| !s.trim().is_empty(), "title cannot be empty"),
+                )
+                .post_dispatch(audit_hook)
+        })?
+        .command_with("list", handlers::list__handler, |cfg| {
+            cfg.template("list.jinja")
+        })?
+        .command_with("done", handlers::done__handler, |cfg| {
+            cfg.template("done.jinja").post_dispatch(audit_hook)
+        })?
+        .build()?;
+    Ok(app)
+}
+
+pub fn cli_command() -> clap::Command {
+    Cli::command()
+}
+
+pub fn resolve_store_path() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("TODO_FILE") {
+        return p.into();
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    std::path::PathBuf::from(home).join(".todos.json")
+}
+
+// A post-dispatch hook is the framework's seam for cross-cutting concerns
+// after the handler returns but before rendering. The hook receives the
+// handler's already-serialized JSON and can transform it. Here we use it
+// for an audit trail so the handler stays focused on its single concern.
+fn audit_hook(
+    _matches: &ArgMatches,
+    ctx: &CommandContext,
+    value: JsonValue,
+) -> std::result::Result<JsonValue, HookError> {
+    if let Ok(path) = std::env::var("TODO_AUDIT_LOG") {
+        let line = format!(
+            "{}\t{}\n",
+            ctx.command_path.join("."),
+            value
+                .get("todo")
+                .and_then(|t| t.get("id"))
+                .unwrap_or(&JsonValue::Null)
+        );
+        // A hook returning Err aborts the pipeline; we swallow IO errors
+        // here because audit logging shouldn't fail the user's command.
+        let _ = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .and_then(|mut f| std::io::Write::write_all(&mut f, line.as_bytes()));
+    }
+    Ok(value)
+}

--- a/crates/todo-example/src/main.rs
+++ b/crates/todo-example/src/main.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use todo_example::{build_app, cli_command, resolve_store_path, TodoStore};
+
+fn main() -> Result<()> {
+    let store = TodoStore::load(resolve_store_path())?;
+    let app = build_app(store)?;
+    app.run(cli_command(), std::env::args());
+    Ok(())
+}

--- a/crates/todo-example/src/store.rs
+++ b/crates/todo-example/src/store.rs
@@ -5,10 +5,10 @@
 //! is the same — handlers receive a `&Store` from `ctx.app_state` and call
 //! straightforward methods on it.
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Todo {
@@ -17,7 +17,7 @@ pub struct Todo {
     pub done: bool,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 struct Inner {
     todos: Vec<Todo>,
     next_id: u32,
@@ -44,41 +44,62 @@ impl TodoStore {
     }
 
     pub fn list(&self) -> Vec<Todo> {
-        self.inner.lock().unwrap().todos.clone()
+        self.lock().todos.clone()
     }
 
     pub fn add(&self, title: String) -> Result<Todo> {
-        let mut g = self.inner.lock().unwrap();
-        g.next_id += 1;
+        let mut g = self.lock();
+        // Snapshot-then-commit: build the new state into `next` and only
+        // swap it in after the disk write succeeds, so a save failure
+        // can't leave the in-memory store ahead of the file.
+        let mut next = g.clone();
+        next.next_id += 1;
         let todo = Todo {
-            id: g.next_id,
+            id: next.next_id,
             title,
             done: false,
         };
-        g.todos.push(todo.clone());
-        save(&self.path, &g)?;
+        next.todos.push(todo.clone());
+        save(&self.path, &next)?;
+        *g = next;
         Ok(todo)
     }
 
     pub fn mark_done(&self, id: u32) -> Result<Todo> {
-        let mut g = self.inner.lock().unwrap();
-        let t = g
+        let mut g = self.lock();
+        let mut next = g.clone();
+        let t = next
             .todos
             .iter_mut()
             .find(|t| t.id == id)
             .with_context(|| format!("no todo with id {}", id))?;
         t.done = true;
         let snapshot = t.clone();
-        save(&self.path, &g)?;
+        save(&self.path, &next)?;
+        *g = next;
         Ok(snapshot)
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Inner> {
+        // The mutex only guards in-process state; CLI runs are single-
+        // threaded, so poisoning shouldn't happen in normal operation.
+        // If it does, surface a clear message rather than a bare panic.
+        self.inner
+            .lock()
+            .expect("TodoStore mutex poisoned — this is a bug")
     }
 }
 
 fn save(path: &Path, inner: &Inner) -> Result<()> {
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).ok();
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating directory {}", parent.display()))?;
+        }
     }
-    let json = serde_json::to_string_pretty(inner)?;
+    let json = serde_json::to_string_pretty(inner)
+        .map_err(|e| anyhow!(e))
+        .context("serializing store")?;
     std::fs::write(path, json).with_context(|| format!("writing {}", path.display()))?;
     Ok(())
 }

--- a/crates/todo-example/src/store.rs
+++ b/crates/todo-example/src/store.rs
@@ -1,0 +1,84 @@
+//! Tiny JSON-backed todo store. Mutex inside, `&self` outside, so handlers
+//! can stay simple and `app_state` can hand out a shared reference.
+//!
+//! In a real app you'd put a SQLite DB or a service client here; the shape
+//! is the same — handlers receive a `&Store` from `ctx.app_state` and call
+//! straightforward methods on it.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Todo {
+    pub id: u32,
+    pub title: String,
+    pub done: bool,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct Inner {
+    todos: Vec<Todo>,
+    next_id: u32,
+}
+
+pub struct TodoStore {
+    path: PathBuf,
+    inner: Mutex<Inner>,
+}
+
+impl TodoStore {
+    pub fn load(path: PathBuf) -> Result<Self> {
+        let inner = if path.exists() {
+            let raw = std::fs::read_to_string(&path)
+                .with_context(|| format!("reading {}", path.display()))?;
+            serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?
+        } else {
+            Inner::default()
+        };
+        Ok(Self {
+            path,
+            inner: Mutex::new(inner),
+        })
+    }
+
+    pub fn list(&self) -> Vec<Todo> {
+        self.inner.lock().unwrap().todos.clone()
+    }
+
+    pub fn add(&self, title: String) -> Result<Todo> {
+        let mut g = self.inner.lock().unwrap();
+        g.next_id += 1;
+        let todo = Todo {
+            id: g.next_id,
+            title,
+            done: false,
+        };
+        g.todos.push(todo.clone());
+        save(&self.path, &g)?;
+        Ok(todo)
+    }
+
+    pub fn mark_done(&self, id: u32) -> Result<Todo> {
+        let mut g = self.inner.lock().unwrap();
+        let t = g
+            .todos
+            .iter_mut()
+            .find(|t| t.id == id)
+            .with_context(|| format!("no todo with id {}", id))?;
+        t.done = true;
+        let snapshot = t.clone();
+        save(&self.path, &g)?;
+        Ok(snapshot)
+    }
+}
+
+fn save(path: &Path, inner: &Inner) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let json = serde_json::to_string_pretty(inner)?;
+    std::fs::write(path, json).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}

--- a/crates/todo-example/src/styles/todo.css
+++ b/crates/todo-example/src/styles/todo.css
@@ -1,0 +1,43 @@
+/* The default-mode look. `@media (prefers-color-scheme: ...)` blocks below
+   override these for terminals that report a background-color preference.
+   Standout reads $COLORFGBG (and a few other signals) to pick a mode at
+   runtime, so the same binary adapts to light/dark terminals automatically. */
+
+.title {
+    color: cyan;
+    font-weight: bold;
+}
+
+.index {
+    color: yellow;
+}
+
+.muted {
+    color: gray;
+}
+
+.ok {
+    color: green;
+    font-weight: bold;
+}
+
+.pending {
+    font-weight: bold;
+}
+
+.done {
+    color: gray;
+    text-decoration: line-through;
+}
+
+@media (prefers-color-scheme: light) {
+    .title { color: blue; }
+    .pending { color: black; }
+    .muted { color: #555555; }
+}
+
+@media (prefers-color-scheme: dark) {
+    .title { color: cyan; }
+    .pending { color: white; }
+    .muted { color: #999999; }
+}

--- a/crates/todo-example/src/templates/add.jinja
+++ b/crates/todo-example/src/templates/add.jinja
@@ -1,0 +1,1 @@
+[ok]{{ message }}[/ok] — [pending]{{ todo.title }}[/pending]

--- a/crates/todo-example/src/templates/done.jinja
+++ b/crates/todo-example/src/templates/done.jinja
@@ -1,0 +1,1 @@
+[ok]{{ message }}[/ok] — [done]{{ todo.title }}[/done]

--- a/crates/todo-example/src/templates/list.jinja
+++ b/crates/todo-example/src/templates/list.jinja
@@ -1,0 +1,9 @@
+[title]Your Todos[/title] [muted]({{ total }})[/muted]
+{% if total == 0 %}
+[muted]Nothing here yet. Add one with `tdoo add "<title>"`.[/muted]
+{%- else %}
+{% for todo in todos -%}
+{%- set status = "done" if todo.done else "pending" -%}
+[index]{{ ("#" ~ todo.id) | col(4, align="right") }}[/index]  [{{ status }}]{{ todo.title | col(40, truncate="end") }}[/{{ status }}]
+{% endfor -%}
+{%- endif %}

--- a/crates/todo-example/tests/integration.rs
+++ b/crates/todo-example/tests/integration.rs
@@ -1,0 +1,156 @@
+//! End-to-end tests that drive the full pipeline (clap → dispatch →
+//! handler → template → output) in-process via `standout-test`.
+//!
+//! `TestHarness` mutates process-global state (env, cwd, default stdin
+//! reader, …) so every test is `#[serial]`.
+
+use serial_test::serial;
+use standout::cli::App;
+use standout_test::TestHarness;
+use tempfile::TempDir;
+use todo_example::{build_app, cli_command, TodoStore};
+
+/// Builds a fresh app pointed at a tempdir-backed store. The TempDir is
+/// returned alongside so the caller can keep it alive for the duration of
+/// the test.
+fn fresh_app() -> (App, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let store = TodoStore::load(dir.path().join("todos.json")).unwrap();
+    (build_app(store).unwrap(), dir)
+}
+
+#[test]
+#[serial]
+fn list_on_empty_store_shows_empty_state() {
+    let (app, _dir) = fresh_app();
+    let result = TestHarness::new()
+        .no_color()
+        .run(&app, cli_command(), ["tdoo", "list"]);
+
+    result.assert_success();
+    result.assert_stdout_contains("Nothing here yet");
+}
+
+#[test]
+#[serial]
+fn add_then_list_round_trips_through_store() {
+    let (app, _dir) = fresh_app();
+
+    TestHarness::new()
+        .no_color()
+        .run(&app, cli_command(), ["tdoo", "add", "--title", "buy milk"])
+        .assert_success();
+
+    let listed = TestHarness::new()
+        .no_color()
+        .run(&app, cli_command(), ["tdoo", "list"]);
+    listed.assert_success();
+    listed.assert_stdout_contains("buy milk");
+    listed.assert_stdout_contains("#1");
+}
+
+#[test]
+#[serial]
+fn add_reads_title_from_piped_stdin_when_arg_is_absent() {
+    let (app, _dir) = fresh_app();
+
+    let added = TestHarness::new()
+        .no_color()
+        .piped_stdin("ship the docs\n")
+        .run(&app, cli_command(), ["tdoo", "add"]);
+    added.assert_success();
+    added.assert_stdout_contains("ship the docs");
+}
+
+#[test]
+#[serial]
+fn add_rejects_empty_title_via_chain_validator() {
+    let (app, _dir) = fresh_app();
+
+    let result =
+        TestHarness::new()
+            .no_color()
+            .run(&app, cli_command(), ["tdoo", "add", "--title", "   "]);
+    // The chain validator runs in pre-dispatch and aborts before the
+    // handler. The framework surfaces the hook error in the rendered
+    // output, so we look for the validator message.
+    result.assert_stdout_contains("title cannot be empty");
+}
+
+#[test]
+#[serial]
+fn done_flips_status_and_list_all_shows_both_states() {
+    let (app, _dir) = fresh_app();
+
+    TestHarness::new()
+        .no_color()
+        .run(&app, cli_command(), ["tdoo", "add", "--title", "first"])
+        .assert_success();
+    TestHarness::new()
+        .no_color()
+        .run(&app, cli_command(), ["tdoo", "add", "--title", "second"])
+        .assert_success();
+    TestHarness::new()
+        .no_color()
+        .run(&app, cli_command(), ["tdoo", "done", "1"])
+        .assert_success();
+
+    // Default `list` filters out done todos.
+    let pending_only = TestHarness::new()
+        .no_color()
+        .run(&app, cli_command(), ["tdoo", "list"]);
+    pending_only.assert_success();
+    pending_only.assert_stdout_contains("second");
+    assert!(
+        !pending_only.stdout().contains("first"),
+        "completed todo should be hidden without --all; got:\n{}",
+        pending_only.stdout()
+    );
+
+    // `--all` shows everything.
+    let everything =
+        TestHarness::new()
+            .no_color()
+            .run(&app, cli_command(), ["tdoo", "list", "--all"]);
+    everything.assert_success();
+    everything.assert_stdout_contains("first");
+    everything.assert_stdout_contains("second");
+}
+
+#[test]
+#[serial]
+fn json_output_mode_serializes_handler_data_directly() {
+    let (app, _dir) = fresh_app();
+
+    TestHarness::new()
+        .no_color()
+        .run(&app, cli_command(), ["tdoo", "add", "--title", "buy milk"])
+        .assert_success();
+
+    let result = TestHarness::new().no_color().run(
+        &app,
+        cli_command(),
+        ["tdoo", "list", "--output", "json"],
+    );
+    result.assert_success();
+    let stdout = result.stdout();
+    assert!(stdout.contains("\"title\""));
+    assert!(stdout.contains("buy milk"));
+    assert!(stdout.contains("\"total\""));
+}
+
+#[test]
+#[serial]
+fn audit_hook_writes_a_log_line_when_env_is_set() {
+    let (app, dir) = fresh_app();
+    let log_path = dir.path().join("audit.log");
+
+    TestHarness::new()
+        .no_color()
+        .env("TODO_AUDIT_LOG", log_path.to_str().unwrap())
+        .run(&app, cli_command(), ["tdoo", "add", "--title", "audited"])
+        .assert_success();
+
+    let log = std::fs::read_to_string(&log_path).expect("audit log written");
+    assert!(log.contains("add\t1"), "unexpected audit log:\n{}", log);
+}


### PR DESCRIPTION
## Summary

Ships a new workspace crate at `crates/todo-example/` — a small but real `tdoo` CLI (`add` / `list` / `done`) that exercises Standout's canonical adoption surface end-to-end. Intended to give new adopters (humans and agents) a single, working reference implementation to copy from instead of stitching together fragments across guides.

The README is a walkthrough that reads top-to-bottom with the source open beside it and surfaces options inline near each call site. Designed to be either a drop-in replacement for the current `complete-example.html` guide or a longer companion doc that the existing short guide links to.

### What it showcases (canonical forms only)

- `App::builder` with `app_state` + `embed_templates!` + `embed_styles!` + `default_theme` + `command_with`
- `#[handler]` proc macro with `#[arg]` / `#[flag]` / `#[ctx]`
- File templates (\`*.jinja\`) with BBCode `[style]` tags and the `col` Jinja filter for tabular layout
- CSS stylesheet with `@media (prefers-color-scheme: light/dark)` adaptive theming
- `InputChain` on `add` (`ArgSource` → `StdinSource` → empty-string validator) — declarative input resolved in pre-dispatch and reachable via `ctx.input::<String>(\"title\")`
- `post_dispatch` audit hook gated on `TODO_AUDIT_LOG` env var (real cross-cutting use case for hooks)
- Free `--output json` / `text` / `yaml` modes from the same handlers

Deliberately omitted (and called out in the README): `#[derive(Dispatch)]`, `#[derive(Tabular)]` + the framework `list-view` template, `pipe_to_clipboard`, topics-based help, `standout-seeker`. Each is a one-line edit away if a reader wants it.

### Tests

7 integration tests in `tests/integration.rs` using `standout-test::TestHarness`, all `#[serial]`, all in-process — no subprocesses, no stdout grepping. Coverage:

- Empty-state list rendering
- Add → list round-trip through the JSON store
- Piped-stdin resolution via the InputChain
- Validator firing on empty title
- `done` flipping status; `--all` filtering behavior
- `--output json` serializing handler data directly
- `audit_hook` writing to the env-pointed log file

## Test plan

- [x] `cargo build -p todo-example`
- [x] `cargo test -p todo-example` — 7/7 pass
- [x] `cargo build --workspace --tests` — no regressions
- [x] Manual smoke test: `tdoo add` (via `--title` and via piped stdin), `tdoo list`, `tdoo list --all`, `tdoo done <id>`, `tdoo list --output json`
- [x] Pre-commit hook (`cargo check`, `cargo fmt --check`, `cargo clippy`, full test suite) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)