### PR TITLE
Add Standout implementation quality checklist

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,6 +8,7 @@
 
 - [Minimal single-crate example](./guides/minimal-single-crate.md)
 - [Production-shaped application](./guides/production-shaped-example.md)
+- [Leveraging Standout checklist](./guides/leveraging-standout.md)
 - [Quick Start](./guides/tldr-intro-to-standout.md)
 - [Introduction to Standout](./guides/intro-to-standout.md)
 - [Introduction to Testing](./guides/intro-to-testing.md)

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -7,6 +7,7 @@ Step-by-step walkthroughs covering principles, rationale, and features.
 - **[Introduction to Standout](./intro-to-standout.md)** — Adopting Standout in a working CLI. Start here.
 - **[TLDR Quick Start](./tldr-intro-to-standout.md)** — Fast-paced intro for experienced developers.
 - **[Introduction to Testing](./intro-to-testing.md)** — Testing Standout CLIs end-to-end, in-process, with full environment control.
+- **[Leveraging Standout: Value and Implementation Quality Checklist](./leveraging-standout.md)** — Review ownership, rendering, testing, optional capabilities, and framework gaps.
 
 ## Crate Guides
 
@@ -28,5 +29,9 @@ If you're new to Standout, begin with [Introduction to Standout](./intro-to-stan
 For a quick overview without the explanations, see the [TLDR Quick Start](./tldr-intro-to-standout.md).
 
 Once you have the framework in place, [Introduction to Testing](./intro-to-testing.md) shows how the architecture plus the `standout-test` harness largely replaces slow, brittle subprocess-based CLI tests with fast in-process ones.
+
+Use the [implementation quality checklist](./leveraging-standout.md) to review
+whether an application preserves Standout's invariants, applies relevant
+capabilities, and identifies framework gaps explicitly.
 
 If you want to use the crates independently (without the full framework), start with the crate-specific guides above.

