### PR TITLE
feat(ci): adopt rust-ci.yml reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,24 @@
 name: CI
 
+# Thin caller for the canonical reusable Rust CI workflow at
+# arthur-debert/release. Replaces the previously hand-rolled
+# rust-toolchain + Swatinem cache + bin/check sequence.
+#
+# See docs/per-stack/rust-ci.md in arthur-debert/release for the
+# full input reference. dodot is the reference adopter.
+#
+# standout is a rust-lib workspace (no top-level binary crate
+# shipping a CLI), so neither `binary-name` nor `bats` is set —
+# just runs the canonical `bin/check` umbrella on one Linux runner.
+
 on:
   push:
-    branches:
-      - '**'
+    branches: ['**']
   pull_request:
 
 permissions:
   contents: read
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-        # Version and components are read from rust-toolchain.toml
-
-      - name: Cache Rust toolchain and cargo artifacts
-        uses: Swatinem/rust-cache@v2
-
-      - name: Run CI checks
-        run: ./bin/check
+  ci:
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@take-iii


### PR DESCRIPTION
## Summary
- Replace hand-rolled ci.yml with a thin caller to `arthur-debert/release/.github/workflows/rust-ci.yml@take-iii`.
- standout is a rust-lib workspace (no top-level CLI binary), so neither `binary-name` nor `bats` is set.
- The toolchain pin in `rust-toolchain.toml` is still honored via the shared `setup-rust` composite action.
- dodot is the reference adopter; see release/'s `docs/per-stack/rust-ci.md`.

## Required-checks rename
Job name changes from `test` to `ci / check`. Ruleset updated in the same sweep via `apply-ruleset --checks "ci / check"`.

## Test plan
- [ ] `ci / check` (fmt + lint + tests) goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)