### PR TITLE
chore(release): seed [Unreleased] for first canonical dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- First release through the canonical `arthur-debert/release/.github/workflows/rust-lib.yml@v1` reusable workflow (replacing the hand-rolled `publish.yml` tag-push trigger). No source changes; this dispatch validates the canonical rust-lib pipeline end-to-end for the standout workspace's 8 published crates.
+
 ## [7.6.2] - 2026-04-30
 
 ### Added


### PR DESCRIPTION
## Summary
- Adds a one-line `[Unreleased]` entry to CHANGELOG.md so `roll-changelog.sh` accepts the upcoming dispatch through `rust-lib.yml@v1`.
- No source changes. This unblocks the first canonical release for the 8-crate standout workspace and flips the rust-lib stack from *implemented* to *pilot-running* (alongside clapfig).

## Test plan
- [x] CHANGELOG `[Unreleased]` is non-empty (roll-changelog hard-rejects empty unreleased)
- [ ] CI green on this PR
- [ ] After merge, dispatch `release.yml -f version=7.6.3` and verify the canonical pipeline ships all 8 crates to crates.io + a GH release.

Refs arthur-debert/release#166