--- a/docs/guides/leveraging-standout.md
+++ b/docs/guides/leveraging-standout.md
@@ -1,0 +1,127 @@
+# Leveraging Standout: Value and Implementation Quality Checklist
+
+Standout is most valuable when it creates a testable seam between application
+behavior and shell presentation. Use this guide to review an implementation,
+decide which framework capabilities add value, and name missing framework
+support without pushing presentation concerns back into handlers.
+
+## Evaluation classes
+
+Classify every finding before deciding whether it needs work:
+
+- **Invariant** — a property the application should preserve wherever Standout
+  owns a command. Violating it weakens the architecture or public behavior.
+- **Applicable capability** — a Standout feature that is valuable only when the
+  application's needs call for it. Not using it is not automatically a defect.
+- **Framework gap** — a desirable behavior that Standout does not currently
+  integrate. Record the gap instead of hiding a custom workaround in a handler.
+
+The checklist uses **I**, **A**, and **G** for those classes.
+
+## Ownership and dispatch
+
+- **I — Keep reusable behavior CLI-free.** Domain rules, state transitions,
+  validation, persistence, and reusable services should expose ordinary Rust
+  interfaces. A separate core crate is the recommended production shape, not a
+  requirement enforced by Standout. Small applications may keep the same seam
+  inside one crate.
+- **I — Let the binary own the shell.** Clap types, Standout app construction,
+  handlers, CLI view DTOs, templates, styles, environment lookup, and final
+  output belong in the CLI package. Handlers are adapters: translate parsed
+  arguments, call the core, and return serializable data.
+- **I — Integrate with Clap.** Standout does not replace Clap. Clap remains the
+  command and argument parser; Standout adds dispatch, rendering, output modes,
+  hooks, and test seams around the resulting command model.
+- **A — Prefer declarative dispatch when conventions fit.**
+  `#[derive(Dispatch)]` maps Clap variants to handlers and can attach templates,
+  hooks, nested dispatch, and pipes. Use explicit `command_with` registration
+  when a command needs configuration that is clearer in builder code.
+
+The production-shaped [`todo-core` + `tdoo` example](production-shaped-example.md)
+shows this ownership boundary in executable code. The
+[dispatch guide](../crates/dispatch/guides/intro-to-dispatch.md) covers the
+pipeline in detail.
+
+## Output and rendering
+
+- **I — Return data, not presentation.** A normal handler returns
+  `Output::Render(data)`, `Output::Silent`, or `Output::Binary { ... }`. It
+  should not print, emit ANSI, render a template, or branch on output mode.
+- **I — Keep one data contract across modes.** `auto`, `term`, and `text` render
+  the MiniJinja template and transform semantic style tags. `term-debug` keeps
+  the tags visible. Structured `json`, `yaml`, `xml`, and `csv` modes serialize
+  handler data directly and bypass templates, including template-injected
+  context.
+- **A — Use MiniJinja and semantic CSS.** Put layout in file-backed MiniJinja
+  templates and appearance in CSS classes such as `.title` or `.warning`.
+  Define adaptive overrides with `@media (prefers-color-scheme: light)` and
+  `@media (prefers-color-scheme: dark)`; Standout resolves the matching style
+  variant for the terminal background.
+- **A — Embed resources and keep the debug loop short.** `embed_templates!` and
+  `embed_styles!` provide release-safe assets. Hot reload specifically means
+  that debug file-backed resources are re-read on render, so source edits can
+  be observed without rebuilding while the original paths remain available.
+- **A — Use tabular layout for column relationships.** Reach for the `col`
+  filter and tabular specifications when alignment, width allocation,
+  truncation, or nested columns matter; do not hand-pad strings in handlers.
+- **I — Use the right render diagnostic.** `--output term-debug` shows where
+  style tags were placed, but it preserves known and unknown tags alike and
+  does not validate that the tags exist. Use `validate_template` in development
+  or tests to detect missing style definitions. Terminal mode's `?` marker is a
+  visible warning, not a substitute for validation.
+- **G — Do not imply integrated per-command CSV projection.** Normal app
+  dispatch automatically flattens serializable data for CSV. The direct
+  `render_auto_with_spec` API can render CSV with a `FlatDataSpec`, but arbitrary
+  per-command projection through normal `App` dispatch is not currently
+  integrated. Prefer a stable CLI-owned view DTO, or record the missing app
+  configuration seam.
+
+See [Output Modes](../topics/output-modes.md),
+[Templating](../crates/render/topics/templating.md),
+[Styling System](../crates/render/topics/styling-system.md),
+[File System Resources](../crates/render/topics/file-system-resources.md), and
+[Introduction to Tabular](../crates/render/guides/intro-to-tabular.md) for the
+focused APIs and trade-offs.
+
+## Testing pyramid
+
+- **I — Core tests:** exercise validation, filtering, state transitions, and
+  persistence through the CLI-free Rust interface.
+- **I — Adapter tests:** call the typed handler function directly and assert the
+  CLI-to-core mapping plus returned view DTO.
+- **I — Pipeline tests:** use `standout-test::TestHarness` for Clap parsing,
+  dispatch, hooks, inputs, templates, structured modes, and controlled process
+  seams. Mark harness tests serial because those seams are process-global.
+- **A — Process tests:** reserve a small end-to-end layer for real PTYs,
+  signals, subprocess behavior, and build or link boundaries the harness cannot
+  model.
+
+This ordering keeps most failures close to their owner while still proving the
+user-visible shell contract. See [Testing](../topics/testing.md) for the full
+boundary matrix.
+
+## Optional application capabilities
+
+These are **applicable capabilities**, not baseline requirements:
+
+- **Hooks** place cross-command validation, request-context injection,
+  serialized-data transformation, or post-output observation at an explicit
+  pipeline phase.
+- **Declarative input chains** resolve values from arguments, environment,
+  stdin, clipboard, defaults, editors, or prompts with one validation path.
+- **Pipes** send or transform rendered text after output; binary and silent
+  results pass through unchanged.
+- **Partial adoption** lets an existing Clap application delegate selected
+  commands to Standout and retain its legacy path for unmatched commands.
+
+Adopt each capability only when it removes application-owned orchestration or
+improves a test seam. If the framework cannot express the required behavior,
+classify it as a framework gap and keep the workaround isolated in the CLI
+layer.
+
+## Review outcome
+
+A high-quality implementation has no unresolved invariant violations, uses the
+applicable capabilities that materially simplify its shell boundary, and names
+framework gaps explicitly. That is a stronger signal than counting how many
+Standout features an application uses.

