### PR TITLE
chore(ci): migrate release reusable-workflow callers @v2 → @v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ permissions:
 
 jobs:
   ci:
-    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v2
+    uses: arthur-debert/release/.github/workflows/rust-ci.yml@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-# Thin caller of arthur-debert/release/.github/workflows/mdbook.yml@v2.
+# Thin caller of arthur-debert/release/.github/workflows/mdbook.yml@v3.
 # book.toml at repo root, output directory `book/` (mdbook default).
 # `cname: standout.magik.works` for the custom-domain deploy.
 
@@ -20,6 +20,6 @@ permissions:
 
 jobs:
   docs:
-    uses: arthur-debert/release/.github/workflows/mdbook.yml@v2
+    uses: arthur-debert/release/.github/workflows/mdbook.yml@v3
     with:
       cname: standout.magik.works

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   release:
-    uses: arthur-debert/release/.github/workflows/rust-lib.yml@v2
+    uses: arthur-debert/release/.github/workflows/rust-lib.yml@v3
     with:
       version: ${{ inputs.version }}
       # Topological order (deps before dependents). standout-test and

--- a/CHANGELOG/unreleased-release-v3.md
+++ b/CHANGELOG/unreleased-release-v3.md
@@ -1,0 +1,1 @@
+ci: migrate release reusable-workflow callers from @v2 to @v3

--- a/CHANGELOG/unreleased-release-v3.md
+++ b/CHANGELOG/unreleased-release-v3.md
@@ -1,1 +1,1 @@
-ci: migrate release reusable-workflow callers from @v2 to @v3
+- ci: migrate release reusable-workflow callers from @v2 to @v3


### PR DESCRIPTION
Migrate release reusable-workflow callers from \`@v2\` to \`@v3\` after release cut v3.0.0.

v3 is MAJOR only because release removed the deprecated singular \`wasm-package\` input (#634) — no consumer used it, so this is mechanical.

## Changes
- \`.github/workflows/ci.yml\`: rust-ci.yml @v2 → @v3
- \`.github/workflows/release.yml\`: rust-lib.yml @v2 → @v3
- \`.github/workflows/docs.yml\`: mdbook.yml @v2 → @v3 (uses + prose comment)
- \`copilot-review.yml\` left at @v1 (intentional)

The managed tree is NOT in this PR — it arrives via the consumer's own wheel pull. Only workflow caller refs + a changelog fragment are touched here.

🤖 Generated with Claude Code