### PR TITLE
ci: adopt shipit release pipeline — declarations + blessed stage-choice caller (ADP02-WS08)

### DIFF
--- a/.github/workflows/shipit-release.yml
+++ b/.github/workflows/shipit-release.yml
@@ -1,0 +1,146 @@
+name: shipit-release
+
+# standout's shipit release caller (ADP02-WS08, the rust fleet-cutover
+# PATHFINDER — arthur-debert/shipit#841) — the WS09 BLESSED per-stage
+# dispatch shape (ADR-0054, workflows.lex §8), copied from
+# arthur-debert/shipit's own shipit-release.yml: one workflow_dispatch
+# caller with a `stage` choice (full | prepare | build | sign | publish),
+# one job per stage, each a single `uses:` line against the matching
+# block, gated `if: inputs.stage == '...'`, forwarding
+# `version`/`tag`/`run-id`/`unsigned` verbatim. Routing ONLY (ADR-0040):
+# the release plan — matrix, live stages, the post-RC-guard endpoint set,
+# required secrets — is preflight's, computed inside the blocks; nothing
+# is re-derived or wired stage-to-stage here.
+#
+# Every ref is the FULL remote `arthur-debert/shipit/...@v1` form — never
+# `./` relative (which would resolve against THIS repo, where no blocks
+# live), never SHA-pinned (the fleet rides the advance-major-moved `v1`,
+# ADR-0010).
+#
+# standout's release surface is crates-only (.shipit.toml
+# [artifacts.standout]: a no-build artifact, endpoints gh-release +
+# crates — the workspace's 8 publishable library crates in derived
+# dependency order, plus the notes-only GH release the legacy surface
+# cut), so the plan's matrix is EMPTY and the build/sign stages are
+# plan-proven no-ops: a `build` or `sign` dispatch re-derives the plan at
+# the tag, fans over nothing, and skips. The choices stay offered because
+# this caller rides the blessed shape, never a trimmed variant.
+#
+# Secrets — exactly the plan-required set for standout's plan:
+#   RELEASE_TOKEN         prepare's tag+branch push through the ruleset
+#                         (a GITHUB_TOKEN push would not re-trigger
+#                         workflows).
+#   CARGO_REGISTRY_TOKEN  the crates endpoint's registry token, mapped
+#                         from this repo's legacy-named CRATES_IO_KEY
+#                         secret (NOT renamed: the legacy release.yml
+#                         still consumes it under that name until WS08
+#                         retires it). Forwarded to the stages that can
+#                         publish crates (`full`, `publish`); the RC
+#                         guard drops the crates endpoint on an
+#                         -release-rc version centrally.
+# gh-release rides the workflow's own GITHUB_TOKEN (no registry entry).
+# The Apple signing set is not forwarded: standout has never signed mac
+# (no darwin lane, no sign stage in the plan), and preflight refuses a
+# break-glass `--unsigned` on a plan with no sign stage.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          The release version, consumed by `full`/`prepare`: a bare semver
+          (1.0.0, 1.0.0-release-rc) or a bump word (major|minor|patch).
+          Ignored by the tag-dispatched stages.
+        required: false
+        type: string
+      stage:
+        description: >-
+          What to dispatch: the full composed chain (default) or ONE
+          independently re-runnable stage block (per-stage dispatch,
+          ADR-0054). `prepare` dispatches on `version`; `build`, `sign`
+          and `publish` on `tag` (+ `run-id` for the artifact-consuming
+          stages).
+        required: false
+        type: choice
+        default: full
+        options:
+          - full
+          - prepare
+          - build
+          - sign
+          - publish
+      tag:
+        description: >-
+          The release tag (v<version>), consumed by the `build`/`sign`/
+          `publish` stage dispatches (ADR-0041: the version is read off
+          the tag). Ignored by `full`/`prepare`.
+        required: false
+        type: string
+      run-id:
+        description: >-
+          The SOURCE run id whose artifacts feed an artifact-consuming
+          stage dispatch (`sign`, `publish`) — one source run per dispatch
+          (workflows.lex §8). Ignored by the other stages.
+        required: false
+        type: string
+      unsigned:
+        description: >-
+          Break-glass: flip a signing plan to the unsigned path. Forwarded
+          verbatim; standout's plan has no sign stage, so preflight
+          refuses it here — offered because this caller rides the blessed
+          shape.
+        required: false
+        type: boolean
+        default: false
+
+# The standalone dispatch caller's grant (workflows.lex §8): `contents:
+# write` for prepare's push and publish's gh-release, `actions: read` for
+# the cross-run artifact downloads (`run-id` flips download-artifact onto
+# the REST API). The downloading blocks deliberately declare NO
+# `permissions:` key — a called workflow can only downgrade this token.
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  release:
+    if: inputs.stage == 'full'
+    uses: arthur-debert/shipit/.github/workflows/wf-release.yml@v1
+    with:
+      version: ${{ inputs.version }}
+      unsigned: ${{ inputs.unsigned }}
+    secrets:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}
+
+  prepare:
+    if: inputs.stage == 'prepare'
+    uses: arthur-debert/shipit/.github/workflows/wf-prepare.yml@v1
+    with:
+      version: ${{ inputs.version }}
+      unsigned: ${{ inputs.unsigned }}
+    secrets:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+  build:
+    if: inputs.stage == 'build'
+    uses: arthur-debert/shipit/.github/workflows/wf-build.yml@v1
+    with:
+      tag: ${{ inputs.tag }}
+
+  sign:
+    if: inputs.stage == 'sign'
+    uses: arthur-debert/shipit/.github/workflows/wf-sign-mac.yml@v1
+    with:
+      tag: ${{ inputs.tag }}
+      run-id: ${{ inputs.run-id }}
+
+  publish:
+    if: inputs.stage == 'publish'
+    uses: arthur-debert/shipit/.github/workflows/wf-publish.yml@v1
+    with:
+      tag: ${{ inputs.tag }}
+      run-id: ${{ inputs.run-id }}
+      unsigned: ${{ inputs.unsigned }}
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}

