### PR TITLE
chore: lint cleanup for strict shell-quality gate

### DIFF
--- a/ARCHITECTURE_REVIEW.md
+++ b/ARCHITECTURE_REVIEW.md
@@ -14,11 +14,11 @@ The framework's fragility stems from **five fundamental design issues**:
 
 ## Issue 1: The App/LocalApp Split (Critical)
 
-### Current State
+### Current State (Issue 1)
 
 The codebase has two parallel hierarchies that duplicate ~80% of their logic:
 
-```
+```text
 App (671 lines)           ←→  LocalApp (410 lines)
 AppBuilder (295 lines)    ←→  LocalAppBuilder (617 lines)
 ClosureRecipe             ←→  LocalClosureRecipe
@@ -43,6 +43,7 @@ The same dispatch logic is repeated **6+ times** across these files:
 | `local_builder.rs:181-232` | `LocalStructRecipe::create_dispatch` | Local struct |
 
 Each implementation has the same pattern:
+
 ```rust
 match result {
     Ok(HandlerOutput::Render(data)) => {
@@ -74,9 +75,10 @@ The split exists because of a **type-level constraint mismatch**:
 
 The framework chose to duplicate everything rather than abstract over this difference.
 
-### Recommended Fix
+### Recommended Fix (Issue 1)
 
 Create a shared `AppCore<M: HandlerMode>` that contains:
+
 - All rendering logic
 - Output mode handling
 - Hook execution
@@ -112,7 +114,7 @@ struct AppCore<M: HandlerMode> {
 
 ## Issue 2: Optional Fields with Silent Fallbacks (High)
 
-### Current State
+### Current State (Issue 2)
 
 Multiple critical fields are `Option<T>` with inconsistent fallback behavior:
 
@@ -123,7 +125,7 @@ pub(crate) stylesheet_registry: Option<StylesheetRegistry>,
 pub(crate) theme: Option<Theme>,
 ```
 
-### The Problem
+### The Problem (Issue 2)
 
 When these are `None`, methods behave silently:
 
@@ -142,15 +144,16 @@ let theme = self.theme.clone().unwrap_or_default();
 ```
 
 **The caller cannot distinguish:**
+
 - "No templates configured" (misconfiguration) vs
 - "Templates configured but empty" (valid state) vs
 - "Templates not needed for this use case" (intentional)
 
-### Manifestation
+### Manifestation (Issue 2)
 
 User configures templates incorrectly → `template_names()` returns empty → no error → rendering fails later with confusing message about template not found.
 
-### Recommended Fix
+### Recommended Fix (Issue 2)
 
 **Option A: Null Object Pattern** (for optional features)
 
@@ -200,7 +203,7 @@ fn build_minimal(self) -> App<Minimal>                    // No templates needed
 
 ## Issue 3: Panic-Based Invariant Enforcement (High)
 
-### Current State
+### Current State (Issue 3)
 
 Multiple places use `panic!` or `.expect()` for configuration errors:
 
@@ -225,7 +228,7 @@ opt.as_ref()
     .expect("finalized_commands should be Some after ensure_commands_finalized")
 ```
 
-### The Problem
+### The Problem (Issue 3)
 
 These are **build-time configuration errors** that manifest as **runtime panics**:
 
