### PR TITLE
feat(dev-env): canonical setup-dev-env.sh + SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/setup-dev-env.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ local
 site/
 book/
 .claude/
+
+# Canonical SessionStart hook is tracked
+!.claude/settings.json

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# scripts/setup-dev-env.sh — per-session dev-environment setup, invoked by
+# the SessionStart hook in .claude/settings.json.
+#
+# Source of truth: arthur-debert/release templates/setup-dev-env.sh.
+# Re-sync via the gh-repo-setup skill (or by copying this file verbatim).
+# Repos that need project-specific extras (Xvfb daemon, pinned-binary
+# fetch, extra rustup targets, etc.) append them below the marker at the
+# bottom — anything above it is rsync'd from the template.
+#
+# Cloud-only: local sessions exit early (devs already have their env).
+# Detects stack by filesystem signals — handles rust, node, ruby, python,
+# and consumers with no project deps (just lefthook / hand-rolled hook
+# wiring).
+#
+# Idempotent — safe to re-run. Errors are best-effort: a failure in one
+# step does not abort the rest (transient registry hiccups shouldn't
+# block the lefthook install).
+
+set -euo pipefail
+
+# Cloud-only gate. Local sessions already have their env set up.
+[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+# --- 1. Universal git hygiene --------------------------------------------
+# Cloud clones are shallow; restore submodule content and release tags.
+# Submodule update is a no-op when in sync; tag fetch is one round-trip.
+
+if [ -f .gitmodules ]; then
+  git submodule update --init --recursive --quiet || true
+fi
+git fetch --tags --quiet origin || true
+
+# --- 2. Project dep cache ------------------------------------------------
+# Pick the right tool based on lockfile / manifest. Per stack, idempotent.
+
+# Rust: cargo fetch with --locked so we don't silently mutate Cargo.lock.
+if [ -f Cargo.toml ] && command -v cargo >/dev/null 2>&1; then
+  cargo fetch --locked --quiet || true
+fi
+
+# Node (npm/yarn/pnpm). We deliberately do NOT guard on `! -d node_modules`:
+# the env-snapshot caches a node_modules paired with a previous branch's
+# lockfile, and a feature branch that bumps the lockfile (Playwright is
+# the canonical case) drifts silently. Re-installing when already in sync
+# is ~2s; chasing a stale lockfile bug is hours. Pay the two seconds.
+if [ -f package.json ]; then
+  if [ -f package-lock.json ] && command -v npm >/dev/null 2>&1; then
+    npm ci 2>/dev/null || npm install
+  elif [ -f yarn.lock ] && command -v yarn >/dev/null 2>&1; then
+    yarn install --frozen-lockfile 2>/dev/null || yarn install
+  elif [ -f pnpm-lock.yaml ] && command -v pnpm >/dev/null 2>&1; then
+    pnpm install --frozen-lockfile 2>/dev/null || pnpm install
+  fi
+fi
+
+# Ruby / Bundler.
+if [ -f Gemfile ] && command -v bundle >/dev/null 2>&1; then
+  bundle install --quiet || true
+fi
+
+# Python / pip + venv. Only initialise if .venv missing — pip install is
+# slower than node/cargo and the guard wins more than it costs.
+if [ -f pyproject.toml ] && [ ! -d .venv ] && command -v python3 >/dev/null 2>&1; then
+  python3 -m venv .venv
+  .venv/bin/pip install --upgrade pip --quiet || true
+  .venv/bin/pip install -e '.[dev]' --quiet 2>/dev/null \
+    || .venv/bin/pip install -e . --quiet 2>/dev/null \
+    || true
+fi
+
+# --- 3. Pre-commit hook wiring -------------------------------------------
+# Default: lefthook (binary installed at env-setup time). Fallback for
+# repos that ship a hand-rolled scripts/pre-commit instead (zed-lex,
+# tree-sitter-lex pattern): symlink it into .git/hooks/.
+
+if [ -f lefthook.yml ] && command -v lefthook >/dev/null 2>&1; then
+  if ! lefthook install >/dev/null; then
+    echo "warning: lefthook install failed — pre-commit hook NOT wired" >&2
+  fi
+elif [ -x scripts/pre-commit ]; then
+  mkdir -p .git/hooks
+  ln -sf ../../scripts/pre-commit .git/hooks/pre-commit
+fi
+
+# --- 4. Project-local extras ---------------------------------------------
+# Everything above this marker is the canonical cross-repo setup-dev-env.sh
+# from arthur-debert/release templates/setup-dev-env.sh. Do NOT modify it
+# in-place; consumers append project-specific steps BELOW this marker.
+# (See e.g. lex-fmt/lexed for an Xvfb start, lex-fmt/nvim for pinned-bin
+# fetches.)
+
+exit 0


### PR DESCRIPTION
Brings this rust workspace (10 library crates) repo onto the canonical cross-repo cloud-env contract. Source: `arthur-debert/release` `templates/setup-dev-env.sh`. Cloud-only — local sessions exit early via the `CLAUDE_CODE_REMOTE` gate.