### PR TITLE
ci: bump release reusable workflows to @v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ permissions:
 
 jobs:
   ci:
-    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v1
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v2

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: arthur-debert/release/.github/workflows/copilot-review.yml@v1
+    uses: arthur-debert/release/.github/workflows/copilot-review.yml@v2
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-# Thin caller of arthur-debert/release/.github/workflows/mdbook.yml@v1.
+# Thin caller of arthur-debert/release/.github/workflows/mdbook.yml@v2.
 # book.toml at repo root, output directory `book/` (mdbook default).
 # `cname: standout.magik.works` for the custom-domain deploy.
 
@@ -20,6 +20,6 @@ permissions:
 
 jobs:
   docs:
-    uses: arthur-debert/release/.github/workflows/mdbook.yml@v1
+    uses: arthur-debert/release/.github/workflows/mdbook.yml@v2
     with:
       cname: standout.magik.works

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   release:
-    uses: arthur-debert/release/.github/workflows/rust-lib.yml@v1
+    uses: arthur-debert/release/.github/workflows/rust-lib.yml@v2
     with:
       version: ${{ inputs.version }}
       # Topological order (deps before dependents). standout-test and


### PR DESCRIPTION
Moves onto release/'s v2 major line (v2.0.0 = strict lint gate). Reusable workflows unchanged v1→v2; behavior-neutral. Admin-merged without the review loop per maintainer direction.