### PR TITLE
Add release note for the Standout implementation guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+- Add a compact implementation-quality guide and skill checklist for leveraging Standout's logic/presentation boundary, output modes, templates and CSS, tabular layout, declarative dispatch, and layered test seams.
+
 ## 7.6.4 - 2026-07-17
 
 - Fix the standout-docs skill: relocate to standout-docs/SKILL.md and add required frontmatter so it's discoverable

--- a/CHANGELOG/unreleased-implementation-quality-guide.md
+++ b/CHANGELOG/unreleased-implementation-quality-guide.md
@@ -1,0 +1,1 @@
+- Add a compact implementation-quality guide and skill checklist for leveraging Standout's logic/presentation boundary, output modes, templates and CSS, tabular layout, declarative dispatch, and layered test seams.


### PR DESCRIPTION
## Context

PR #202 added the Standout implementation-quality guide and compact skill checklist after the 7.6.4 release, but it landed without the unreleased changelog fragment required by the current release pipeline. This PR adds that single release-note fragment and regenerates the changelog projection; release tooling and unrelated files are intentionally unchanged.

for #202

## Validation

- ./bin/shipit changelog check
- pixi run lint
- pixi run test (1711 tests passed)