--- a/.shipit.toml
+++ b/.shipit.toml
@@ -60,6 +60,30 @@ local = true
 [toolchains]
 "." = "rust"
 
+# [artifacts] — standout's declared release surface for the shipit release
+# pipeline (ADP02-WS08, the rust fleet-cutover PATHFINDER; modeled on
+# padz's WS06 map and shipit's own no-build artifact). standout is a
+# crates-only rust workspace: 8 library crates published to crates.io in
+# dependency order, plus a notes-only GitHub release — the legacy surface
+# (release.yml → rust-lib.yml@v3) published the same 8 crates and cut a GH
+# release with ZERO assets (verified against v7.6.3). The honest
+# declaration is therefore a NO-BUILD artifact: no binary, no bundle, no
+# platforms — preflight plans an EMPTY matrix (build/sign are plan-proven
+# no-op stages that skip) and publish fans over the two endpoints. The
+# crates endpoint rides the [toolchains] rust leg above and DERIVES the
+# publish order from `cargo metadata` at publish time (topological,
+# alphabetical ties) — the legacy caller's hand-copied topo list is
+# deliberately NOT repeated here.
+# KNOWN GAP (flagged in the WS08 PR): the derivation does not filter
+# `publish = false` members, so it appends standout-test and todo-example
+# after the 8 publishable crates. Harmless on the rc proof (the central RC
+# guard drops the crates endpoint on a -release-rc version) but a REAL
+# publish aborts on `cargo publish -p standout-test` — shipit-side
+# follow-up owns the filter; do not hand-copy an order here to work
+# around it.
+[artifacts.standout]
+endpoints = ["gh-release", "crates"]
+
 [shipit]
 version = "0898a6f9847e80d30f709ef4d9b539cbd68b253a"
 


### PR DESCRIPTION
Closes #186. For arthur-debert/shipit#841 (ADP02-WS08 rust fleet cutover — standout is the pathfinder; umbrella arthur-debert/shipit#658).

Cuts standout's release path onto shipit's composed release pipeline: `[artifacts]` declarations in `.shipit.toml` plus a `shipit-release.yml` caller ALONGSIDE the untouched legacy `release.yml`. Legacy removal is NOT this PR — it follows the remote rc proof, a later coordinator-driven step.

## What changed

- **`.shipit.toml` → `[artifacts.standout]`**: the crates-only NO-BUILD shape — `endpoints = ["gh-release", "crates"]`, no build/bundle/platforms. Honest to the legacy surface: the workspace's 8 publishable library crates go to crates.io, and the GH release ships notes with **zero assets** (verified: `gh release view` on v7.6.3 → `assets: []`). The crates endpoint rides the existing `[toolchains]` rust leg and derives the publish order from `cargo metadata` at publish time — the legacy caller's hand-copied topo list is deliberately not repeated in config (the schema does not require it).
- **`.github/workflows/shipit-release.yml`**: arthur-debert/shipit's own WS09 blessed stage-choice caller (ADR-0054: `stage: full|prepare|build|sign|publish`, `tag` + `run-id` inputs) copied VERBATIM, adapting only (a) the header comment to standout facts, (b) the secrets set: `RELEASE_TOKEN` (prepare's tag+branch push) + `CARGO_REGISTRY_TOKEN` mapped from the legacy-named `CRATES_IO_KEY` repo secret (NOT renamed — legacy `release.yml` still consumes it until WS08 retires it), forwarded on `full` and `publish`. No Apple set (never signed mac); gh-release rides `GITHUB_TOKEN`. All five stage choices kept — `build`/`sign` are plan-proven empty-matrix no-ops that skip.