--- a/docs/guides/production-shaped-example.md
+++ b/docs/guides/production-shaped-example.md
@@ -45,3 +45,7 @@ Read the canonical source rather than copying a second implementation here:
 
 For a five-minute look at dispatch and rendering without the package split, use
 the [minimal single-crate example](minimal-single-crate.md).
+
+For a broader review of ownership, rendering, testing, and optional framework
+capabilities, use the
+[Leveraging Standout implementation quality checklist](leveraging-standout.md).

--- a/docs/topics/output-modes.md
+++ b/docs/topics/output-modes.md
@@ -96,6 +96,8 @@ Use cases:
 - Automated testing of template output
 
 Unlike Term mode, unknown tags don't get the `?` marker in TermDebug.
+TermDebug shows tag placement; it does not check whether a tag has a matching
+style definition. Use `validate_template` when validation is required.
 
 ## Structured Modes
 
@@ -132,11 +134,17 @@ Same handler, same types—different output format. This enables:
 
 ### CSV Output
 
-CSV mode flattens nested JSON automatically. For more control, use `FlatDataSpec`.
+Normal `App` dispatch flattens the serializable handler data automatically for
+CSV. That is the same handler data used by the other structured modes; handlers
+should not inspect the requested mode or return a CSV-specific shape.
 
-See [Tabular Layout](tabular.md) for detailed CSV configuration.
+The standalone rendering API also supports direct `FlatDataSpec` rendering when
+a caller needs explicit columns and headers:
 
 ```rust
+use standout::tabular::{Column, FlatDataSpec, Width};
+use standout::{render_auto_with_spec, OutputMode};
+
 let spec = FlatDataSpec::builder()
     .column(Column::new(Width::Fixed(10)).key("name").header("Name"))
     .column(Column::new(Width::Fixed(10)).key("meta.role").header("Role"))
@@ -146,6 +154,15 @@ render_auto_with_spec(template, &data, &theme, OutputMode::Csv, Some(&spec))?
 ```
 
 The `key` field uses dot notation for nested paths (`"meta.role"` extracts `data["meta"]["role"]`).
+
+`FlatDataSpec` is not accepted as per-command configuration by normal `App`
+dispatch, so arbitrary per-command CSV projection is not currently integrated
+into that path. Prefer a stable CLI-owned output DTO. If the CLI requires a
+different projection, treat that as an explicit rendering integration or a
+framework gap rather than branching inside the handler.
+
+See [Introduction to Tabular](../crates/render/guides/intro-to-tabular.md) for
+tabular specifications and layout.
 
 ## File Output
 
