### PR TITLE
chore: canonical changelog lint ignores (closes arthur-debert/release#237)

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,6 @@
+# Changelog files are generated / historical content where markdownlint
+# defaults structurally disagree with Keep-a-Changelog convention
+# (MD024 duplicate headings, MD041 first-line heading, MD013 line length).
+# Per arthur-debert/release#237.
 CHANGELOG.md
-CHANGELOG/legacy.md
+CHANGELOG/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Changelog files are generated / historical content. Re-policing
+# format buys nothing. Per arthur-debert/release#237.
+CHANGELOG.md
+CHANGELOG/


### PR DESCRIPTION
Add canonical .markdownlintignore + .prettierignore for CHANGELOG files per [arthur-debert/release#237](https://github.com/arthur-debert/release/issues/237).