### PR TITLE
feat(bbparser): backslash escapes for [ and ]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Backslash escape syntax in `standout-bbparser`.** Text now supports `\[` → `[` and `\]` → `]` so user-provided strings (e.g. clap `about` / `help` text rendered through standout's help interception) can contain literal brackets without being mistaken for tag delimiters. A backslash that is not followed by `[` or `]` is left alone, so file paths (`C:\foo\bar`), regex examples (`\d+`), and other content containing `\` pass through unchanged. To emit a literal `\[` write `\\[` (the first `\` is preserved because `\\` is not a recognized escape, then `\[` is consumed and emits `[`). Escapes are honored in all transform modes (`Apply`, `Remove`, `Keep`) and by `strip_tags`; they don't generate validation errors.
+
+### Fixed
+
+- **`standout_render::tabular::visible_width` no longer mismeasures strings that contain both BBCode tags and raw ANSI escapes.** Previously the function ran `strip_tags` first, and the `[` / `]` bytes inside CSI sequences (`\x1b[31m...`) confused the tag stripper into treating the surrounding region as one malformed tag, leaving the inner BBCode intact. ANSI codes are now stripped before BBCode, matching the function's documented contract.
+
 ## [7.5.1] - 2026-04-25
 
 ### Added

--- a/crates/standout-bbparser/src/lib.rs
+++ b/crates/standout-bbparser/src/lib.rs
@@ -662,9 +662,15 @@ fn find_unescaped_bracket(s: &str) -> Option<usize> {
 
 /// Replaces `\[` with `[` and `\]` with `]` in a text segment. Other
 /// backslashes pass through unchanged. Returns `Cow::Borrowed` when no
-/// backslash is present so the no-escape fast path stays allocation-free.
+/// actual `\[` or `\]` escape sequence is present, so backslash-containing
+/// but escape-free inputs (Windows paths, `\d+` regex examples, etc.) stay
+/// allocation-free.
 fn unescape(s: &str) -> std::borrow::Cow<'_, str> {
-    if !s.contains('\\') {
+    let bytes = s.as_bytes();
+    let has_escape = bytes
+        .windows(2)
+        .any(|w| w[0] == b'\\' && (w[1] == b'[' || w[1] == b']'));
+    if !has_escape {
         return std::borrow::Cow::Borrowed(s);
     }
     let mut out = String::with_capacity(s.len());
@@ -1418,6 +1424,29 @@ mod tests {
         fn lone_backslash_is_literal() {
             let parser = BBParser::new(test_styles(), TagTransform::Remove);
             assert_eq!(parser.parse("path C:\\foo\\bar"), "path C:\\foo\\bar");
+        }
+
+        #[test]
+        fn unescape_borrows_when_no_bracket_escape_present() {
+            // Backslash-containing inputs without `\[` or `\]` (Windows paths,
+            // `\d+` regex examples) must not allocate — they should round-trip
+            // through `Cow::Borrowed`.
+            assert!(matches!(
+                unescape("plain text"),
+                std::borrow::Cow::Borrowed(_)
+            ));
+            assert!(matches!(
+                unescape("C:\\foo\\bar"),
+                std::borrow::Cow::Borrowed(_)
+            ));
+            assert!(matches!(unescape("\\d+"), std::borrow::Cow::Borrowed(_)));
+            assert!(matches!(
+                unescape("trailing\\"),
+                std::borrow::Cow::Borrowed(_)
+            ));
+            // Actual escape sequences must take the owned path.
+            assert!(matches!(unescape("\\["), std::borrow::Cow::Owned(_)));
+            assert!(matches!(unescape("\\]"), std::borrow::Cow::Owned(_)));
         }
 
         #[test]

--- a/crates/standout-bbparser/src/lib.rs
+++ b/crates/standout-bbparser/src/lib.rs
@@ -49,6 +49,20 @@
 //! - Case-sensitive (lowercase recommended)
 //!
 //! Pattern: `[a-z_][a-z0-9_-]*`
+//!
+//! # Escaping
+//!
+//! To emit a literal `[` or `]` without it being treated as a tag delimiter,
+//! prefix it with a backslash:
+//!
+//! - `\[` → `[`
+//! - `\]` → `]`
+//!
+//! A backslash that is not followed by `[` or `]` is left alone, so file
+//! paths, regex examples, and other content containing `\` pass through
+//! unchanged. To emit a literal `\[` in the output, write `\\[` (the first
+//! `\` is kept as-is because `\\` is not a recognized escape, then `\[` is
+//! consumed as an escape and emits `[`).
 
 use console::Style;
 use std::collections::HashMap;
@@ -334,7 +348,7 @@ impl BBParser {
         while i < tokens.len() {
             match &tokens[i] {
                 Token::Text { content, .. } => {
-                    events.push(ParseEvent::Literal(std::borrow::Cow::Borrowed(content)));
+                    events.push(ParseEvent::Literal(unescape(content)));
                 }
                 Token::OpenTag { name, start, end } => {
                     if valid_opens.contains(&i) {
@@ -619,6 +633,57 @@ enum Token<'a> {
     },
 }
 
+/// Finds the byte offset of the next `[` that is not preceded by a `\` escape.
+///
+/// Both `\[` and `\]` are treated as escape sequences and skipped. Other
+/// backslashes (e.g. `\n`, `\\`, trailing `\`) are not consumed and don't
+/// affect bracket detection.
+///
+/// Byte-level scanning is safe here: `\`, `[`, and `]` are ASCII and cannot
+/// appear as continuation bytes in a UTF-8 sequence.
+fn find_unescaped_bracket(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 1 < bytes.len() {
+            let next = bytes[i + 1];
+            if next == b'[' || next == b']' {
+                i += 2;
+                continue;
+            }
+        }
+        if bytes[i] == b'[' {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Replaces `\[` with `[` and `\]` with `]` in a text segment. Other
+/// backslashes pass through unchanged. Returns `Cow::Borrowed` when no
+/// backslash is present so the no-escape fast path stays allocation-free.
+fn unescape(s: &str) -> std::borrow::Cow<'_, str> {
+    if !s.contains('\\') {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if let Some(&next) = chars.peek() {
+                if next == '[' || next == ']' {
+                    out.push(next);
+                    chars.next();
+                    continue;
+                }
+            }
+        }
+        out.push(c);
+    }
+    std::borrow::Cow::Owned(out)
+}
+
 /// Tokenizer for BBCode-style tags.
 struct Tokenizer<'a> {
     input: &'a str,
@@ -666,8 +731,9 @@ impl<'a> Iterator for Tokenizer<'a> {
         let remaining = &self.input[self.pos..];
         let start_pos = self.pos;
 
-        // Look for the next '['
-        if let Some(bracket_pos) = remaining.find('[') {
+        // Look for the next unescaped '['. `\[` and `\]` are skipped so they
+        // can be emitted as literal characters by the text path.
+        if let Some(bracket_pos) = find_unescaped_bracket(remaining) {
             if bracket_pos > 0 {
                 // There's text before the bracket
                 let text = &remaining[..bracket_pos];
@@ -1308,6 +1374,116 @@ mod tests {
                 parser.parse("[style-with-dash]text[/style-with-dash]"),
                 "text"
             );
+        }
+    }
+
+    // ==================== Escape Sequence Tests ====================
+
+    mod escapes {
+        use super::*;
+
+        #[test]
+        fn escaped_open_bracket_is_literal() {
+            let parser = BBParser::new(test_styles(), TagTransform::Remove);
+            assert_eq!(parser.parse("\\[bold\\]"), "[bold]");
+        }
+
+        #[test]
+        fn escaped_brackets_inside_known_tag() {
+            let parser = BBParser::new(test_styles(), TagTransform::Remove);
+            assert_eq!(
+                parser.parse("[bold]hello \\[world\\][/bold]"),
+                "hello [world]"
+            );
+        }
+
+        #[test]
+        fn escapes_keep_mode_emits_literal_brackets() {
+            let parser = BBParser::new(test_styles(), TagTransform::Keep);
+            assert_eq!(parser.parse("\\[bold\\]"), "[bold]");
+        }
+
+        #[test]
+        fn escapes_apply_mode_styles_around_literals() {
+            let mut styles = HashMap::new();
+            styles.insert("bold".to_string(), Style::new().bold().force_styling(true));
+            let parser = BBParser::new(styles, TagTransform::Apply);
+            let result = parser.parse("[bold]\\[x\\][/bold]");
+            // Inner text should contain literal brackets, no `[bold]` re-emitted.
+            assert!(result.contains("[x]"));
+            assert!(!result.contains("[bold]"));
+        }
+
+        #[test]
+        fn lone_backslash_is_literal() {
+            let parser = BBParser::new(test_styles(), TagTransform::Remove);
+            assert_eq!(parser.parse("path C:\\foo\\bar"), "path C:\\foo\\bar");
+        }
+
+        #[test]
+        fn trailing_backslash_is_literal() {
+            let parser = BBParser::new(test_styles(), TagTransform::Remove);
+            assert_eq!(parser.parse("end\\"), "end\\");
+        }
+
+        #[test]
+        fn double_backslash_then_open_emits_backslash_then_literal_bracket() {
+            // `\\` is not an escape sequence, so the first `\` is literal;
+            // the second `\` pairs with `[` to emit a literal `[`.
+            let parser = BBParser::new(test_styles(), TagTransform::Remove);
+            assert_eq!(parser.parse("\\\\[bold]"), "\\[bold]");
+        }
+
+        #[test]
+        fn escaped_brackets_dont_create_unknown_tags() {
+            let parser = BBParser::new(test_styles(), TagTransform::Apply);
+            let (output, errors) = parser.parse_with_diagnostics("\\[unknown\\]");
+            assert_eq!(output, "[unknown]");
+            assert!(errors.is_empty());
+        }
+
+        #[test]
+        fn escapes_pass_validation() {
+            let parser = BBParser::new(test_styles(), TagTransform::Apply);
+            assert!(parser.validate("\\[anything\\]").is_ok());
+            assert!(parser.validate("[bold]a\\[b\\]c[/bold]").is_ok());
+        }
+
+        #[test]
+        fn strip_tags_handles_escapes() {
+            assert_eq!(strip_tags("\\[bold\\]"), "[bold]");
+            assert_eq!(strip_tags("[bold]a\\[b\\]c[/bold]"), "a[b]c");
+        }
+
+        #[test]
+        fn escape_does_not_apply_inside_tag_name() {
+            // `\` is not a valid tag-name char, so the bracket scanner still
+            // sees the opening `[` and the malformed content becomes an
+            // InvalidTag passthrough rather than a styled tag.
+            let parser = BBParser::new(test_styles(), TagTransform::Keep);
+            assert_eq!(parser.parse("[bo\\ld]"), "[bo\\ld]");
+        }
+
+        #[test]
+        fn escapes_with_multibyte_text() {
+            let parser = BBParser::new(test_styles(), TagTransform::Remove);
+            assert_eq!(parser.parse("café \\[é\\] 🎉"), "café [é] 🎉");
+        }
+
+        #[test]
+        fn only_open_escaped_leaves_close_unmatched() {
+            // Escaping only the open turns it into literal text; the close
+            // becomes an unexpected close. Output contains both literally,
+            // and validation surfaces the error.
+            let parser = BBParser::new(test_styles(), TagTransform::Apply);
+            let (output, errors) = parser.parse_with_diagnostics("\\[bold]hi[/bold]");
+            assert!(output.contains("[bold]hi"));
+            assert!(output.contains("[/bold]"));
+            assert!(!errors.is_empty());
+            assert!(errors
+                .errors
+                .iter()
+                .any(|e| e.kind == UnknownTagKind::UnexpectedClose));
         }
     }
 

--- a/crates/standout-render/src/tabular/util.rs
+++ b/crates/standout-render/src/tabular/util.rs
@@ -3,7 +3,7 @@
 //! All functions in this module correctly handle ANSI escape codes: they are
 //! preserved in output but don't count toward display width calculations.
 
-use console::{measure_text_width, pad_str, Alignment};
+use console::{measure_text_width, pad_str, strip_ansi_codes, Alignment};
 use standout_bbparser::strip_tags;
 
 /// Returns the display width of a string, ignoring ANSI escape codes.
@@ -31,6 +31,9 @@ pub fn display_width(s: &str) -> usize {
 /// Use this for any text that may contain markup. For strings known to be
 /// tag-free (e.g., separator literals), [`display_width`] avoids the overhead.
 ///
+/// ANSI is stripped first so that the `[` and `]` bytes inside CSI sequences
+/// don't get mistaken for malformed BBCode tags by the tag stripper.
+///
 /// # Example
 ///
 /// ```rust
@@ -41,7 +44,8 @@ pub fn display_width(s: &str) -> usize {
 /// assert_eq!(visible_width("\x1b[31m[red]hi[/red]\x1b[0m"), 2);
 /// ```
 pub fn visible_width(s: &str) -> usize {
-    display_width(&strip_tags(s))
+    let no_ansi = strip_ansi_codes(s);
+    measure_text_width(&strip_tags(&no_ansi))
 }
 
 /// Truncates a string from the end to fit within a maximum display width.

--- a/docs/topics/standout-help.md
+++ b/docs/topics/standout-help.md
@@ -24,6 +24,22 @@ All three invocation forms produce identical output. Subcommand-level help (e.g.
 
 **Required for features:** `command_groups` and topics require `help_handling(true)`. If you configure either without it, `build()` will panic.
 
+## Styling User-Provided Strings
+
+When help interception is enabled, your clap `about` and `help` strings are rendered through standout's BBCode parser, so they can use any tag defined in your stylesheet:
+
+```rust
+#[command(name = "myapp", about = "[bold]myapp[/bold] — a small CLI")]
+struct Cli { /* ... */ }
+```
+
+To emit a literal `[` or `]` in help text, escape it with a backslash: `\[` and `\]`. Other backslashes (file paths, regex examples like `\d+`) pass through unchanged. To emit a literal `\[`, write `\\[`.
+
+```rust
+#[command(about = "Match pattern \\[regex: \\d+\\]")]
+// renders as: Match pattern [regex: \d+]
+```
+
 ## Default Behavior
 
 Without any group configuration, all subcommands appear in a single "Commands" section:


### PR DESCRIPTION
## Summary

- Adds `\[` → `[` and `\]` → `]` escape syntax to `standout-bbparser`, so user-provided strings (clap `about`/`help` text routed through `App::help_handling(true)`, custom template content, etc.) can contain literal brackets without being misparsed as tag delimiters.
- Lone backslashes pass through unchanged — file paths (`C:\foo`), regex examples (`\d+`), and other content with `\` are unaffected. Literal `\[` is expressed as `\\[`.
- Honored in all three transform modes (`Apply` / `Remove` / `Keep`) and by `strip_tags`. Doesn't generate validation errors. Correct positions reported on subsequent unknown-tag errors.

Also fixes a pre-existing failing doctest: `tabular::visible_width` was running `strip_tags` before stripping ANSI, so the `[` / `]` inside CSI sequences (`\x1b[31m...`) confused the BBCode tokenizer into eating surrounding markup as one malformed tag. ANSI is now stripped first, matching the function's documented contract.

## Implementation notes

- `standout-bbparser/src/lib.rs`: two private helpers — `find_unescaped_bracket` (used by `Tokenizer::next` when scanning for the next tag-starting `[`) and `unescape` (run on `Token::Text` content at emit time, returns `Cow::Borrowed` on the no-escape fast path so existing inputs allocate nothing extra). Byte-level scan is safe — `\`, `[`, `]` are all ASCII single-byte and can't appear as UTF-8 continuation bytes.
- `standout-render/src/tabular/util.rs`: `visible_width` now does `strip_ansi_codes` → `strip_tags` → `measure_text_width`. Doc comment updated to call out the ordering.
- `crates/standout-bbparser/src/lib.rs`: 12 new test cases under `tests::escapes` covering Apply/Remove/Keep/`strip_tags`, validation, escapes inside known tags, only-open-escaped (verifies the unmatched close still surfaces as `UnexpectedClose`), lone/trailing/double backslash, mid-tag-name backslash, and multibyte text (`café`, emoji).
- `docs/topics/standout-help.md`: new "Styling User-Provided Strings" section with a concrete clap `#[command(about = ...)]` example.
- `CHANGELOG.md`: entries under `[Unreleased]` for both the feature and the fix.

## Test plan

- [x] `cargo test -p standout-bbparser` — 96 unit + 5 integration + 5 doc all pass
- [x] `cargo test --workspace` — all crates green; the previously-failing `visible_width` doctest now passes
- [ ] Manual: `tdoo --help` in `crates/todo-example` to eyeball that nothing changed for help text without tags
- [ ] Manual: temporarily add `[bold]` to a clap `about` string and re-run `--help` to confirm styled output

🤖 Generated with [Claude Code](https://claude.com/claude-code)