### PR TITLE
fix(ci): use canonical gh-dagentic name in reusable workflow ref

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,10 +5,11 @@ This is a Rust project (CLI, library crate, or workspace).
 ## Before suggesting a fix
 
 - Run the project's umbrella check script if one exists (in `scripts/`,
-  commonly named `check`, `pre-commit`, `ci.sh`, or `rust-pre-commit` — run
+  commonly named `check`, `pre-commit`, `rust-pre-commit`, or `ci.sh` — run
   `ls scripts/` to see which); otherwise `cargo fmt --check && cargo clippy
-  -- -D warnings && cargo test`. CI runs the same; suggestions that don't
-  pass won't merge.
+  -- -D warnings && cargo test` (some projects use `cargo nextest run`
+  instead of `cargo test`). CI runs the same; if your suggestion doesn't
+  pass, it won't merge — check `.github/workflows/` for the source of truth.
 - Never propose changes that leave tests failing.
 - Update the changelog's `Unreleased` section for user-visible changes
   (`CHANGELOG_UNRELEASED.md` if the project has one, otherwise the
@@ -33,6 +34,6 @@ This is a Rust project (CLI, library crate, or workspace).
 - Style nits in code that already follows the project's style.
 - Defensive error handling for invariants the type system already enforces.
 - Comments that restate what the code does.
-- Pinning org-internal reusable workflows (e.g. `arthur-debert/dagentic`) to
-  SHA — the reusable pattern is "fix once, propagate", and same-owner
+- Pinning org-internal reusable workflows (e.g. `arthur-debert/gh-dagentic`)
+  to SHA — the reusable pattern is "fix once, propagate", and same-owner
   supply-chain risk is negligible.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 ## Checklist
 
 - [ ] Changelog `Unreleased` section updated (or chore/docs-only)
-- [ ] Project umbrella check passes locally — `scripts/check`, `scripts/pre-commit`, `scripts/ci.sh`, or `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
+- [ ] Project umbrella check passes locally — `scripts/{check,pre-commit,rust-pre-commit,ci.sh}` or `cargo fmt --check && cargo clippy -- -D warnings && cargo test` (or `cargo nextest run`)
 - [ ] Tests added or updated for behavior changes
 
 ## Notes for reviewers

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -10,6 +10,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: arthur-debert/dagentic/.github/workflows/copilot-review.yml@main
+    uses: arthur-debert/gh-dagentic/.github/workflows/copilot-review.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Replaces `arthur-debert/dagentic` (a GitHub repo redirect) with the canonical name `arthur-debert/gh-dagentic` in `.github/workflows/copilot-review.yml`. Workflow `uses:` does NOT follow repo redirects, so the auto-trigger has been failing on every PR with "workflow file issue" since the policy sweep landed.

Also re-syncs the other policy files (copilot-instructions.md, pull_request_template.md) with the latest canonical templates.

Same fix landed in arthur-debert/dodot#84 and is now being swept across the other repos onboarded in the policy rollout.

## Checklist

- [x] Changelog `Unreleased` section updated (or chore/docs-only) — chore (CI fix)
- [x] Project umbrella check passes locally — N/A (config-only)
- [x] Tests added or updated for behavior changes (N/A — config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)