@@ -182,31 +199,13 @@ App::builder()
     .build()?
 ```
 
-## Accessing OutputMode in Handlers
+## Keep Output Mode Out of Handlers
 
-`CommandContext` carries the resolved output mode:
-
-```rust
-fn handler(matches: &ArgMatches, ctx: &CommandContext) -> HandlerResult<Data> {
-    if ctx.output_mode.is_structured() {
-        // Skip interactive prompts in JSON mode
-    }
-
-    if ctx.output_mode == OutputMode::Csv {
-        // Maybe adjust data structure for flat output
-    }
-
-    Ok(Output::Render(data))
-}
-```
-
-Helper methods:
-
-```rust
-ctx.output_mode.should_use_color()  // True for Term, depends on terminal for Auto
-ctx.output_mode.is_structured()     // True for Json, Yaml, Xml, Csv
-ctx.output_mode.is_debug()          // True for TermDebug
-```
+Output mode is a rendering concern and is deliberately absent from
+`CommandContext`. A handler should return the same serializable data regardless
+of whether the caller selected terminal, text, or structured output. If a
+command's behavior genuinely differs, model that as an explicit command or
+argument rather than an implicit presentation-mode branch.
 
 ## Rendering Without CLI
 

--- a/skills/standout/SKILL.md
+++ b/skills/standout/SKILL.md
@@ -40,6 +40,7 @@ Read every reference whose condition matches the task; each is directly reachabl
 - **Must read [testing.md](references/testing.md)** before writing or reviewing Standout tests, choosing a test level, using `TestHarness`, or diagnosing test interference.
 - **Must read [hooks-input-and-piping.md](references/hooks-input-and-piping.md)** before adding hooks, declarative inputs, prompts, stdin/clipboard sources, or output pipes.
 - **Must read [project-map-and-gotchas.md](references/project-map-and-gotchas.md)** when locating ownership, choosing a crate/doc/example, upgrading copied code, or resolving an API mismatch.
+- **Must read [implementation-quality-checklist.md](references/implementation-quality-checklist.md)** before reviewing how completely or effectively an application leverages Standout.
 
 Use `crates/todo-example/todo-core/` as the canonical CLI-free library and
 `crates/todo-example/tdoo/` as the canonical binary-only Standout CLI. For

--- a/skills/standout/references/implementation-quality-checklist.md
+++ b/skills/standout/references/implementation-quality-checklist.md
@@ -1,0 +1,28 @@
+# Implementation quality checklist
+
+The canonical public checklist is
+[`docs/guides/leveraging-standout.md`](../../../docs/guides/leveraging-standout.md).
+Use it for implementation reviews; do not duplicate its framework guidance
+here.
+
+Classify findings before recommending work:
+
+- **Invariant:** required ownership or behavior boundary.
+- **Applicable capability:** useful only when the application needs it.
+- **Framework gap:** desired behavior that normal Standout integration does not
+  provide.
+
+Review in this order:
+
+1. Confirm the reusable core is CLI-free and the CLI owns Clap, Standout,
+   adapters, view DTOs, resources, app assembly, and final output.
+2. Confirm handlers return data without printing, rendering, or output-mode
+   branching.
+3. Confirm structured modes preserve the CLI data contract and bypass
+   templates.
+4. Check rendering, diagnostics, and tabular behavior only where applicable.
+5. Look for core, typed-handler, harness, and narrowly scoped process tests.
+6. Classify hooks, inputs, pipes, and partial adoption as optional capabilities;
+   name unsupported integration as a gap rather than forcing it into a handler.
+
+Verify version-sensitive claims against the checked-out public types and tests.


### PR DESCRIPTION
## Context

This change adds one compact canonical public checklist because implementation reviews need a shared way to separate required architecture from optional framework features and genuine framework gaps. The public guide owns the detailed guidance; the agent reference stays intentionally short and routes back to that canonical source.

The guide and output-mode cleanup were verified against the checked-out Clap dispatch, render, resource reload, style resolution, CSV flattening, FlatDataSpec, tag diagnostics, and test harness implementations.

Out of scope: framework API changes, a new per-command FlatDataSpec integration in App dispatch, changes to the worked todo example, and broader rewrites of existing guides.

## Summary

- add the Leveraging Standout value and implementation quality checklist
- route the Standout skill to a concise agent reference and the canonical guide
- link the guide from the book summary, guide index, and production-shaped example
- correct output-mode handler and CSV projection guidance and repair the tabular link

## Validation

- `mdbook build`
- local relative-link check across changed documentation
- targeted `markdownlint`
- `pixi run lint`
- `pixi run test` (1711 passed)