@@ -249,7 +252,7 @@ fn create_dispatch(&self, ...) -> DispatchFn {
 
 This encodes a **runtime invariant** ("this function must only be called once") that should be a **compile-time guarantee**.
 
-### Recommended Fix
+### Recommended Fix (Issue 3)
 
 **For configuration errors:** Return `Result` from builder methods:
 
@@ -284,14 +287,15 @@ impl ErasedConfigRecipe {
 
 ## Issue 4: Missing Defensive Defaults (Medium)
 
-### Current State
+### Current State (Issue 4)
 
 When optional features aren't configured, code either:
+
 1. Silently returns empty results (templates, themes)
 2. Uses hardcoded defaults (OutputMode::Auto)
 3. Panics (missing required state)
 
-### Manifestation
+### Manifestation (Issue 4)
 
 Example: User forgets to configure templates but uses render():
 
@@ -305,11 +309,12 @@ app.render("list", &data, OutputMode::Term)?;
 ```
 
 The error is confusing because:
+
 1. It happens at render time, not build time
 2. "registry" is internal jargon
 3. No hint about how to fix it
 
-### Recommended Fix
+### Recommended Fix (Issue 4)
 
 **Fail fast at configuration time:**
 
@@ -347,7 +352,7 @@ impl NullTemplateRegistry {
 
 ## Issue 5: Untested Configuration Combinatorics (Medium)
 
-### Current State
+### Current State (Issue 5)
 
 The framework has multiple orthogonal configuration dimensions:
 
@@ -360,26 +365,28 @@ The framework has multiple orthogonal configuration dimensions:
 | Help system | Enabled, Disabled | 2 |
 | Output flag | Enabled, Custom name, Disabled | 3 |
 
-**Total combinations: 8 × 2 × 3 × 4 × 2 × 3 = 1,152**
+**Total combinations:** 8 × 2 × 3 × 4 × 2 × 3 = 1,152
 
 ### Current Test Coverage
 
 From the exploration, integration tests cover:
+
 - OutputMode::Term: 2 tests
 - OutputMode::Json: 3 tests
 - OutputMode::Text: 1 test
 - Other modes: 0 tests
 
-**Coverage: <1% of configuration space**
+**Coverage:** <1% of configuration space
 
-### Manifestation
+### Manifestation (Issue 5)
 
 Real-world user reports bugs like:
+
 - "JSON output doesn't respect theme" (works in Term, not in Json)
 - "LocalApp doesn't render templates correctly" (works in App)
 - "Embedded templates work but file-based don't" (different code paths)
 
-### Recommended Fix
+### Recommended Fix (Issue 5)
 
 **Property-based testing with configuration generators:**
 
@@ -431,7 +438,7 @@ fn output_mode_with_theme_matrix(mode: OutputMode, with_theme: bool) {
 
 ## Issue 6: Feature Flag Complexity (Low-Medium)
 
-### Current State
+### Current State (Issue 6)
 
 The `clap` feature gates significant functionality:
 
@@ -447,23 +454,25 @@ pub use dispatch::*;
 // ... etc
 ```
 
-### The Problem
+### The Problem (Issue 6)
 
 1. **Without `clap`**: Only rendering functions available, no App/LocalApp
 2. **With `clap`**: Full CLI framework
 
 This is a reasonable split, BUT:
+
 - The rendering core (`render_auto`, `Theme`, `TemplateRegistry`) works without `clap`
 - But they're not well-tested independently
 - Some code assumes clap is always available (uses `clap::ArgMatches` in signatures)
 
-### Manifestation
+### Manifestation (Issue 6)
 
 Users who want just the rendering engine (without CLI) may find:
+
 - Missing functionality that's gated behind `clap`
 - Confusing imports that don't work without the feature
 
-### Recommended Fix
+### Recommended Fix (Issue 6)
 
 **Clear feature boundaries with separate test suites:**
 
@@ -477,6 +486,7 @@ full = ["cli", "macros"]
 ```
 
 **Test each feature level:**
+
 ```rust
 // tests/rendering_only.rs
 #![cfg(not(feature = "cli"))]
@@ -492,7 +502,8 @@ full = ["cli", "macros"]
 ## Prioritized Remediation Plan
 
 ### Phase 1: Stop the Bleeding (1-2 weeks)
-**Goal: Prevent new breakage, improve error messages**
+
+**Goal:** Prevent new breakage, improve error messages
 
 1. **Replace panics with Results in builder methods**
    - `default_command()` → returns `Result<Self, BuilderError>`
@@ -507,9 +518,10 @@ full = ["cli", "macros"]
    - Test each OutputMode with and without theme
 
 ### Phase 2: Unify App/LocalApp (2-4 weeks)
-**Goal: Eliminate code duplication, ensure feature parity**
 
-*Note: You mentioned this is in progress*
+**Goal:** Eliminate code duplication, ensure feature parity
+
+*Note:* You mentioned this is in progress
 
 1. **Extract `AppCore<M>` with shared logic**
    - Rendering, output mode handling, hook execution
@@ -528,9 +540,11 @@ full = ["cli", "macros"]
    - LocalApp gets help interception
 
 ### Phase 3: Configuration Safety (2-3 weeks)
-**Goal: Make misconfiguration impossible or obvious**
+
+**Goal:** Make misconfiguration impossible or obvious
 
 1. **Type-state builders**
+
    ```rust
    AppBuilder<NoTemplates>  →  .templates()  →  AppBuilder<HasTemplates>
    AppBuilder<HasTemplates> →  .build()      →  RenderableApp
@@ -542,6 +556,7 @@ full = ["cli", "macros"]
    - Warn on unused configuration
 
 3. **Configuration diagnostics**
+
    ```rust
    let app = App::builder()
        // ...
@@ -549,7 +564,8 @@ full = ["cli", "macros"]
    ```
 
 ### Phase 4: Comprehensive Testing (Ongoing)
-**Goal: Prevent regression, cover configuration space**
+
+**Goal:** Prevent regression, cover configuration space
 
 1. **Property-based tests** for rendering invariants
 2. **Snapshot tests** for all output modes
@@ -576,7 +592,7 @@ full = ["cli", "macros"]
 The framework's fragility is not from any single issue but from the **accumulation of design decisions that optimized for initial development speed over long-term maintainability**:
 
 1. **Copy-paste vs abstraction**: Duplication was faster than designing proper abstractions
-2. **Option<T> vs explicit states**: Options are easier to add than modeling configuration states
+2. **`Option<T>` vs explicit states**: Options are easier to add than modeling configuration states
 3. **panic! vs Result**: Panics are shorter to write than proper error handling
 4. **Happy path vs defensive**: Testing the happy path is faster than testing edge cases
 

--- a/crates/standout-dispatch/README.md
+++ b/crates/standout-dispatch/README.md
@@ -21,7 +21,7 @@ CLI commands typically mix business logic with output formatting: database queri
 
 **standout-dispatch** enforces a clean separation:
 
-```
+```text
 CLI args → Handler (logic) → Data → Renderer (presentation) → Output
 ```
 
@@ -213,14 +213,17 @@ fn main() -> anyhow::Result<()> {
 ## Documentation
 
 ### Guides
+
 - [Introduction to Dispatch](docs/guides/intro-to-dispatch.md) — Complete dispatch tutorial
 
 ### Topics
+
 - [Handler Contract](docs/topics/handler-contract.md) — Handler types, Output enum, testing
 - [Execution Model](docs/topics/execution-model.md) — Pipeline, hooks, command routing
 - [Partial Adoption](docs/topics/partial-adoption.md) — Incremental migration strategies
 
 ### Reference
+
 - [API Documentation](https://docs.rs/standout-dispatch) — Full API reference
 
 ## Used By

--- a/crates/standout-dispatch/docs/guides/intro-to-dispatch.md
+++ b/crates/standout-dispatch/docs/guides/intro-to-dispatch.md
@@ -77,6 +77,7 @@ fn list_handler(matches: &ArgMatches, _ctx: &CommandContext) -> HandlerResult<Li
 ```
 
 The handler:
+
 - Receives parsed arguments (`&ArgMatches`) and execution context
 - Returns a `Result` with serializable data
 - Contains zero presentation logic

--- a/crates/standout-dispatch/docs/topics/app-state.md
+++ b/crates/standout-dispatch/docs/topics/app-state.md
@@ -37,7 +37,7 @@ let app = App::builder()
     .build()?;
 ```
 
-### Access in Handlers
+### Accessing App State in Handlers
 
 ```rust
 fn list_handler(matches: &ArgMatches, ctx: &CommandContext) -> HandlerResult<Vec<Item>> {
@@ -107,7 +107,7 @@ let hooks = Hooks::new()
     });
 ```
 
-### Access in Handlers
+### Accessing Extensions in Handlers
 
 ```rust
 fn list_handler(matches: &ArgMatches, ctx: &CommandContext) -> HandlerResult<Vec<Item>> {
@@ -127,7 +127,7 @@ fn list_handler(matches: &ArgMatches, ctx: &CommandContext) -> HandlerResult<Vec
 
 ## When to Use Which
 
-### Use App State For:
+### Use App State For
 
 - **Database connections** - Expensive to create, should be pooled
 - **Configuration** - Loaded once at startup
@@ -135,7 +135,7 @@ fn list_handler(matches: &ArgMatches, ctx: &CommandContext) -> HandlerResult<Vec
 - **Caches** - Shared lookup tables or memoization
 - **Feature flags** - Global toggles loaded at startup
 
-### Use Extensions For:
+### Use Extensions For
 
 - **User context** - Current user, session, permissions
 - **Request metadata** - Request ID, timing, correlation ID
@@ -212,7 +212,7 @@ if let Some(cache) = ctx.app_state.get::<Cache>() {
 
 `get_required` produces descriptive errors:
 
-```
+```text
 Extension missing: type myapp::Database not found in context
 ```
 

--- a/crates/standout-dispatch/docs/topics/execution-model.md
+++ b/crates/standout-dispatch/docs/topics/execution-model.md
@@ -264,6 +264,7 @@ fn(&serde_json::Value, &str) -> Result<String, RenderError>
 ```
 
 Parameters:
+
 - `data`: The serialized handler output
 - `view`: A view/template name hint (can be ignored)
 

--- a/crates/standout-dispatch/docs/topics/partial-adoption.md
+++ b/crates/standout-dispatch/docs/topics/partial-adoption.md
@@ -22,6 +22,7 @@ Many CLI frameworks require a complete rewrite:
 ### Step 1: Identify a Good Starting Command
 
 Pick a command that:
+
 - Is self-contained (few dependencies on other commands)
 - Has clear inputs and outputs
 - Would benefit from structured output (JSON, etc.)
@@ -82,6 +83,7 @@ fn main() {
 ### Step 4: Repeat
 
 Migrate one command at a time. Each migration:
+
 - Is a small, reviewable change
 - Can be tested independently
 - Doesn't affect other commands

--- a/crates/standout-input/docs/design.md
+++ b/crates/standout-input/docs/design.md
@@ -6,7 +6,7 @@
 
 This is the symmetric counterpart to `standout-pipe`:
 
-```
+```text
 standout-pipe:   Handler → Render → [jq/tee/clipboard]   (output flows OUT)
 standout-input:  [arg/stdin/editor/prompt] → Handler     (input flows IN)
 ```
@@ -22,7 +22,7 @@ standout-input:  [arg/stdin/editor/prompt] → Handler     (input flows IN)
 
 ## Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                    standout-input (core)                         │
 │                                                                  │
@@ -221,6 +221,7 @@ impl EditorCollector {
 ```
 
 Editor detection follows conventions:
+
 1. Check env vars in order (default: `VISUAL`, then `EDITOR`)
 2. Fall back to platform defaults (`vim` on Unix, `notepad` on Windows)
 3. Search PATH for common editors
@@ -462,6 +463,7 @@ pub fn create(
 ## Implementation Phases
 
 ### Phase 1: Core Structure
+
 - `InputCollector<T>` trait
 - `InputChain<T>` builder
 - `InputError` type
@@ -469,16 +471,19 @@ pub fn create(
 - Basic tests
 
 ### Phase 2: Backends
+
 - `feature = "editor"`: `EditorCollector` with tempfile + which
 - `feature = "simple-prompts"`: `SimpleText`, `SimpleConfirm`
 - `feature = "inquire"`: Full inquire adapter suite
 
 ### Phase 3: Standout Integration
+
 - Builder API support (`.input()` method)
 - Pre-dispatch resolution hook
 - Documentation and examples
 
 ### Future Considerations
+
 - `feature = "dialoguer"`: Dialoguer adapter (shares console with standout-render)
 - `feature = "validify"`: Deep validation integration
 - `#[input]` attribute for handler macro

--- a/crates/standout-input/docs/guides/intro-to-input.md
+++ b/crates/standout-input/docs/guides/intro-to-input.md
@@ -46,6 +46,7 @@ fn get_message(matches: &ArgMatches) -> Result<String, Error> {
 ```
 
 Problems:
+
 - Imperative logic obscures the intended priority
 - Hard to test (stdin, environment, terminal detection)
 - Duplicated across commands
@@ -71,6 +72,7 @@ let message = InputChain::<String>::new()
 The chain tries each source in order. The first source that provides input wins. If all sources return `None`, the chain returns `InputError::NoInput`.
 
 Benefits:
+
 - **Declarative** — Priority is explicit and readable
 - **Testable** — All sources accept mocks for deterministic testing
 - **Composable** — Build chains for different commands with shared sources
@@ -107,6 +109,7 @@ let message = InputChain::<String>::new()
 ```
 
 This chain:
+
 1. Checks if `--message` was provided
 2. If not, reads from stdin (only if piped, not interactive)
 3. Falls back to the default value

--- a/crates/standout-input/docs/topics/backends.md
+++ b/crates/standout-input/docs/topics/backends.md
@@ -55,6 +55,7 @@ let source = ArgSource::new("message");  // Reads --message or -m
 ```
 
 **Behavior:**
+
 - `is_available()`: Returns `true` if the argument was provided
 - `collect()`: Returns `Some(value)` if present, `None` otherwise
 - Type: `String`
@@ -71,6 +72,7 @@ let source = FlagSource::new("no-color").inverted();  // --no-color → false
 ```
 
 **Behavior:**
+
 - `is_available()`: Returns `true` if the flag was provided (set to true)
 - `collect()`: Returns `Some(true)` if set, `None` otherwise
 - `inverted()`: Inverts the logic (flag set → `false`)
@@ -88,12 +90,14 @@ let source = StdinSource::new().trim(false);  // Don't trim whitespace
 ```
 
 **Behavior:**
+
 - `is_available()`: Returns `true` if stdin is piped (not a terminal)
 - `collect()`: Reads all stdin content, returns `None` if empty
 - `trim`: Whether to trim leading/trailing whitespace (default: `true`)
 - Type: `String`
 
 **Testing:**
+
 ```rust
 use standout_input::{StdinSource, MockStdin};
 
@@ -113,11 +117,13 @@ let source = EnvSource::new("GITHUB_TOKEN");
 ```
 
 **Behavior:**
+
 - `is_available()`: Returns `true` if the variable is set and non-empty
 - `collect()`: Returns `Some(value)` if set, `None` otherwise
 - Type: `String`
 
 **Testing:**
+
 ```rust
 use standout_input::{EnvSource, MockEnv};
 
@@ -139,12 +145,14 @@ let source = ClipboardSource::new();
 ```
 
 **Behavior:**
+
 - `is_available()`: Returns `true` if clipboard has non-empty text content
 - `collect()`: Returns clipboard text, `None` if empty
 - Platform: Uses `pbpaste` (macOS), `xclip` (Linux)
 - Type: `String`
 
 **Testing:**
+
 ```rust
 use standout_input::{ClipboardSource, MockClipboard};
 
@@ -193,6 +201,7 @@ let source = EditorSource::new()
 ### Editor Detection
 
 Editors are detected in this order:
+
 1. `$VISUAL` environment variable (supports GUI editors like VS Code)
 2. `$EDITOR` environment variable
 3. Platform fallbacks: `vim`, `vi`, `nano` on Unix; `notepad` on Windows
@@ -257,12 +266,14 @@ let source = TextPromptSource::new("Email: ").trim(false);
 ```
 
 **Behavior:**
+
 - `is_available()`: Returns `true` if stdin is a terminal
 - `collect()`: Prints prompt, reads line, returns `None` if empty
 - `can_retry()`: Returns `true`
 - Type: `String`
 
 **Testing:**
+
 ```rust
 use standout_input::{TextPromptSource, MockTerminal};
 
@@ -288,6 +299,7 @@ let source = ConfirmPromptSource::new("Delete all?").default(false);
 ```
 
 **Behavior:**
+
 - `is_available()`: Returns `true` if stdin is a terminal
 - `collect()`: Prints prompt with `[y/n]`, `[Y/n]`, or `[y/N]` suffix based on default
 - Accepts: `y`, `yes`, `Y`, `YES` → `true`; `n`, `no`, `N`, `NO` → `false`
@@ -297,6 +309,7 @@ let source = ConfirmPromptSource::new("Delete all?").default(false);
 - Type: `bool`
 
 **Testing:**
+
 ```rust
 use standout_input::{ConfirmPromptSource, MockTerminal};
 
@@ -568,6 +581,7 @@ fn test_config_source() {
 | Inquire | `inquire` | inquire | InquireText, InquireConfirm, InquireSelect, InquireMultiSelect, InquirePassword, InquireEditor |
 
 All sources follow the same pattern:
+
 1. Implement `InputCollector<T>`
 2. Accept a mock via `with_reader()` or `with_runner()`
 3. Return `Ok(None)` to pass to the next source in the chain

--- a/crates/standout-input/docs/topics/framework-integration.md
+++ b/crates/standout-input/docs/topics/framework-integration.md
@@ -52,7 +52,7 @@ The chain runs in the **pre-dispatch** phase — before the handler is called �
 
 `standout`'s execution pipeline runs hooks in three phases:
 
-```
+```text
 parsed CLI args → PRE-DISPATCH → handler → POST-DISPATCH → render → POST-OUTPUT
 ```
 
@@ -146,7 +146,7 @@ Chain-level validation runs as part of `resolve_with_source`. If validation fail
 
 If the user runs `mycli create --body "   "`, the framework reports:
 
-```
+```text
 Hook error: input `body`: validation failed: body must not be empty
 ```
 

--- a/crates/standout-input/docs/topics/input-sources.md
+++ b/crates/standout-input/docs/topics/input-sources.md
@@ -41,7 +41,7 @@ Standout's input system integrates as a pre-handler phase, running *before* your
 
 Input sources fall into two categories:
 
-### Non-Interactive Sources
+### Non-Interactive Sources at a Glance
 
 These work in scripts and CI pipelines:
 
@@ -53,7 +53,7 @@ These work in scripts and CI pipelines:
 | **Env** | Environment variable |
 | **Default** | Hardcoded fallback |
 
-### Interactive Sources
+### Interactive Sources at a Glance
 
 These require a TTY and user interaction:
 
@@ -448,7 +448,7 @@ Input sources and output piping are symmetric but opposite:
 | Interactive | Can be (editor) | Never |
 | Purpose | Acquire content | Transform/route output |
 
-```
+```text
               INPUT SOURCES                    OUTPUT PIPING
               ↓                                ↓
 [Arg/Stdin/Editor] → Handler → Render → [jq/tee/clipboard]

--- a/crates/standout-input/docs/topics/interactive-flows.md
+++ b/crates/standout-input/docs/topics/interactive-flows.md
@@ -106,6 +106,7 @@ let proceed = InquireConfirm::new("Continue?")
 ```
 
 Behavior:
+
 - Stdin not a TTY *or* empty submission → `InputError::NoInput`
 - Otherwise → the typed value
 - User cancellation is **backend-specific**:

--- a/crates/standout-pipe/docs/topics/piping.md
+++ b/crates/standout-pipe/docs/topics/piping.md
@@ -213,6 +213,7 @@ This is useful for transformations that don't need a shell command.
 **Piped content is always plain text.** This matches standard shell behavior where `command | other_command` receives unformatted output because stdout is not a TTY.
 
 When you pipe output:
+
 - The piped content has all ANSI escape codes stripped automatically
 - Terminal display still shows rich formatting (colors, bold, etc.)
 - Clipboard operations receive clean, pasteable text
@@ -227,6 +228,7 @@ cfg.template("[bold]{{ title }}[/bold]: [green]{{ count }}[/green]")
 ```
 
 This is implemented using the framework's two-pass rendering:
+
 1. Template engine produces output with `[style]...[/style]` tags
 2. `apply_style_tags` is called twice: once with ANSI codes for terminal, once stripped for piping
 

--- a/crates/standout-render/README.md
+++ b/crates/standout-render/README.md
@@ -35,7 +35,7 @@ The result: output that's easy to write, easy to change, and looks polished.
 
 ### Two-Pass Rendering Pipeline
 
-```
+```text
 Template + Data → MiniJinja → Text with style tags → BBParser → ANSI output
 ```
 
@@ -175,15 +175,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ## Documentation
 
 ### Guides
+
 - [Introduction to Rendering](docs/guides/intro-to-rendering.md) — Complete rendering tutorial
 - [Introduction to Tabular](docs/guides/intro-to-tabular.md) — Column layouts and tables
 
 ### Topics
+
 - [Styling System](docs/topics/styling-system.md) — Themes, adaptive styles, CSS syntax
 - [Templating](docs/topics/templating.md) — MiniJinja, style tags, processing modes
 - [File System Resources](docs/topics/file-system-resources.md) — Hot reload, registries, embedding
 
 ### Reference
+
 - [API Documentation](https://docs.rs/standout-render) — Full API reference
 
 ## Used By

--- a/crates/standout-render/docs/guides/intro-to-rendering.md
+++ b/crates/standout-render/docs/guides/intro-to-rendering.md
@@ -297,6 +297,7 @@ let output = render_with_output(template, &data, &theme, OutputMode::Auto)?;
 ```
 
 In auto mode:
+
 - TTY with color support → rich output
 - Pipe or redirect → plain text
 

--- a/crates/standout-render/docs/topics/file-system-resources.md
+++ b/crates/standout-render/docs/topics/file-system-resources.md
@@ -7,11 +7,13 @@
 ## The Development Workflow
 
 During development, you want to:
+
 1. Edit a template or stylesheet
 2. Re-run your program
 3. See changes immediately
 
 During release, you want:
+
 1. A single binary with no external dependencies
 2. No file paths to manage
 3. No risk of missing assets
@@ -42,6 +44,7 @@ let output = renderer.render("report", &data)?;
 ### How It Works
 
 The `Renderer` tracks the source of each template:
+
 - **Inline**: Content provided as a string (always cached)
 - **File-based**: Path recorded, content read on demand
 

--- a/crates/standout-render/docs/topics/styling-system.md
+++ b/crates/standout-render/docs/topics/styling-system.md
@@ -153,6 +153,7 @@ Instead of defining separate "light theme" and "dark theme" files, you define mo
 ```
 
 When resolving `panel` in dark mode:
+
 1. Start with base attributes (`bold`, `gray`)
 2. Merge dark overrides (`white` replaces `gray`)
 3. Result: bold white text
@@ -284,6 +285,7 @@ All odd-row styles are adaptive: they resolve to a dark variant when the termina
 Organize your styles in three conceptual layers:
 
 **1. Visual primitives** (low-level appearance):
+
 ```css
 ._cyan-bold { color: cyan; font-weight: bold; }
 ._dim { opacity: 0.5; }
@@ -291,6 +293,7 @@ Organize your styles in three conceptual layers:
 ```
 
 **2. Presentation roles** (UI concepts — use aliases in code):
+
 ```rust
 theme.add("heading", "_cyan-bold")
      .add("secondary", "_dim")
@@ -298,6 +301,7 @@ theme.add("heading", "_cyan-bold")
 ```
 
 **3. Semantic names** (domain concepts — aliases to presentation):
+
 ```rust
 // In templates, use these
 theme.add("task-title", "heading")
@@ -309,6 +313,7 @@ theme.add("task-title", "heading")
 Templates use semantic names (`task-title`), which resolve to presentation roles (`heading`), which resolve to visual primitives (`_cyan-bold`).
 
 This layering lets you:
+
 - Refactor visuals without touching templates
 - Maintain consistency across domains
 - Document the purpose of each style

--- a/crates/standout-render/docs/topics/template-engines.md
+++ b/crates/standout-render/docs/topics/template-engines.md
@@ -43,6 +43,7 @@ Full-featured Jinja2-compatible engine. This is what you get by default.
 ```
 
 **Supports:**
+
 - Variable substitution with filters: `{{ name | upper }}`
 - Control flow: `{% if %}`, `{% for %}`, `{% macro %}`
 - Template includes: `{% include "partial.jinja" %}`
@@ -61,12 +62,14 @@ Contact: {user.profile.email}
 ```
 
 **Supports:**
+
 - Simple variable substitution: `{name}`
 - Nested property access: `{user.profile.email}`
 - Array index access: `{items.0}`
 - Escaped braces: `{{` renders as `{`
 
 **Does NOT support:**
+
 - Loops (`{% for %}`)
 - Conditionals (`{% if %}`)
 - Filters (`| upper`)
@@ -78,14 +81,14 @@ Contact: {user.profile.email}
 
 ## Choosing an Engine
 
-### Use MiniJinjaEngine (default) when:
+### Use MiniJinjaEngine (default) when
 
 - Templates need loops or conditionals
 - You use filters for formatting
 - Templates include other templates
 - You're not concerned about binary size
 
-### Use SimpleEngine when:
+### Use SimpleEngine when
 
 - Templates only substitute variables
 - Binary size is critical

--- a/crates/standout-render/docs/topics/templating.md
+++ b/crates/standout-render/docs/topics/templating.md
@@ -18,7 +18,7 @@ Template + Data → [Pass 1: MiniJinja] → Text with style tags → [Pass 2: BB
 
 **Pass 2 - BBParser**: Style tag processing. Bracket-notation tags are converted to ANSI escape codes (or stripped, depending on output mode).
 
-### Example
+### Pipeline Example
 
 ```text
 Template:     [title]{{ name }}[/title] has {{ count }} items
@@ -144,7 +144,7 @@ Pass 2 (BBParser) processes style tags differently based on the output mode:
 | `Text` | Strip tags completely | Plain text, pipes, files |
 | `TermDebug` | Keep tags as literal text | Debugging, testing |
 
-### Example
+### Processing Modes Example
 
 Template: `[title]Hello[/title]`
 
@@ -260,6 +260,7 @@ let output = renderer.render("greeting", &data)?;
 Supported extensions (in priority order): `.jinja`, `.jinja2`, `.j2`, `.stpl`, `.txt`
 
 When you request `"report"`, the registry checks:
+
 - Inline template named `"report"`
 - `report.jinja` in registered directories
 - `report.jinja2`, `report.j2`, `report.stpl`, `report.txt` (lower priority)
@@ -368,6 +369,7 @@ if !errors.is_empty() {
 ```
 
 Validation catches:
+
 - Misspelled style names
 - References to undefined styles
 - Mismatched opening/closing tags

--- a/crates/standout/README.md
+++ b/crates/standout/README.md
@@ -92,14 +92,17 @@ myapp list --output json    # JSON for scripting
 - **Book**: [standout.magik.works](https://standout.magik.works/)
 
 ### Framework Topics
+
 - [App Configuration](https://standout.magik.works/topics/app-configuration.html) — AppBuilder API
 - [Output Modes](https://standout.magik.works/topics/output-modes.html) — --output flag and format handling
 
 ### Crate Documentation
+
 - [standout-render](https://standout.magik.works/crates/render/guides/intro-to-rendering.html) — Templates, themes, tabular layouts
 - [standout-dispatch](https://standout.magik.works/crates/dispatch/guides/intro-to-dispatch.html) — Handlers, hooks, command routing
 
 ### API Reference
+
 - [API Documentation](https://docs.rs/standout) — Full API reference
 
 ## Standalone Crates

--- a/docs/dev/design-guidelines.md
+++ b/docs/dev/design-guidelines.md
@@ -5,6 +5,7 @@
 ## 1. Motivation: The Complexity Trap
 
 Standout is designed to be flexible. It supports:
+
 - **8 Output Modes** (Auto, Term, Text, TermDebug, Json, Yaml, Xml, Csv)
 - **3 Template Sources** (Embedded, File, None)
 - **4 Style Sources** (Embedded, File, Programmatic, None)
@@ -27,8 +28,8 @@ To manage this complexity, we adhere to three core pillars:
 - **Rule**: No `unwrap()` or `expect()` on user configuration. All builder methods must return `Result<Self, SetupError>`.
 - **Rule**: No silent fallbacks for optional fields. If a template is required but missing, fail safely, do not silently output nothing.
 - **Rule**: Use "Type Detection" not "Option checking".
-    - *Bad*: `if let Some(t) = self.templates { ... }`
-    - *Good*: `AppBuilder<HasTemplates>` vs `AppBuilder<NoTemplates>` (Typestate pattern where applicable).
+  - *Bad*: `if let Some(t) = self.templates { ... }`
+  - *Good*: `AppBuilder<HasTemplates>` vs `AppBuilder<NoTemplates>` (Typestate pattern where applicable).
 
 ### II. Structural Unification
 
@@ -64,25 +65,25 @@ pub struct App {
 ### Error Handling
 
 - **Setup Phase** (`App::builder()`): Returns `Result<Self, SetupError>`.
-    - Errors: `Io`, `Template`, `DuplicateCommand`.
+  - Errors: `Io`, `Template`, `DuplicateCommand`.
 - **Runtime Phase** (`dispatch()`): Returns `RunResult`.
-    - Errors from handlers are propagated via `HandlerResult` (`anyhow::Error` or similar).
+  - Errors from handlers are propagated via `HandlerResult` (`anyhow::Error` or similar).
 
 ## 4. PR Evaluation Checklist
 
 When proposing changes, evaluate against this checklist:
 
 - [ ] **Complexity**: Does this add a new configuration dimension?
-    - If yes: Have you added it to the `proptest` strategy?
+  - If yes: Have you added it to the `proptest` strategy?
 - [ ] **Safety**: Does this introduce any `unwrap()` or `expect()`?
-    - If yes: Can it be replaced by `Result` propagation?
+  - If yes: Can it be replaced by `Result` propagation?
 - [ ] **Duplication**: Did you copy logic unnecessarily?
-    - If yes: Stop. Refactor to a shared implementation.
+  - If yes: Stop. Refactor to a shared implementation.
 - [ ] **Verification**: Did you include a snapshot test for the UI output?
 
 ## 5. Development Workflow
 
-1.  **Plan**: Draft an `implementation_plan.md` using the Design Guidelines.
-2.  **Safety First**: Implement types and builders before logic.
-3.  **Test**: Add property tests if changing core dispatch.
-4.  **Verify**: Run `cargo test` and check snapshots.
+1. **Plan**: Draft an `implementation_plan.md` using the Design Guidelines.
+2. **Safety First**: Implement types and builders before logic.
+3. **Test**: Add property tests if changing core dispatch.
+4. **Verify**: Run `cargo test` and check snapshots.

--- a/docs/dev/documentation-guidelines.md
+++ b/docs/dev/documentation-guidelines.md
@@ -8,11 +8,11 @@ Pushing a full framework for shell apps is a hard ask. Between not seeing the va
 
 ## Context
 
-### 1. The Framework over Lover Level Libs
+### 1. The Framework over Lower Level Libs
 
 Given that, if we can advance the idea that a strong separation between logic and presentation in shell programs is desirable and easy, that's a win.
 For that reason, we've structured the project in two layers:
-    - base creates: (i.e. standout-render, standout-dispatch), lower level libraries that can be used for a more focus task, and don't dictate architectures, designs. They are stand alone libs that you can use alone, or both, with or without the framework.
+    - base crates: (i.e. standout-render, standout-dispatch), lower level libraries that can be used for a more focused task, and don't dictate architectures, designs. They are stand alone libs that you can use alone, or both, with or without the framework.
     - standout: the full framework. Most of the functionality is provided by the lower level crates, while the framework will wire them together, cut the boilerplate and offer a stock configuration that is highly productive, feature rich and simple to setup.
 
 - standout-dispatch:  a execution flow orchestrator that manages cli arg + logic and presentation handers + hooks and runs them in a structured way.
@@ -21,11 +21,11 @@ For that reason, we've structured the project in two layers:
 
 This design has two main objectives:
     - Facilitate adoption: users can use one or both, and customize them to their respective needs, while having a clear message and value.
-    - Improve the framework's design: building on top of distinct, stand alone creates ensures that we don't couple domains that shouldn't, that the foundation is flexible to cater to various use cases and so on.
-    - Documentation and communication: since users might use one crate. both or the full framework, writing a single documentation that would cater for all possible permutations was impossible..
+    - Improve the framework's design: building on top of distinct, stand alone crates ensures that we don't couple domains that shouldn't, that the foundation is flexible to cater to various use cases and so on.
+    - Documentation and communication: since users might use one crate, both or the full framework, writing a single documentation that would cater for all possible permutations was impossible.
 Hence, the two main pillars of standout are:
 
-### 2 The Guides vs Topics Styles
+### 2. The Guides vs Topics Styles
 
 Again, asking developers to complete change their apps, with a subtle value proposition is a pipe dream.
 However, adoption is more of a spectrum than a yes and on, and there is value in many points along the way. When you put these two together:
@@ -34,14 +34,14 @@ However, adoption is more of a spectrum than a yes and on, and there is value in
 - We see value in a list of smaller steps towards the goal of shell apps that are easy to write and maintain.
 
 Hence, our documentation style is designed walk-through a specific domain / task by a tutorial, real use case scenario that is shown in many small steps.  
-Each step is valuable on it's own, hence, we , naturally, think the full list of steps provides optimal value, although it requires more commitment and work.
+Each step is valuable on its own, hence, we, naturally, think the full list of steps provides optimal value, although it requires more commitment and work.
 
 This format allows us:
     - To explain the motivation and benefits at each step.
     - To show how standout / crates can help you achieve there.
 
 That is, this format allows users to engage with varying levels of buy in, while giving us an opportunity to show the value and motivation for each things.
-This are the guides, and the quintessential example is ../guides/intro-to-standout.md .
+These are the guides, and the quintessential example is ../guides/intro-to-standout.md.
 
 ## Guidelines
 
@@ -49,16 +49,16 @@ This are the guides, and the quintessential example is ../guides/intro-to-stando
     1.1. The core documentation should , match the code, and be in the crate it's in.  
     1.2. It should assume the stand alone crate as a lib usage, not presuppose standout the framework.
     1.3. However: callout boxes in relevant pages (for example over a configuration / glue code that the standout framework handles for it) is welcomed.
-    1.4. Is it all about the why and how, now the what:
+    1.4. Is it all about the why and how, not the what:
         Modern IDES and tooling have become really good. Simply parroting an API is pointless, as users can do that on their IDES, much faster and without interruptions.
         The documentation is about exposing the problem that code solves, it's design. Designs are trade-offs, and it's often useful to go over what that allows and what it makes difficult.
-        So the why is what problem is being solved? THe how is : the design, the blue print for this solution.
-        We like to give users context so that understand how things connect, why certain some choices were made (when counter-intuitive or stray from mental mainstream.)
+        So the why is what problem is being solved? The how is : the design, the blueprint for this solution.
+        We like to give users context so that they understand how things connect, why certain choices were made (when counter-intuitive or stray from mental mainstream.)
 
 2. Guides:
-    2.1. Sequence of steps with increasing : value and commitment
+    2.1. Sequence of steps with increasing: value and commitment
     2.5. Each step should explain the why as needed.
-    2.6 Always show the canonical recommend way to do something. (see bellow)
+    2.6 Always show the canonical recommended way to do something. (see below)
     2.7 Use callouts or mention more advanced options
 3. Topics:
     While less verbose and deeper into the details than guides, topics also benefit from a more general introduction with the problems context, design etc
@@ -67,12 +67,12 @@ This are the guides, and the quintessential example is ../guides/intro-to-stando
 
     Standout strives for ergonomic, easy to use APIs. When possible, we love derive macros. This plays well with the idea that we are non intrusive on your app, and annotating it goes a long way.
 
-    In guides we always showcase the recommend forms. Topics, we showcase and recommend them as well, but also cover the other options for users who need a particular behaviour
+    In guides we always showcase the recommended forms. In topics, we showcase and recommend them as well, but also cover the other options for users who need a particular behaviour
 
     1. Annotation / declarative over imperative: i.e. derive macros vs imperative code.
     2. MiniJinja templates, css for styles
     3. File based presentation assets (templates, css )
-    4. Semantic styling (two layer first style is about the semantics (what the item is) and it links a to a visual style)
+    4. Semantic styling (two-layer: the first style is about the semantics (what the item is) and it links to a visual style)
     5. Core testing is done on the logic handlers
-    6. Use as much as possible from the convention name matching (i.e. template names and handlers names)
-    7. Symlik the full framework docs (docs) to the actual crates (`<crate>/docs/`) files
+    6. Use as much as possible from the convention name matching (i.e. template names and handler names)
+    7. Symlink the full framework docs (docs) to the actual crates (`<crate>/docs/`) files

--- a/docs/dev/documentation-guidelines.md
+++ b/docs/dev/documentation-guidelines.md
@@ -3,34 +3,32 @@
 Standout has a few uncommon bits, so it's worth going over them here as they affect documentation
 The two ideas bellow; the lower level lib + framework structure and the continuum of adoption, value and understanding drive our guidelines..G
 
-
 Standout is a full shell cli framework for complex, non interactive shell applications (otherwise the TUI ones have got you covered)
 Pushing a full framework for shell apps is a hard ask. Between not seeing the value, the skepticism over reliability and locking and plain old habit, it's just a bad plan to push a all or nothing design. The core idea we want to move forward is: it's just too easy to mix shell specific parts inside and app logics  , like print statements, env var access etc.Before you know it, your application is all mixed up in logic with presentation. The first casualty is testing: testing becomes hard, and devs will either give up, or start integration testing everything, which is hard, error prone, brittle and requires you to parse and reverse engineer your logic that your formatting processed.
 
-
 ## Context
 
-### 1. The Framework over Lover Level Libs 
+### 1. The Framework over Lover Level Libs
 
-Given that, if we can advance the idea that a strong separation between logic and presentation in shell programs is desirable and easy, that's a win. 
-For that reason, we've structured the project in two layers: 
-    - base creates: (i.e. standout-render, standout-dispatch), lower level libraries that can be used for a more focus task, and don't dictate architectures, designs. They are stand alone libs that you can use alone, or both, with or without the framework. 
+Given that, if we can advance the idea that a strong separation between logic and presentation in shell programs is desirable and easy, that's a win.
+For that reason, we've structured the project in two layers:
+    - base creates: (i.e. standout-render, standout-dispatch), lower level libraries that can be used for a more focus task, and don't dictate architectures, designs. They are stand alone libs that you can use alone, or both, with or without the framework.
     - standout: the full framework. Most of the functionality is provided by the lower level crates, while the framework will wire them together, cut the boilerplate and offer a stock configuration that is highly productive, feature rich and simple to setup.
+
 - standout-dispatch:  a execution flow orchestrator that manages cli arg + logic and presentation handers + hooks and runs them in a structured way.
 - standout-render: a full env, with template files, css styling, themes, hot reload during dev and more, to produce the best output effortlessly from your presentation formatting step.
 - standout : the actual full framework
 
-This design has two main objectives: 
+This design has two main objectives:
     - Facilitate adoption: users can use one or both, and customize them to their respective needs, while having a clear message and value.
     - Improve the framework's design: building on top of distinct, stand alone creates ensures that we don't couple domains that shouldn't, that the foundation is flexible to cater to various use cases and so on.
     - Documentation and communication: since users might use one crate. both or the full framework, writing a single documentation that would cater for all possible permutations was impossible..
-Hence, the two main pillars of standout are: 
-
+Hence, the two main pillars of standout are:
 
 ### 2 The Guides vs Topics Styles
 
 Again, asking developers to complete change their apps, with a subtle value proposition is a pipe dream.
-However, adoption is more of a spectrum than a yes and on, and there is value in many points along the way. When you put these two together: 
+However, adoption is more of a spectrum than a yes and on, and there is value in many points along the way. When you put these two together:
 
 - Most developers are reluctant to use frameworks for shell apps (either don't see the need, don't have the habit, likely both)
 - We see value in a list of smaller steps towards the goal of shell apps that are easy to write and maintain.
@@ -38,12 +36,12 @@ However, adoption is more of a spectrum than a yes and on, and there is value in
 Hence, our documentation style is designed walk-through a specific domain / task by a tutorial, real use case scenario that is shown in many small steps.  
 Each step is valuable on it's own, hence, we , naturally, think the full list of steps provides optimal value, although it requires more commitment and work.
 
-This format allows us: 
-    - To explain the motivation and benefits at each step. 
+This format allows us:
+    - To explain the motivation and benefits at each step.
     - To show how standout / crates can help you achieve there.
 
 That is, this format allows users to engage with varying levels of buy in, while giving us an opportunity to show the value and motivation for each things.
-This are the guides, and the quintessential example is ../guides/intro-to-standout.md . 
+This are the guides, and the quintessential example is ../guides/intro-to-standout.md .
 
 ## Guidelines
 
@@ -51,25 +49,25 @@ This are the guides, and the quintessential example is ../guides/intro-to-stando
     1.1. The core documentation should , match the code, and be in the crate it's in.  
     1.2. It should assume the stand alone crate as a lib usage, not presuppose standout the framework.
     1.3. However: callout boxes in relevant pages (for example over a configuration / glue code that the standout framework handles for it) is welcomed.
-    1.4. Is it all about the why and how, now the what: 
+    1.4. Is it all about the why and how, now the what:
         Modern IDES and tooling have become really good. Simply parroting an API is pointless, as users can do that on their IDES, much faster and without interruptions.
         The documentation is about exposing the problem that code solves, it's design. Designs are trade-offs, and it's often useful to go over what that allows and what it makes difficult.
         So the why is what problem is being solved? THe how is : the design, the blue print for this solution.
         We like to give users context so that understand how things connect, why certain some choices were made (when counter-intuitive or stray from mental mainstream.)
 
-2. Guides: 
+2. Guides:
     2.1. Sequence of steps with increasing : value and commitment
     2.5. Each step should explain the why as needed.
     2.6 Always show the canonical recommend way to do something. (see bellow)
-    2.7 Use callouts or mention more advanced options 
-3. Topics: 
+    2.7 Use callouts or mention more advanced options
+3. Topics:
     While less verbose and deeper into the details than guides, topics also benefit from a more general introduction with the problems context, design etc
 
-3. Canonical or Recommended APIs
+4. Canonical or Recommended APIs
 
     Standout strives for ergonomic, easy to use APIs. When possible, we love derive macros. This plays well with the idea that we are non intrusive on your app, and annotating it goes a long way.
 
-    In guides we always showcase the recommend forms. Topics, we showcase and recommend them as well, but also cover the other options for users who need a particular behaviour 
+    In guides we always showcase the recommend forms. Topics, we showcase and recommend them as well, but also cover the other options for users who need a particular behaviour
 
     1. Annotation / declarative over imperative: i.e. derive macros vs imperative code.
     2. MiniJinja templates, css for styles
@@ -77,4 +75,4 @@ This are the guides, and the quintessential example is ../guides/intro-to-stando
     4. Semantic styling (two layer first style is about the semantics (what the item is) and it links a to a visual style)
     5. Core testing is done on the logic handlers
     6. Use as much as possible from the convention name matching (i.e. template names and handlers names)
-    7. Symlik the full framework docs (docs) to the actual crates (<crate>/docs/) files
+    7. Symlik the full framework docs (docs) to the actual crates (`<crate>/docs/`) files

--- a/docs/dev/issue_89_sequencing_fix.md
+++ b/docs/dev/issue_89_sequencing_fix.md
@@ -50,6 +50,6 @@ fn dispatch(&self, ...) {
 
 ## Benefits
 
-1.  **Order Independence**: `commands()` and `theme()` can be called in any order.
-2.  **Single Source of Truth**: The theme used is always the one present in the `App` at runtime, not a stale copy.
-3.  **Compile-Time Guarantee**: It is impossible to call a handler without providing a theme, eliminating "forgotten theme" bugs.
+1. **Order Independence**: `commands()` and `theme()` can be called in any order.
+2. **Single Source of Truth**: The theme used is always the one present in the `App` at runtime, not a stale copy.
+3. **Compile-Time Guarantee**: It is impossible to call a handler without providing a theme, eliminating "forgotten theme" bugs.

--- a/docs/guides/intro-to-standout.md
+++ b/docs/guides/intro-to-standout.md
@@ -362,6 +362,7 @@ mod handlers {
 ```
 
 The `#[handler]` macro:
+
 - Extracts CLI arguments automatically from `ArgMatches`
 - Converts `#[flag]` to `bool` flags, `#[arg]` to required/optional args
 - Auto-wraps `Result<T, E>` in `Output::Render` for you
@@ -673,6 +674,7 @@ let app = App::builder()
 ```
 
 Three piping modes:
+
 - `pipe_through("cmd")`: Use command's stdout as new output (filters like jq, sort)
 - `pipe_to("cmd")`: Run command but keep original output (side effects like tee)
 - `pipe_to_clipboard()`: Send to system clipboard (pbcopy on macOS, xclip on Linux)
@@ -707,6 +709,7 @@ fn create(_m: &ArgMatches, ctx: &CommandContext) -> HandlerResult<Value> {
 ```
 
 Features:
+
 - **Declarative priority**: Source order is explicit in the chain
 - **Framework-integrated**: `.input(name, chain)` registers the chain alongside `template`, `hooks`, and `pipe_*`; resolution happens in pre-dispatch
 - **Testable**: All sources accept mocks for CI-safe testing (the `TestHarness` from `standout-test` wires them automatically)

--- a/docs/guides/intro-to-testing.md
+++ b/docs/guides/intro-to-testing.md
@@ -159,7 +159,7 @@ fn list_runs() {
 That's it. `run()` drives the same dispatch path as production — same clap parsing, same handler lookup, same render pipeline — and returns the rendered text. No subprocess, no stdout capture gymnastics.
 
 > **Why `#[serial]`?** The harness mutates process-global state (env vars, cwd, terminal detectors, default input readers). Tests that use `TestHarness` must run serially. The `serial_test::serial` attribute is re-exported from `standout_test` for convenience: `use standout_test::serial;`.
-
+>
 > **Verify:** Add a `TestHarness::new().run(...)` test to your app. It should run in under 10ms, not 100ms.
 
 ### 4.1 Env vars

--- a/docs/guides/upgrading-from-3.8.md
+++ b/docs/guides/upgrading-from-3.8.md
@@ -165,7 +165,7 @@ fn list(#[flag] all: bool) -> Result<Vec<Item>, Error> {
 }
 ```
 
-### Auto-wrap Result<T> (v3.6.1)
+### Auto-wrap `Result<T>` (v3.6.1)
 
 Handlers can return `Result<T, E>` directly instead of `Ok(Output::Render(...))`:
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,4 +1,4 @@
-## Create Oustanding Shell Applications for free
+# Create Oustanding Shell Applications for free
 
 Standout is a rust library for building finely crafted non-interactive command line applications.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,4 +1,4 @@
-# Create Oustanding Shell Applications for free
+# Create Outstanding Shell Applications for free
 
 Standout is a rust library for building finely crafted non-interactive command line applications.
 

--- a/docs/proposals/list-view.md
+++ b/docs/proposals/list-view.md
@@ -9,6 +9,7 @@
 ListView provides a standardized pattern for displaying collections in CLI applications. It is the first building block toward a Django-style CRUD system where common operations are generated from annotated structs.
 
 **Goals:**
+
 1. Minimal boilerplate for common list displays
 2. Consistent structure: intro → items → ending → messages
 3. First-class tabular integration (zero-template lists)
@@ -51,6 +52,7 @@ Three tiers of complexity:
 ### Composition Over Inheritance
 
 ListView is a configuration pattern, not a base class. It composes:
+
 - **Tabular** for layout (optional)
 - **Seeker** for filtering (optional)
 - **Templates** for custom rendering (optional)
@@ -141,7 +143,7 @@ pub struct Task {
 
 Renders as:
 
-```
+```text
 Your tasks:
 
    1  Implement authentication          pending
@@ -214,6 +216,7 @@ fn list_tasks(args: &ArgMatches, query: Query) -> HandlerResult<ListViewResult<T
 ### CLI Arguments (Phase 4 Integration)
 
 When using `#[derive(FilterArgs)]` from Seeker Phase 4, the dispatch automatically:
+
 1. Generates filter arguments (`--name-contains`, `--status-eq`, etc.)
 2. Parses them into a `Query`
 3. Passes the query to the handler
@@ -232,12 +235,12 @@ enum Commands {
 The user runs:
 
 ```bash
-$ myapp list --status-eq=pending --name-contains=auth --limit=10
+myapp list --status-eq=pending --name-contains=auth --limit=10
 ```
 
 And gets filtered results with a summary:
 
-```
+```text
 Showing 2 of 15 tasks (filtered by: status=pending, name contains "auth")
 
    5  Implement authentication          pending
@@ -270,7 +273,7 @@ pub struct Task { /* ... */ }
 
 Generates:
 
-```
+```text
 myapp task list [--filters...]
 myapp task view <id>
 myapp task delete <id>
@@ -296,6 +299,7 @@ enum Commands {
 ```
 
 The `list_view` marker tells dispatch to:
+
 1. Use `list-view.jinja` template
 2. Expect `ListViewResult<Task>` from handler
 3. Use `Task`'s `Tabular` impl for item rendering
@@ -447,6 +451,7 @@ As standout develops higher-level features (list views, detail views, CRUD), it 
 ### The Problem
 
 If the framework provides `list-view.jinja` and a user's project also has `list-view.jinja`, behavior is ambiguous:
+
 - Which takes precedence?
 - How does the user intentionally override vs accidentally collide?
 - How does the user reference the framework version explicitly?
@@ -455,7 +460,7 @@ If the framework provides `list-view.jinja` and a user's project also has `list-
 
 **Templates:** Framework templates live in the `standout/` namespace.
 
-```
+```text
 Framework provides:     standout/list-view.jinja
 User creates:           list-view.jinja (no collision)
 User overrides:         standout/list-view.jinja (intentional)
@@ -500,6 +505,7 @@ let app = App::builder()
 ```
 
 Default is `true` for both. Disabling is useful when:
+
 - Building a completely custom UI system
 - Avoiding any implicit behavior
 - Debugging template resolution
@@ -607,6 +613,7 @@ $ $EDITOR ui/templates/standout/list-view.jinja
 [1] **ListViewResult serialization**: The struct serializes cleanly to JSON for structured output modes. When `--output=json`, the framework bypasses templating and serializes directly.
 
 [2] **Builder pattern**: The `list_view()` helper is a convenience. Direct struct construction works fine for complex cases:
+
 ```rust
 ListViewResult {
     items,
@@ -621,6 +628,7 @@ ListViewResult {
 [3] **Tabular detection**: The template checks if `tabular_spec` is present (set by framework when `T: Tabular`). If not present, it falls back to item templates or basic iteration.
 
 [4] **Handler injection**: The `filterable` attribute causes the dispatch system to:
+
 1. Generate Seeker CLI args via `#[derive(FilterArgs)]`
 2. Parse args into a `Query` before handler invocation
 3. Pass `Query` as second parameter to handler (after `&ArgMatches`)
@@ -628,6 +636,7 @@ ListViewResult {
 This follows the same pattern as other dispatch injections (format, theme).
 
 [5] **Tabular + Seeker synergy**: When both are derived on the same struct, you get:
+
 - Automatic column layout from `#[tabular(...)]`
 - Automatic filter args from `#[seek(...)]`
 - Zero templates needed for a fully-featured filterable list

--- a/docs/proposals/new-api.md
+++ b/docs/proposals/new-api.md
@@ -11,6 +11,7 @@ The `standout-clap` crate will be folded into `standout` core, with clap-specifi
 functionality behind a `clap` feature flag.
 
 **Rationale:**
+
 - Users almost always need both crates together
 - Documentation is awkwardly split between crates
 - Re-exports create circular-feeling dependencies
@@ -18,7 +19,8 @@ functionality behind a `clap` feature flag.
 - Simplifies dependency management for users
 
 **New structure:**
-```
+
+```text
 standout/
 ├── src/
 │   ├── lib.rs           # Core exports
@@ -43,6 +45,7 @@ standout/
 **Problem:** `run()` doesn't run anything - it just parses arguments.
 
 **Current (confusing):**
+
 ```rust
 Standout::run(cmd)           // Returns ArgMatches, doesn't execute
 builder.run_and_print(cmd, args) // Actually runs and prints
@@ -50,6 +53,7 @@ builder.dispatch_from(cmd, args) // Runs, returns result
 ```
 
 **Proposed (intuitive):**
+
 ```rust
 // Primary API - matches user expectation
 app.run(cmd, args)              // Execute handlers, print output, exit on error
@@ -97,6 +101,7 @@ let app = Standout::builder()
 **Problem:** Too many render variants with unclear distinctions.
 
 **Current (7 functions):**
+
 ```rust
 render()
 render_with_output()
@@ -108,6 +113,7 @@ render_or_serialize_with_spec()
 ```
 
 **Proposed (3 functions + builder for advanced):**
+
 ```rust
 // Simple rendering
 render(template, data, theme) -> String
@@ -143,6 +149,7 @@ Renderer::new(theme)
 **Problem:** `CommandResult` mixes success/error with output type.
 
 **Current:**
+
 ```rust
 pub enum CommandResult<T: Serialize> {
     Ok(T),
@@ -153,6 +160,7 @@ pub enum CommandResult<T: Serialize> {
 ```
 
 **Proposed:**
+
 ```rust
 pub enum Output<T: Serialize> {
     Render(T),                    // Render with template
@@ -210,6 +218,7 @@ match app.dispatch(matches) {
 ### 7. Remove Deprecated Items
 
 Per project guidelines (no backwards compatibility), remove:
+
 - `TopicHelper` type alias
 - `TopicHelperBuilder` type alias
 - `TopicHelpResult` type alias
@@ -219,7 +228,7 @@ Per project guidelines (no backwards compatibility), remove:
 
 ## Module Structure After Merge
 
-```
+```text
 standout/
 ├── Cargo.toml
 └── src/
@@ -304,6 +313,7 @@ pub use standout_macros::{embed_templates, embed_styles, Dispatch};
 ## Migration Examples
 
 ### Before (current API)
+
 ```rust
 use standout::{render_or_serialize, Theme, OutputMode};
 use standout_clap::{Standout, CommandResult, CommandContext};
@@ -317,6 +327,7 @@ let matches = Standout::builder()
 ```
 
 ### After (new API)
+
 ```rust
 use standout::{App, Theme, OutputMode, HandlerResult, Output};
 
@@ -340,18 +351,21 @@ the codebase in a working state with passing tests.
 
 ### Phase 1: Preparation (Non-Breaking)
 
-**1.1 Remove deprecated type aliases**
+#### 1.1 Remove deprecated type aliases
+
 - Delete `TopicHelper`, `TopicHelperBuilder`, `TopicHelpResult`, `Config` aliases
 - Update any internal usage
 - ~30 min
 
-**1.2 Consolidate duplicate render functions**
+#### 1.2 Consolidate duplicate render functions
+
 - `render_with_output()` and `render_with_mode()` have overlapping purposes
 - Audit and document the actual difference (output mode vs color mode)
 - Add deprecation notes in code comments for functions to be merged later
 - ~1 hr
 
-**1.3 Add feature flag structure to standout**
+#### 1.3 Add feature flag structure to standout
+
 - Add `[features]` section to `standout/Cargo.toml`
 - Create empty `src/cli/mod.rs` behind `clap` feature
 - Ensure existing API unchanged
@@ -361,29 +375,34 @@ the codebase in a working state with passing tests.
 
 ### Phase 2: Crate Merge (Structural)
 
-**2.1 Copy standout-clap source into standout/src/cli/**
+#### 2.1 Copy standout-clap source into standout/src/cli/
+
 - Move all source files
 - Update internal `use` statements to reference sibling modules
 - Keep `standout-clap` crate temporarily (will delete later)
 - ~2 hr
 
-**2.2 Update standout/Cargo.toml dependencies**
+#### 2.2 Update standout/Cargo.toml dependencies
+
 - Add clap dependency behind feature flag
 - Add other standout-clap dependencies (anyhow, etc.)
 - ~30 min
 
-**2.3 Wire up cli module exports**
+#### 2.3 Wire up cli module exports
+
 - Add `pub mod cli` behind `#[cfg(feature = "clap")]`
 - Export types from `lib.rs`
 - ~1 hr
 
-**2.4 Create standout-clap as thin re-export crate**
+#### 2.4 Create standout-clap as thin re-export crate
+
 - Replace standout-clap/src/lib.rs with `pub use standout::cli::*;`
 - Add deprecation notice to crate docs
 - Ensures existing users still compile
 - ~30 min
 
-**2.5 Delete standout-clap crate**
+#### 2.5 Delete standout-clap crate
+
 - Remove from workspace
 - Delete crate directory
 - Update workspace Cargo.toml
@@ -393,18 +412,21 @@ the codebase in a working state with passing tests.
 
 ### Phase 3: Builder Unification
 
-**3.1 Add `.templates()` method to AppBuilder**
+#### 3.1 Add `.templates()` method to AppBuilder
+
 - Accept `EmbeddedTemplates` (like RenderSetup does)
 - Store alongside existing `template_dir`
 - ~1 hr
 
-**3.2 Unify RenderSetup into AppBuilder**
+#### 3.2 Unify RenderSetup into AppBuilder
+
 - Move RenderSetup's build logic into AppBuilder
 - AppBuilder now handles both embedded resources AND command dispatch
 - RenderSetup becomes type alias (temporarily) or internal
 - ~2 hr
 
-**3.3 Make builder.build() return Result**
+#### 3.3 Make builder.build() return Result
+
 - Change signature from `fn build(self) -> Standout` to `fn build(self) -> Result<App, SetupError>`
 - Update all call sites
 - ~1 hr
@@ -413,23 +435,27 @@ the codebase in a working state with passing tests.
 
 ### Phase 4: Run Semantics Fix
 
-**4.1 Rename current run methods (preparation)**
+#### 4.1 Rename current run methods (preparation)
+
 - `Standout::run()` → `Standout::parse()` (internal rename, keep old as deprecated alias)
 - `Standout::run_with()` → `Standout::parse_with()`
 - `Standout::run_from()` → `Standout::parse_from()`
 - ~1 hr
 
-**4.2 Implement new run() that executes and prints**
+#### 4.2 Implement new run() that executes and prints
+
 - New `fn run(self, cmd, args) -> !` that calls dispatch + prints + exits
 - This is what users expect
 - ~1 hr
 
-**4.3 Implement run_to_string()**
+#### 4.3 Implement run_to_string()
+
 - New `fn run_to_string(&self, cmd, args) -> Result<String, Error>`
 - For testing and composition
 - ~1 hr
 
-**4.4 Remove deprecated parse aliases**
+#### 4.4 Remove deprecated parse aliases
+
 - Delete the old `run()` → `parse()` aliases
 - Final cleanup
 - ~30 min
@@ -438,22 +464,26 @@ the codebase in a working state with passing tests.
 
 ### Phase 5: Type Renames
 
-**5.1 Rename Standout → App**
+#### 5.1 Rename Standout → App
+
 - Rename struct and impl blocks
 - Update all references
 - ~1 hr
 
-**5.2 Rename StandoutBuilder → AppBuilder**
+#### 5.2 Rename StandoutBuilder → AppBuilder
+
 - Rename struct
 - Update builder() method
 - ~30 min
 
-**5.3 Rename StandoutApp → RenderEngine**
+#### 5.3 Rename StandoutApp → RenderEngine
+
 - Or merge into Renderer
 - Evaluate if this type is still needed
 - ~1 hr
 
-**5.4 Rename RunResult::Unhandled → RunResult::NoMatch**
+#### 5.4 Rename RunResult::Unhandled → RunResult::NoMatch
+
 - Simple enum variant rename
 - ~15 min
 
@@ -461,20 +491,24 @@ the codebase in a working state with passing tests.
 
 ### Phase 6: Handler Result Refactor
 
-**6.1 Create new Output<T> enum**
+#### 6.1 Create new `Output<T>` enum
+
 - Define new enum alongside CommandResult
 - ~30 min
 
-**6.2 Create HandlerResult type alias**
+#### 6.2 Create HandlerResult type alias
+
 - `type HandlerResult<T> = Result<Output<T>, anyhow::Error>`
 - ~15 min
 
-**6.3 Update Handler trait to use new types**
+#### 6.3 Update Handler trait to use new types
+
 - Change return type from `CommandResult<T>` to `HandlerResult<T>`
 - Update all handler implementations
 - ~2 hr
 
-**6.4 Remove old CommandResult enum**
+#### 6.4 Remove old CommandResult enum
+
 - Delete after all usages migrated
 - ~30 min
 
@@ -482,15 +516,18 @@ the codebase in a working state with passing tests.
 
 ### Phase 7: Render Function Cleanup
 
-**7.1 Implement render_auto()**
+#### 7.1 Implement render_auto()
+
 - New function that chooses template vs serialize based on OutputMode
 - ~1 hr
 
-**7.2 Deprecate redundant render functions**
+#### 7.2 Deprecate redundant render functions
+
 - Mark render_or_serialize* as deprecated in favor of render_auto
 - ~30 min
 
-**7.3 Remove deprecated render functions**
+#### 7.3 Remove deprecated render functions
+
 - Delete after deprecation period (or immediately per project guidelines)
 - ~30 min
 
@@ -498,16 +535,19 @@ the codebase in a working state with passing tests.
 
 ### Phase 8: Documentation and Polish
 
-**8.1 Update lib.rs documentation**
+#### 8.1 Update lib.rs documentation
+
 - Rewrite module docs to reflect new API
 - Add migration guide
 - ~2 hr
 
-**8.2 Update intro.lex examples**
+#### 8.2 Update intro.lex examples
+
 - Ensure all code examples work with new API
 - ~1 hr
 
-**8.3 Update README and other docs**
+#### 8.3 Update README and other docs
+
 - Sync all documentation
 - ~1 hr
 
@@ -516,12 +556,14 @@ the codebase in a working state with passing tests.
 ## Commit Strategy
 
 Each numbered item (1.1, 1.2, etc.) should be a single commit with:
+
 - Descriptive commit message referencing this proposal
 - All tests passing
 - No breaking changes to external API until Phase 4+
 
 Example commit messages:
-```
+
+```text
 refactor: remove deprecated type aliases (Phase 1.1)
 
 Remove TopicHelper, TopicHelperBuilder, TopicHelpResult, and Config
@@ -530,7 +572,7 @@ type aliases per API unification proposal.
 Ref: docs/proposals/new-api.md
 ```
 
-```
+```text
 feat: merge standout-clap into standout core (Phase 2.1-2.3)
 
 Move CLI integration code into standout crate behind "clap" feature.
@@ -544,16 +586,19 @@ Ref: docs/proposals/new-api.md
 ## Risk Mitigation
 
 **Testing strategy:**
+
 - Run full test suite after each commit
 - Phase 2 (crate merge) is highest risk - take extra care
 - Consider temporary CI job that tests both old and new import paths
 
 **Rollback points:**
+
 - After Phase 2.4, old standout-clap still works (re-exports)
 - After Phase 3, builder unification complete but types unchanged
 - After Phase 4, run semantics fixed but types unchanged
 
 **Dependencies:**
+
 - Phase 1 has no dependencies
 - Phase 2 depends on Phase 1.3
 - Phase 3 depends on Phase 2
@@ -575,6 +620,6 @@ Ref: docs/proposals/new-api.md
 | 7. Render Cleanup | 2 hr | 3 |
 | 8. Documentation | 4 hr | All |
 
-**Total: ~27 hours of focused work**
+**Total:** ~27 hours of focused work.
 
 Phases 4-7 can be parallelized if multiple contributors, reducing wall-clock time.

--- a/docs/proposals/seeker.md
+++ b/docs/proposals/seeker.md
@@ -202,6 +202,7 @@ A **clause** is a single filter predicate consisting of:
 - A comparison value
 
 Examples:
+
 - `name Eq "index.html"` — name equals "index.html"
 - `size Lt 1024` — size less than 1024
 - `status In [Active, Pending]` — status is Active or Pending
@@ -220,7 +221,7 @@ A **clause group** is a set of clauses sharing a logical role. There are three g
 
 A **query** combines clause groups using fixed semantics:
 
-```
+```text
 match = (all AND clauses match)
       ∧ (at least one OR clause matches, OR no OR clauses exist)
       ∧ (no NOT clause matches)
@@ -280,7 +281,7 @@ A query may specify:
 
 ### Crate Structure
 
-```
+```text
 crates/standout-seeker/
 ├── Cargo.toml
 ├── src/
@@ -674,7 +675,7 @@ proptest! {
 
 ## Phase 2: Derive Macros
 
-**Status: Implemented**
+**Status:** Implemented
 
 The `#[derive(Seekable)]` macro generates accessor functions and field constants.
 
@@ -759,13 +760,14 @@ Built-in `SeekerTimestamp` implementations exist for `i64` and `u64`.
 
 ## Phase 3: String Parsing
 
-**Status: In Progress**
+**Status:** In Progress
 
 A shell-agnostic layer that parses key-value string pairs into typed `Query` objects. This layer is reusable across different interfaces (CLI, web APIs, configuration files).
 
-### Motivation
+### String Parsing Motivation
 
 The string format `field-operator=value` appears in multiple contexts:
+
 - CLI arguments: `--name-contains=foo`
 - URL query params: `?name-contains=foo`
 - Configuration: `name-contains = foo`
@@ -775,6 +777,7 @@ By separating string parsing from CLI specifics, we get a reusable layer.
 ### SeekerSchema Trait
 
 The parser needs field metadata to:
+
 1. Validate field names exist
 2. Determine field types for value parsing
 3. Validate operators are appropriate for the field type
@@ -810,6 +813,7 @@ The derive macro generates `SeekerSchema` alongside `Seekable` by default. Users
 **Key format:** `field-name-operator`
 
 Rules:
+
 1. Split on `-` (dash)
 2. Operators cannot contain dashes
 3. Last segment is the operator (if it's a valid operator name)
@@ -817,6 +821,7 @@ Rules:
 5. If no operator segment, use the type's default operator
 
 **Examples:**
+
 - `name-contains` → field: `name`, operator: `contains`
 - `created-at-before` → field: `created-at`, operator: `before`
 - `modified-by-eq` → field: `modified-by`, operator: `eq`
@@ -870,7 +875,7 @@ Values are parsed based on field type:
 
 For `In` operator, values are comma-separated: `--status-in=active,pending,done`
 
-### Clause Groups
+### String Parsing Clause Groups
 
 Group markers change which group subsequent clauses are added to:
 
@@ -952,6 +957,7 @@ pub fn parse_value(
 ### Enum Value Resolution
 
 For enum fields, values can be either:
+
 1. **Numeric discriminant:** `0`, `1`, `2`
 2. **Variant name:** `pending`, `active`, `completed`
 
@@ -1004,7 +1010,7 @@ let results = query.filter(&tasks, Task::accessor);
 
 ### Crate Structure Addition
 
-```
+```text
 crates/standout-seeker/
 ├── src/
 │   ├── ...existing files...
@@ -1024,9 +1030,10 @@ crates/standout-seeker/
 
 Clap integration for automatic CLI argument generation.
 
-### Overview
+### CLI Bridge Overview
 
 Phase 4 builds on Phase 3's string parsing to provide seamless clap integration:
+
 - Auto-generated `--field-op=value` arguments from `SeekerSchema`
 - `--AND`, `--OR`, `--NOT` flags for group markers
 - `--order-by`, `--limit`, `--offset` standard arguments
@@ -1051,7 +1058,7 @@ struct ListArgs {
 
 For a `Task` with fields `name: String`, `priority: Number`, `done: Bool`:
 
-```
+```text
 OPTIONS:
     --name <VALUE>              Filter by name (equals)
     --name-eq <VALUE>           Filter by name equals
@@ -1121,7 +1128,7 @@ Or implement `SeekerSchema` manually to control exposure.
 
 Integrates with standout's help topics system to provide detailed filter documentation:
 
-```
+```text
 $ myapp help filters
 
 QUERY FILTERS

--- a/docs/proposals/standout-dispatch-breakup.md
+++ b/docs/proposals/standout-dispatch-breakup.md
@@ -20,7 +20,7 @@ PR #44 extracted `standout-render` as a standalone crate. This proposal continue
 
 ## New Architecture
 
-```
+```text
 standout-bbparser     (BBCode parser - standalone)
 standout-macros       (embed macros - standalone)
 standout-render       (rendering engine - standalone)
@@ -35,6 +35,7 @@ Each library crate is independently useful. The `standout` crate becomes the int
 ### standout-dispatch
 
 **Owns:**
+
 - Command routing (name → handler mapping)
 - Handler traits (`Handler`, `FnHandler`)
 - Handler result types (`Output<T>`, `HandlerResult<T>`, `RunResult`)
@@ -51,6 +52,7 @@ Each library crate is independently useful. The `standout` crate becomes the int
 - Command path extraction from ArgMatches
 
 **Does NOT own:**
+
 - Templates or template registries
 - Themes or style processing
 - BBCode/style tag parsing
@@ -58,6 +60,7 @@ Each library crate is independently useful. The `standout` crate becomes the int
 - Help topics system (stays in standout)
 
 **Dependencies:**
+
 - `clap` (argument parsing)
 - `serde`, `serde_json`, `serde_yaml`, `csv`, `quick-xml` (serialization)
 - `atty` or equivalent (TTY detection)
@@ -66,6 +69,7 @@ Each library crate is independently useful. The `standout` crate becomes the int
 ### standout-render
 
 **Owns:**
+
 - Template rendering (MiniJinja integration)
 - Style tag processing (BBCode-like syntax via standout-bbparser)
 - Theme system (CSS/YAML stylesheets)
@@ -76,6 +80,7 @@ Each library crate is independently useful. The `standout` crate becomes the int
 - The two-phase render pass (MiniJinja → BBParser)
 
 **Does NOT own:**
+
 - Command routing or dispatch
 - Argument parsing
 - Output mode selection
@@ -85,6 +90,7 @@ Each library crate is independently useful. The `standout` crate becomes the int
 ### standout (glue crate)
 
 **Owns:**
+
 - Integration of standout-dispatch with standout-render
 - `App` type alias with standout rendering
 - Builder conveniences that wire templates/themes to dispatch
@@ -158,12 +164,14 @@ pub type RenderFn = Arc<
 ```
 
 For dispatch-only users (no standout-render):
+
 ```rust
 // TextMode is ignored since there are no styles to process
 |data, _mode| Ok(format_my_output(data))
 ```
 
 For standout users:
+
 ```rust
 // standout constructs closures that call standout-render
 // TextMode maps to how style tags are processed
@@ -213,6 +221,7 @@ fn main() -> anyhow::Result<()> {
 ```
 
 **What dispatch-only users get:**
+
 - Command routing
 - Handler execution with `CommandContext`
 - Pre/post dispatch hooks
@@ -239,6 +248,7 @@ fn main() -> anyhow::Result<()> {
 ```
 
 **What full standout users get:**
+
 - Everything from dispatch
 - Template-based rendering with MiniJinja
 - Style tags with BBCode syntax
@@ -271,6 +281,7 @@ println!("{}", output);
 ## Help Topics System
 
 The help topics system (`TopicRegistry`, help rendering) remains in `standout` because:
+
 - It requires both dispatch (command handling) and render (styled output)
 - It's a high-level feature, not a primitive
 - Moving it to dispatch would re-introduce render coupling
@@ -286,6 +297,7 @@ The help topics system (`TopicRegistry`, help rendering) remains in `standout` b
 | `standout` | Full framework | dispatch + render |
 
 This architecture enables:
+
 - Dispatch-only adoption (simple, no templates)
 - Render-only adoption (servers, TUIs)
 - Full framework adoption (CLI apps with rich output)

--- a/docs/proposals/tabular-macros.md
+++ b/docs/proposals/tabular-macros.md
@@ -29,7 +29,7 @@ The `row_from<T: Serialize>()` method works by serializing to JSON and extractin
 
 **Purpose:** Generate a `TabularSpec` from struct field annotations.
 
-### Usage
+### Tabular Usage
 
 ```rust
 use standout::tabular::{Tabular, TabularSpec};
@@ -98,7 +98,7 @@ impl Tabular for Task {
 
 **Purpose:** Generate optimized row extraction without runtime JSON serialization.
 
-### Usage
+### TabularRow Usage
 
 ```rust
 use standout::tabular::TabularRow;
@@ -163,6 +163,7 @@ Create the macro module structure and attribute parsing utilities.
 3. Error reporting with `syn::Error`
 
 **Files:**
+
 - `crates/standout-macros/src/tabular/mod.rs`
 - `crates/standout-macros/src/tabular/attrs.rs`
 
@@ -184,11 +185,13 @@ Implement the spec generation macro.
 4. Handle container `#[tabular(...)]` attributes
 
 **Files:**
+
 - `crates/standout-macros/src/tabular/derive_tabular.rs`
 - `crates/standout-macros/src/lib.rs` (register macro)
 - `crates/standout/src/rendering/tabular/traits.rs` (Tabular trait)
 
 **Tests:**
+
 - Simple struct with fixed widths
 - All width variants (fixed, fill, fraction, bounded)
 - All attribute combinations
@@ -212,10 +215,12 @@ Implement the row extraction macro.
 4. Handle `#[col(skip)]` attribute
 
 **Files:**
+
 - `crates/standout/src/rendering/tabular/traits.rs` (TabularRow trait)
 - `crates/standout-macros/src/tabular/derive_row.rs`
 
 **Tests:**
+
 - String fields
 - Numeric fields (i32, u64, f64)
 - Option fields
@@ -238,10 +243,12 @@ Integrate macros with existing formatter.
 4. Benchmark trait-based vs serde-based extraction
 
 **Files:**
+
 - `crates/standout/src/rendering/tabular/formatter.rs`
 - `crates/standout/src/rendering/tabular/decorator.rs`
 
 **Tests:**
+
 - End-to-end: derive → format → output
 - Equivalence: trait output matches serde output
 - Performance comparison
@@ -261,6 +268,7 @@ Enable macro-derived specs in templates.
 3. Example templates
 
 **Files:**
+
 - `crates/standout/src/rendering/tabular/filters.rs`
 - Examples in `examples/`
 
@@ -282,7 +290,7 @@ Complete documentation and examples.
 
 ## Phase Dependencies
 
-```
+```text
 Phase 1 (Infrastructure)
     │
     ├──→ Phase 2 (Tabular derive)
@@ -312,6 +320,7 @@ Phases 2 and 3 can be developed in parallel after Phase 1.
 2. **`TabularRow`** generates row extraction (field → string conversion)
 
 They serve different purposes and can be used independently:
+
 - Use only `Tabular` with `row_from<T: Serialize>()` for flexibility
 - Use only `TabularRow` with manually-built specs for control
 - Use both for maximum type safety and performance
@@ -319,6 +328,7 @@ They serve different purposes and can be used independently:
 ### Why Not Combine Them?
 
 Separation allows:
+
 - Using `Tabular` without `TabularRow` (keep serde flexibility)
 - Using `TabularRow` with different specs (same data, different views)
 - Clearer error messages and simpler macro logic
@@ -326,6 +336,7 @@ Separation allows:
 ### Field Ordering
 
 Both macros preserve struct field order. This ensures:
+
 - `tabular_spec()` columns match `to_row()` values
 - Predictable output without explicit ordering attributes
 - Simple mental model for users


### PR DESCRIPTION
Content-only pre-cleaning ahead of release/'s strict-gate tightening (arthur-debert/release#288). No managed config or symlinks touched; only owned shell + markdown files. CI still runs the relaxed config, so proof is local strict lint (below).

## Shell

All owned shell files (`palette_compare.sh`, `bin/check-lint`, `bin/check-fmt`, `app-bin/docs-book`, `app-bin/docs-spellcheck`, `crates/standout/scripts/pre-commit`) **already passed** `shellcheck --severity=info` with zero findings. No changes needed, no `# shellcheck disable` directives added.

## Markdown — finding categories fixed (strict config)

Strict config used: `{"MD013":false,"line-length":false,"MD060":false,"table-column-style":false}` (matches release/'s canonical `shell-quality/.markdownlint.json`).

- **MD032 / MD031 / MD030 / MD022 / MD009 / MD012 / MD007 / MD004** — mechanical (blanks around lists/fences/headings, trailing spaces, list indent/markers). Auto-fixed via `markdownlint --fix`.
- **MD040** (24) — bare code fences given a `text` language (ASCII diagrams, trees, command/output blocks, git commit-message samples).
- **MD036** (37) — emphasis-as-heading: numbered sub-step pseudo-headings in `new-api.md` promoted to real `####` headings; label lines (`**Goal: ...**`, `**Status: ...**`, `**Total: ...**`, `**Coverage: ...**`) reshaped to `**Label:** value` so the whole line is no longer emphasis.
- **MD024** (23) — duplicate headings disambiguated by parent context (e.g. `Current State` -> `Current State (Issue N)`, `Access in Handlers` -> `Accessing App State/Extensions in Handlers`, `Usage` -> `Tabular Usage` / `TabularRow Usage`, etc.). No behavior impact.
- **MD033** (4) — inline-HTML false positives (`Option<T>`, `Result<T>`, `Output<T>`, `<crate>`) wrapped in backticks.
- **MD041** (1) — `docs/intro.md` first heading promoted `##` -> `#`.
- **MD028** (1) — adjacent blockquotes in `intro-to-testing.md` joined with a `>` continuation line.

Local strict re-run is clean on every owned md file **except** `docs/SUMMARY.md` (see below).

## Known residual: `docs/SUMMARY.md` (MD025, 5 findings) — left intentionally

This is an mdBook `SUMMARY.md`. Its multiple H1s (`# Getting Started`, `# Rendering (standout-render)`, ...) are mdBook **part titles** and MUST be H1 — converting them to H2 removes them from the rendered TOC entirely (verified locally: `part-title` count drops 5 -> 0). Fixing MD025 here would break the book, which violates the content-only/preserve-behavior rule. This should be handled upstream by adding `SUMMARY.md` (or `docs/SUMMARY.md`) to the managed `.markdownlintignore` in release/'s `templates/commons/`, the same way `CHANGELOG.md` is already excluded.

## Verification

- `shellcheck --severity=info` -> 0 on every owned shell file.
- `markdownlint --config <strict>` -> 0 on all owned md except the 5 intentional `docs/SUMMARY.md` MD025 part-title findings noted above.
- `mdbook build` succeeds; all 5 part titles render correctly.
- No shell/test/fixture/bats files were changed (markdown-only), so the test suite was not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)