### PR TITLE
ci: prepare stage job forwards the full plan-required secret set

### DIFF
--- a/.github/workflows/shipit-release.yml
+++ b/.github/workflows/shipit-release.yml
@@ -26,18 +26,22 @@ name: shipit-release
 # the tag, fans over nothing, and skips. The choices stay offered because
 # this caller rides the blessed shape, never a trimmed variant.
 #
-# Secrets — exactly the plan-required set for standout's plan:
+# Secrets — the UNIFORM plan-required set (shipit#896): preflight
+# re-validates the WHOLE release plan at every stage entry, so EVERY
+# stage job (`prepare`, `publish`) forwards the SAME secret set as
+# `full` — no per-stage subsetting; which secrets a stage actually
+# spends is the plan's call, not this caller's. (`build` declares no
+# secrets, so it forwards none; the `sign` block's Apple set is not
+# plan-required here — see below.)
 #   RELEASE_TOKEN         prepare's tag+branch push through the ruleset
 #                         (a GITHUB_TOKEN push would not re-trigger
 #                         workflows).
 #   CARGO_REGISTRY_TOKEN  the crates endpoint's registry token, mapped
 #                         from this repo's legacy-named CRATES_IO_KEY
-#                         secret (NOT renamed: the legacy release.yml
-#                         still consumes it under that name until WS08
-#                         retires it). Forwarded to the stages that can
-#                         publish crates (`full`, `publish`); the RC
-#                         guard drops the crates endpoint on an
-#                         -release-rc version centrally.
+#                         secret (the repo secret keeps its legacy name;
+#                         renaming it is a repo settings change, not
+#                         this caller's). The RC guard drops the crates
+#                         endpoint on an -release-rc version centrally.
 # gh-release rides the workflow's own GITHUB_TOKEN (no registry entry).
 # The Apple signing set is not forwarded: standout has never signed mac
 # (no darwin lane, no sign stage in the plan), and preflight refuses a
@@ -121,6 +125,7 @@ jobs:
       unsigned: ${{ inputs.unsigned }}
     secrets:
       RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}
 
   build:
     if: inputs.stage == 'build'


### PR DESCRIPTION
closes #191

For arthur-debert/shipit#896 (found on the dodot staged-dispatch proof) and arthur-debert/shipit#841.

Preflight re-validates the WHOLE release plan at every stage entry, so a `prepare` stage dispatch fails on any plan-required secret it wasn't granted — the caller forwarded only `RELEASE_TOKEN`.

## What changed

One-block edit to `.github/workflows/shipit-release.yml`:

- `jobs.prepare.secrets` is now an EXACT copy of `jobs.release.secrets`: `RELEASE_TOKEN` + `CARGO_REGISTRY_TOKEN` (mapped from this repo's legacy-named `CRATES_IO_KEY` secret, mapping expression kept verbatim).
- Header comment restated as the uniform-grant rule (cites shipit#896), mirroring arthur-debert/dodot's proven caller comment (dodot#247, two full staged rc chains green 2026-07-13). Dropped the stale "legacy release.yml still consumes CRATES_IO_KEY" rationale — the legacy workflow was retired in #190; the secret keeps its legacy name because renaming is a repo settings change, not this caller's.

## Context

- **Why this approach:** exact-copy of the `full` job's secret set per the issue and the dodot pathfinder model — no per-stage subsetting; which secrets a stage spends is the plan's call, not the caller's.
- **Out of scope / do NOT "fix":** `sign`/`build`/`publish` are untouched on purpose — `build` declares no secrets, `sign`'s Apple set is not plan-required for standout (no darwin lane, no sign stage), `publish` keeps the registry set. Adding undeclared secrets to a `uses:` job is a workflow error. Renaming the `CRATES_IO_KEY` repo secret is also out of scope (repo settings, not this caller).
- **Verified:** `./bin/shipit wf test .github/workflows/shipit-release.yml --event workflow_dispatch --input stage=prepare --input version=1.0.0-release-rc --dry-run` → WF TEST: OK; commit/push hooks ran the full lint suite incl. actionlint + yamllint on the caller (LINT: OK, 29 checks). Self-check against the issue's governing refs (shipit#896 uniform-grant rule, dodot#247 proven caller shape): diff matches — prepare = full set, others verbatim. The coordinator re-runs the staged rc proof after merge.
- **Brief gaps:** none blocking — the issue named the verify commands and decision boundaries explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)