### PR TITLE
shipit: install/update the managed set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,18 @@ book/
 
 # Canonical SessionStart hook is tracked
 !.claude/settings.json
+
+# >>> shipit-managed release-output ignores (do not edit; regenerate via `shipit install`) >>>
+# shipit release-stage outputs — transient artifacts the release verbs write at
+# the repo ROOT: `shipit release notes` writes RELEASE_NOTES.md, the sign stage
+# stages dist-signed/, and compositions write dist/. Ignoring them keeps a
+# root-level single-crate `cargo publish` VCS-dirty check clean (#906 — cargo
+# inspects the crate root, so unignored root-level artifacts abort the publish).
+# The leading slash ROOT-ANCHORS each pattern so it matches only these repo-root
+# artifacts, never a same-named nested path (e.g. crates/foo/dist/). Managed by
+# shipit — a local edit surfaces as an OVERRIDE at the next `shipit install`
+# reconcile; add your OWN ignores outside this block.
+/RELEASE_NOTES.md
+/dist/
+/dist-signed/
+# <<< shipit-managed release-output ignores <<<

--- a/.shipit.toml
+++ b/.shipit.toml
@@ -85,7 +85,7 @@ local = true
 endpoints = ["gh-release", "crates"]
 
 [shipit]
-version = "0a8a4410923b8ccf4db98ac131d0b9c7d5bc5ef0"
+version = "9ed36a74add2da27a468d7d2a0116f8875cc78a5"
 
 [managed]
 "skills/coordinating/SKILL.md" = "sha256:065a793b117dcfbb1e97fea0a80b405c69995850af9a350061dbcc1f4ea4976a"
@@ -100,6 +100,7 @@ version = "0a8a4410923b8ccf4db98ac131d0b9c7d5bc5ef0"
 "skills/to-spec/SKILL.md" = "sha256:9f7e5216675070146daabdc0f63ddb8cc8ecf37843ab5d3290354bf57d8097c0"
 "skills/to-tickets/SKILL.md" = "sha256:38df45b1560de0e10be3ab8f7ef4113114ee851e3790ac9087b4c9560c7dc6df"
 "AGENTS.md#shipit-block" = "sha256:aae40d34d67837bdef546e9294b65900b0e5fbf5ed18603a30ca68c756d7d8db"
+".gitignore#shipit-release-outputs" = "sha256:4a9beb3dea542cd0f1426a298069a506c6ea1fdfb3e852a9d2032dd475dfe143"
 "bin/shipit" = "sha256:c1c8d6653ce37ada6b6dbad1866148bc1e54a8951384ebc07df01abd86d084a3"
 "bin/setup-dev-env.sh" = "sha256:0558c0ba79c3569f55683f4fe80098565b5ffae03a11f14beb279ff29a1be8a7"
 agent-start = "sha256:3f8b7d1d6e1d51f9a714e4781f8be89a60e3da26f33f55715c3a67f4ae2c43fd"


### PR DESCRIPTION
`shipit install` reconciled the managed set.

Pinned to `9ed36a74add2da27a468d7d2a0116f8875cc78a5` — the build that wrote this managed set and passed its self-certification (ADR-0033); the managed `bin/shipit` launcher execs exactly this build.

### Added
- `.gitignore#shipit-release-outputs`

### Checks activated locally
`lefthook install` ran where this install was invoked, so its `.git/hooks/{pre-commit,pre-push}` fire `pixi run lint` there now. Reviewers/mergers: run `./bin/shipit install` on your own checkout (shipit-self: `pixi run -e lint install-hooks`) to make the checks live for you too. Activation is idempotent and leaves unrelated hooks intact.


Refs #194
