### PR TITLE
fix: make standout-docs a discoverable skill

### DIFF
--- a/.claude/skills/standout-docs/SKILL.md
+++ b/.claude/skills/standout-docs/SKILL.md
@@ -1,4 +1,9 @@
-# Skill: Standout Documentation
+---
+name: standout-docs
+description: Write and review documentation for the Standout CLI framework — guides, topics, canonical forms, and the shared `tdoo` example domain. Use when authoring or reviewing docs in a Standout-based project, or deciding whether content belongs in a guide vs a topic.
+---
+
+# Standout Documentation
 
 Write and review documentation for the Standout CLI framework.
 

--- a/CHANGELOG/unreleased-fix-standout-docs-skill.md
+++ b/CHANGELOG/unreleased-fix-standout-docs-skill.md
@@ -1,0 +1,1 @@
+- Fix the standout-docs skill: relocate to standout-docs/SKILL.md and add required frontmatter so it's discoverable


### PR DESCRIPTION
## What

`standout-docs` lived as a loose `.claude/skills/standout-docs.md` with no YAML frontmatter, so Claude Code never discovered it as a skill — it was dead weight in git.

- Relocated to `.claude/skills/standout-docs/SKILL.md` (proper `<name>/SKILL.md` layout; history preserved via `git mv`)
- Added the required `name` + `description` frontmatter
- Content otherwise unchanged

## Why

Surfaced during a fleet skills audit from `arthur-debert/release` — it was the one malformed skill across the consumer fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)