### PR TITLE
chore(dependabot): group github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,13 @@
+# Dependabot config — see arthur-debert/release/README.md "Dependabot policy"
+#
+# Application-dependency freshness (cargo) is deliberately not enabled.
+# Major-version sweeps are evaluated as development work, not pushed by a bot.
+# Security exposure for cargo deps is covered by Dependabot security updates,
+# which are enabled per-repo via the GitHub API (not this file).
+#
+# Only github-actions freshness is enabled — old action versions silently
+# break when GitHub deprecates a runtime, so a low-volume freshness stream
+# here is worth the cost.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -5,3 +15,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      gh-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Adds `groups: gh-actions: patterns: ["*"]` so Dependabot opens one combined PR per week instead of one per action. Aligns with the canonical template at arthur-debert/release.