## ⚠️ FLAG — derived order ≠ legacy list (the issue's stop-and-flag case)

`crates_publish_order` (shipit `release/publish.py`) does **not** filter `publish = false` workspace members. Derived order on this workspace:

`standout-bbparser, standout-dispatch, standout-input, standout-macros, standout-pipe, standout-seeker, standout-render, standout` — same SET as the legacy list, topologically valid (ties break alphabetically, so the interior order differs harmlessly from legacy's hand-order) — **then appends `standout-test, todo-example`** (both `publish = false`).

Per the issue I did NOT force a hand-copied order into config. Impact: none on the rc proof (the central RC guard drops the crates endpoint on `-release-rc`, confirmed by preflight below), but a REAL publish would abort on `cargo publish -p standout-test` after the 8 real crates upload (re-runs resume past already-published crates per ADR-0009, but the run can never go green). Needs a shipit-side `publish = false` filter in `crates_publish_order` before standout's first real release — follow-up issue for the coordinator to place on arthur-debert/shipit, not scope creep here.

## Verification (run in the Tree)

The repo pin (`0898a6f`, 81 commits behind) predates the `release`/`wf` verbs, so the local checks below ran on **current shipit main** via `uvx --from git+https://github.com/arthur-debert/shipit@main` — as the issue anticipated; the remote run happens post-reconcile at the new pin.

- `shipit release preflight 0.0.0-release-rc --json` → resolves: `matrix: []`, stages `preflight/prepare/publish`, endpoints `["gh-release"]` (**crates DROPPED by the central RC guard**), secrets exactly `["RELEASE_TOKEN"]`. Non-rc control (`1.0.0`): endpoints `["gh-release", "crates"]`, secrets `["RELEASE_TOKEN", "CARGO_REGISTRY_TOKEN"]`. Presence validation confirmed live: preflight with no env fails loudly on missing `RELEASE_TOKEN`.
- `shipit wf test .github/workflows/shipit-release.yml --event workflow_dispatch --input stage=prepare --input version=0.0.0-release-rc --dry-run` → **WF TEST: OK** (act resolves the remote `wf-prepare@v1` block; the job graph evaluates green). The bare `--event push` form finds no stages by construction (dispatch-only caller).
- `pixi run test` → 1700/1700 passed (no product code touched; suite guards the tree).
- Lint: the commit hook ran the full managed gate — 29 checks OK, including actionlint + yamllint on the new caller. No separate lint run needed.

## Self-check against governing docs

- **ADR-0040** (routing, never logic): the caller contains no plan logic, no stage-to-stage wiring, no companion workflow — five `uses:` lines, inputs forwarded verbatim.
- **ADR-0054 / workflows.lex §8**: the blessed stage-choice shape verbatim from the dogfooded original — full remote `arthur-debert/shipit/...@v1` refs (never `./`, never SHA-pinned), `contents: write` + `actions: read` grant, all five stages offered.
- **ADR-0041** (tag-authoritative version): `tag` is forwarded verbatim to the tag-dispatched stages; nothing here computes a version.
- **ADR-0009** (partial-release prevention): the barrier/resume logic stays inside the blocks; the no-build declaration makes build/sign plan-proven non-live, the shape wf-publish's gate explicitly accepts. The `publish = false` flag above is the one residual ADR-0009 exposure, on shipit's side.
- **docs/prd/adoption.md**: declarations + caller alongside legacy, cutover proof before legacy removal — this PR is exactly that first step.

## Out of scope — do not "fix" here

- Legacy `release.yml`, `docs.yml`, checks surfaces: untouched by design.
- The shipit pin / reconcile PR (blocked on arthur-debert/shipit#846): independent; no `shipit install` run here.
- `copilot-review.yml` + `bin/install-release-core` retired-but-modified units: the reconcile/cleanup path owns them.
- No dispatches, no tags, nothing published — the coordinator dispatches the rc proof after merge.
- `SCCACHE_GCS_KEY` is checks-side, not release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)