### PR TITLE
Add per-command structured-output projections

### DIFF
--- a/crates/standout-render/Cargo.toml
+++ b/crates/standout-render/Cargo.toml
@@ -24,6 +24,7 @@ unicode-width = "0.2"
 cssparser = "0.31"
 terminal_size = "0.4"
 standout-bbparser = { version = "7.6.5", path = "../standout-bbparser" }
+thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3.24.0"

--- a/crates/standout-render/src/lib.rs
+++ b/crates/standout-render/src/lib.rs
@@ -152,6 +152,7 @@ mod error;
 pub mod file_loader;
 pub mod output;
 pub mod prelude;
+mod projection;
 pub mod style;
 pub mod tabular;
 pub mod template;
@@ -177,6 +178,9 @@ pub use theme::{
 
 // Output module exports
 pub use output::{write_binary_output, write_output, OutputDestination, OutputMode};
+pub use projection::{
+    CsvProjection, CsvProjectionBuilder, ProjectionError, StructuredOutputProjection,
+};
 
 // Environment detection exports
 pub use environment::{

--- a/crates/standout-render/src/projection.rs
+++ b/crates/standout-render/src/projection.rs
@@ -82,7 +82,16 @@ impl CsvProjection {
             self.columns
                 .iter()
                 .enumerate()
-                .map(|(index, projection)| projection.column().clone().key(index.to_string()))
+                .map(|(index, projection)| {
+                    let column = projection.column();
+                    let header = column
+                        .header
+                        .as_deref()
+                        .or(column.key.as_deref())
+                        .unwrap_or("");
+
+                    column.clone().header(header).key(index.to_string())
+                })
                 .collect(),
         );
 
@@ -304,6 +313,25 @@ mod tests {
         assert_eq!(
             projection().render(&root).unwrap(),
             "LANGUAGE,CODE,NET\nRust,-,-2\nTOTAL,-,-2\n"
+        );
+    }
+
+    #[test]
+    fn preserves_key_based_header_fallback_for_direct_and_derived_columns() {
+        let projection = CsvProjection::builder("items")
+            .column(Column::new(Width::default()).key("language"))
+            .derived_column(Column::new(Width::default()).key("net"), |row, _root| {
+                json!(row["code"].as_i64().unwrap() - row["comments"].as_i64().unwrap())
+            })
+            .build();
+
+        assert_eq!(
+            projection
+                .render(&json!({
+                    "items": [{ "language": "Rust", "code": 12, "comments": 2 }]
+                }))
+                .unwrap(),
+            "language,net\nRust,10\n"
         );
     }
 }

--- a/crates/standout-render/src/projection.rs
+++ b/crates/standout-render/src/projection.rs
@@ -1,0 +1,309 @@
+//! Declarative projections for machine-readable output.
+//!
+//! A projection is a presentation-layer view over a canonical serialized
+//! response. It never mutates the value used by other output modes.
+
+use std::fmt;
+use std::rc::Rc;
+
+use serde_json::{Map, Value};
+
+use crate::tabular::{Column, FlatDataSpec};
+
+type DerivedCell = Rc<dyn Fn(&Value, &Value) -> Value>;
+type SyntheticRow = Rc<dyn Fn(&Value) -> Option<Value>>;
+
+/// A per-command projection for structured output modes.
+///
+/// CSV is the first supported projection. The wrapper keeps command
+/// configuration mode-aware without exposing output-mode details to handlers.
+#[derive(Clone)]
+pub struct StructuredOutputProjection {
+    csv: CsvProjection,
+}
+
+impl StructuredOutputProjection {
+    /// Creates a structured-output projection for CSV.
+    pub fn csv(projection: CsvProjection) -> Self {
+        Self { csv: projection }
+    }
+
+    /// Returns the configured CSV projection.
+    pub fn csv_projection(&self) -> &CsvProjection {
+        &self.csv
+    }
+}
+
+impl fmt::Debug for StructuredOutputProjection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StructuredOutputProjection")
+            .field("csv", &self.csv)
+            .finish()
+    }
+}
+
+/// A declarative CSV view over a command's canonical JSON response.
+///
+/// The projection selects a nested array as its row source, evaluates columns
+/// in registration order, and may append synthetic rows derived from the root
+/// response. Direct columns use [`Column::key`] dot paths. Derived columns can
+/// inspect both the current row and the root response.
+#[derive(Clone)]
+pub struct CsvProjection {
+    row_source: String,
+    columns: Vec<ProjectionColumn>,
+    synthetic_rows: Vec<SyntheticRow>,
+}
+
+impl CsvProjection {
+    /// Starts a projection whose rows come from the nested `row_source` path.
+    pub fn builder(row_source: impl Into<String>) -> CsvProjectionBuilder {
+        CsvProjectionBuilder {
+            row_source: row_source.into(),
+            columns: Vec::new(),
+            synthetic_rows: Vec::new(),
+        }
+    }
+
+    /// Projects the canonical response and serializes the result as CSV.
+    pub fn render(&self, root: &Value) -> Result<String, ProjectionError> {
+        let rows = value_at_path(root, &self.row_source).ok_or_else(|| {
+            ProjectionError::MissingRowSource {
+                path: self.row_source.clone(),
+            }
+        })?;
+        let rows = rows
+            .as_array()
+            .ok_or_else(|| ProjectionError::RowSourceNotArray {
+                path: self.row_source.clone(),
+            })?;
+
+        let spec = FlatDataSpec::new(
+            self.columns
+                .iter()
+                .enumerate()
+                .map(|(index, projection)| projection.column().clone().key(index.to_string()))
+                .collect(),
+        );
+
+        let mut wtr = csv::Writer::from_writer(Vec::new());
+        wtr.write_record(spec.extract_header())?;
+
+        for row in rows {
+            wtr.write_record(self.extract_row(&spec, row, root))?;
+        }
+        for row in self
+            .synthetic_rows
+            .iter()
+            .filter_map(|synthetic| synthetic(root))
+        {
+            wtr.write_record(self.extract_row(&spec, &row, root))?;
+        }
+
+        let bytes = wtr.into_inner().map_err(|error| error.into_error())?;
+        Ok(String::from_utf8(bytes)?)
+    }
+
+    fn extract_row(&self, spec: &FlatDataSpec, row: &Value, root: &Value) -> Vec<String> {
+        let values = self
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(index, projection)| {
+                let value = match projection {
+                    ProjectionColumn::Direct(column) => column
+                        .key
+                        .as_deref()
+                        .and_then(|path| value_at_path(row, path))
+                        .cloned()
+                        .unwrap_or(Value::Null),
+                    ProjectionColumn::Derived { derive, .. } => derive(row, root),
+                };
+                (index.to_string(), value)
+            })
+            .collect::<Map<_, _>>();
+
+        spec.extract_row(&Value::Object(values))
+    }
+}
+
+impl fmt::Debug for CsvProjection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CsvProjection")
+            .field("row_source", &self.row_source)
+            .field("column_count", &self.columns.len())
+            .field("synthetic_row_count", &self.synthetic_rows.len())
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+enum ProjectionColumn {
+    Direct(Column),
+    Derived { column: Column, derive: DerivedCell },
+}
+
+impl ProjectionColumn {
+    fn column(&self) -> &Column {
+        match self {
+            Self::Direct(column) | Self::Derived { column, .. } => column,
+        }
+    }
+}
+
+/// Builder for [`CsvProjection`].
+pub struct CsvProjectionBuilder {
+    row_source: String,
+    columns: Vec<ProjectionColumn>,
+    synthetic_rows: Vec<SyntheticRow>,
+}
+
+impl CsvProjectionBuilder {
+    /// Adds a direct column. Its key is resolved against each selected row.
+    pub fn column(mut self, column: Column) -> Self {
+        self.columns.push(ProjectionColumn::Direct(column));
+        self
+    }
+
+    /// Adds a derived column whose callback receives `(row, root)`.
+    pub fn derived_column<F>(mut self, column: Column, derive: F) -> Self
+    where
+        F: Fn(&Value, &Value) -> Value + 'static,
+    {
+        self.columns.push(ProjectionColumn::Derived {
+            column,
+            derive: Rc::new(derive),
+        });
+        self
+    }
+
+    /// Appends an unconditional synthetic row derived from the root response.
+    pub fn synthetic_row<F>(self, row: F) -> Self
+    where
+        F: Fn(&Value) -> Value + 'static,
+    {
+        self.conditional_row(move |root| Some(row(root)))
+    }
+
+    /// Appends a synthetic row when the callback returns `Some`.
+    pub fn conditional_row<F>(mut self, row: F) -> Self
+    where
+        F: Fn(&Value) -> Option<Value> + 'static,
+    {
+        self.synthetic_rows.push(Rc::new(row));
+        self
+    }
+
+    /// Finishes the projection.
+    pub fn build(self) -> CsvProjection {
+        CsvProjection {
+            row_source: self.row_source,
+            columns: self.columns,
+            synthetic_rows: self.synthetic_rows,
+        }
+    }
+}
+
+/// Failure while applying or serializing a structured-output projection.
+#[derive(Debug, thiserror::Error)]
+pub enum ProjectionError {
+    /// The configured row-source path was not present in the response.
+    #[error("projection row source `{path}` was not found")]
+    MissingRowSource { path: String },
+    /// The configured row-source path did not resolve to a collection.
+    #[error("projection row source `{path}` is not an array")]
+    RowSourceNotArray { path: String },
+    /// CSV serialization failed.
+    #[error(transparent)]
+    Csv(#[from] csv::Error),
+    /// The CSV writer failed while finalizing its buffer.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// The CSV encoder produced non-UTF-8 bytes.
+    #[error(transparent)]
+    Utf8(#[from] std::string::FromUtf8Error),
+}
+
+fn value_at_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    path.split('.')
+        .try_fold(value, |current, segment| match current {
+            Value::Object(object) => object.get(segment),
+            _ => None,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::tabular::{Column, Width};
+
+    fn column(key: &str, header: &str) -> Column {
+        Column::new(Width::default()).key(key).header(header)
+    }
+
+    fn projection() -> CsvProjection {
+        CsvProjection::builder("report.items")
+            .column(column("language", "LANGUAGE"))
+            .column(column("counts.code", "CODE"))
+            .derived_column(column("net", "NET"), |row, root| {
+                json!(
+                    row["counts"]["code"].as_i64().unwrap_or(0)
+                        - row["counts"]["comments"].as_i64().unwrap_or(0)
+                        + root["adjustment"].as_i64().unwrap()
+                )
+            })
+            .synthetic_row(|root| {
+                json!({
+                    "language": "TOTAL",
+                    "counts": {
+                        "code": root["totals"]["code"],
+                        "comments": root["totals"]["comments"]
+                    }
+                })
+            })
+            .conditional_row(|root| {
+                (root["skipped"].as_u64().unwrap() > 0).then(|| {
+                    json!({
+                        "language": "SKIPPED",
+                        "counts": { "code": root["skipped"], "comments": 0 }
+                    })
+                })
+            })
+            .build()
+    }
+
+    #[test]
+    fn selects_nested_rows_derives_cells_and_appends_synthetic_rows() {
+        let root = json!({
+            "report": { "items": [
+                { "language": "Rust", "counts": { "code": 12, "comments": 2 } },
+                { "language": "Python", "counts": { "code": 8, "comments": 1 } }
+            ] },
+            "totals": { "code": 20, "comments": 3 },
+            "skipped": 2,
+            "adjustment": 1
+        });
+
+        assert_eq!(
+            projection().render(&root).unwrap(),
+            "LANGUAGE,CODE,NET\nRust,12,11\nPython,8,8\nTOTAL,20,18\nSKIPPED,2,3\n"
+        );
+    }
+
+    #[test]
+    fn conditional_row_disappears_and_null_repr_matches_flat_data_spec() {
+        let root = json!({
+            "report": { "items": [{ "language": "Rust", "counts": { "comments": 2 } }] },
+            "totals": { "code": null, "comments": 2 },
+            "skipped": 0,
+            "adjustment": 0
+        });
+
+        assert_eq!(
+            projection().render(&root).unwrap(),
+            "LANGUAGE,CODE,NET\nRust,-,-2\nTOTAL,-,-2\n"
+        );
+    }
+}

--- a/crates/standout-test/tests/harness.rs
+++ b/crates/standout-test/tests/harness.rs
@@ -7,6 +7,8 @@ use clap::Command;
 use serde_json::json;
 use serial_test::serial;
 use standout::cli::{App, Output};
+use standout::tabular::{Column, Width};
+use standout::{CsvProjection, StructuredOutputProjection};
 use standout_input::{ClipboardSource, EnvSource, InputChain, StdinSource};
 use standout_render::OutputMode;
 use standout_test::TestHarness;
@@ -349,6 +351,66 @@ fn output_mode_override_forces_json() {
     let out = result.stdout();
     assert!(out.contains("\"msg\""));
     assert!(out.contains("\"hello\""));
+}
+
+#[test]
+#[serial]
+fn rustloc_fixture_uses_configured_csv_projection() {
+    let projection = StructuredOutputProjection::csv(
+        CsvProjection::builder("items")
+            .column(
+                Column::new(Width::default())
+                    .key("language")
+                    .header("LANGUAGE"),
+            )
+            .column(Column::new(Width::default()).key("code").header("CODE"))
+            .derived_column(
+                Column::new(Width::default()).key("net").header("NET"),
+                |row, _root| {
+                    json!(row["code"].as_i64().unwrap_or(0) - row["comments"].as_i64().unwrap_or(0))
+                },
+            )
+            .synthetic_row(|root| {
+                json!({
+                    "language": "TOTAL",
+                    "code": root["totals"]["code"],
+                    "comments": root["totals"]["comments"]
+                })
+            })
+            .conditional_row(|root| {
+                (root["skipped"].as_u64().unwrap_or(0) > 0)
+                    .then(|| json!({ "language": "SKIPPED" }))
+            })
+            .build(),
+    );
+    let app = App::builder()
+        .command_with(
+            "summary",
+            |_matches, _ctx| {
+                Ok(Output::Render(json!({
+                    "items": [
+                        { "language": "Rust", "code": 120, "comments": 20 },
+                        { "language": "Python", "code": 70, "comments": 10 }
+                    ],
+                    "totals": { "code": 190, "comments": 30 },
+                    "skipped": 1
+                })))
+            },
+            |config| config.structured_output_projection(projection),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+    let cmd = Command::new("rustloc").subcommand(Command::new("summary"));
+
+    let result =
+        TestHarness::new()
+            .output_mode(OutputMode::Csv)
+            .run(&app, cmd, ["rustloc", "summary"]);
+
+    result.assert_stdout_eq(
+        "LANGUAGE,CODE,NET\nRust,120,100\nPython,70,60\nTOTAL,190,160\nSKIPPED,-,0\n",
+    );
 }
 
 #[test]

--- a/crates/standout/src/cli/builder/commands.rs
+++ b/crates/standout/src/cli/builder/commands.rs
@@ -87,7 +87,10 @@ impl AppBuilder {
         }
 
         // Create a recipe for deferred closure creation using the handler
-        let recipe = ClosureRecipe::new(config.handler);
+        let mut recipe = ClosureRecipe::new(config.handler);
+        if let Some(projection) = config.structured_output_projection {
+            recipe = recipe.with_structured_output_projection(projection);
+        }
 
         // Store pending command - check for duplicates
         if self.pending_commands.borrow().contains_key(path) {

--- a/crates/standout/src/cli/dispatch.rs
+++ b/crates/standout/src/cli/dispatch.rs
@@ -14,6 +14,7 @@ use crate::cli::handler::CommandContext;
 use crate::cli::handler::Output as HandlerOutput;
 use crate::cli::hooks::Hooks;
 use crate::context::{ContextRegistry, RenderContext};
+use crate::StructuredOutputProjection;
 use crate::Theme;
 use serde::Serialize;
 
@@ -55,6 +56,7 @@ pub(crate) fn render_handler_output<T: Serialize>(
     context_registry: &ContextRegistry,
     template_engine: &dyn standout_render::template::TemplateEngine,
     output_mode: crate::OutputMode,
+    structured_output_projection: Option<&StructuredOutputProjection>,
 ) -> Result<DispatchOutput, String> {
     match result {
         Ok(output) => match output {
@@ -75,17 +77,28 @@ pub(crate) fn render_handler_output<T: Serialize>(
                     &json_data,
                 );
 
-                // Use the split render function to get both formatted and raw output
-                let render_result = standout_render::template::render_auto_with_engine_split(
-                    template_engine,
-                    template,
-                    &json_data,
-                    theme,
-                    output_mode,
-                    context_registry,
-                    &render_ctx,
-                )
-                .map_err(|e| e.to_string())?;
+                // Projection happens at the presentation boundary: after
+                // post-dispatch hooks and before post-output hooks.
+                let render_result = match (output_mode, structured_output_projection) {
+                    (crate::OutputMode::Csv, Some(projection)) => {
+                        standout_render::template::RenderResult::plain(
+                            projection
+                                .csv_projection()
+                                .render(&json_data)
+                                .map_err(|e| e.to_string())?,
+                        )
+                    }
+                    _ => standout_render::template::render_auto_with_engine_split(
+                        template_engine,
+                        template,
+                        &json_data,
+                        theme,
+                        output_mode,
+                        context_registry,
+                        &render_ctx,
+                    )
+                    .map_err(|e| e.to_string())?,
+                };
 
                 Ok(DispatchOutput::Text {
                     formatted: render_result.formatted,

--- a/crates/standout/src/cli/group.rs
+++ b/crates/standout/src/cli/group.rs
@@ -14,6 +14,7 @@ use std::rc::Rc;
 use super::dispatch::{render_handler_output, DispatchFn};
 use crate::cli::handler::{CommandContext, FnHandler, Handler, HandlerResult};
 use crate::cli::hooks::{Hooks, RenderedOutput, TextOutput};
+use crate::StructuredOutputProjection;
 use standout_dispatch::verify::ExpectedArg;
 use standout_pipe::PipeTarget;
 
@@ -72,6 +73,7 @@ where
     handler: Rc<RefCell<FnHandler<F, T>>>,
     template: Option<String>,
     hooks: Option<Hooks>,
+    structured_output_projection: Option<StructuredOutputProjection>,
 }
 
 impl<F, T> ClosureRecipe<F, T>
@@ -84,6 +86,7 @@ where
             handler: Rc::new(RefCell::new(handler)),
             template: None,
             hooks: None,
+            structured_output_projection: None,
         }
     }
 
@@ -96,6 +99,14 @@ where
     #[allow(dead_code)]
     pub fn with_hooks(mut self, hooks: Hooks) -> Self {
         self.hooks = Some(hooks);
+        self
+    }
+
+    pub fn with_structured_output_projection(
+        mut self,
+        projection: StructuredOutputProjection,
+    ) -> Self {
+        self.structured_output_projection = Some(projection);
         self
     }
 }
@@ -126,6 +137,7 @@ where
         let handler = self.handler.clone();
         let template = template.to_string();
         let context_registry = context_registry.clone();
+        let structured_output_projection = self.structured_output_projection.clone();
 
         Rc::new(RefCell::new(
             move |matches: &ArgMatches,
@@ -147,6 +159,7 @@ where
                     &context_registry,
                     &**template_engine,
                     output_mode,
+                    structured_output_projection.as_ref(),
                 )
             },
         ))
@@ -167,6 +180,7 @@ where
     #[allow(dead_code)]
     template: Option<String>,
     hooks: Option<Hooks>,
+    structured_output_projection: Option<StructuredOutputProjection>,
     _phantom: std::marker::PhantomData<T>,
 }
 
@@ -180,6 +194,7 @@ where
             handler: Rc::new(RefCell::new(handler)),
             template: None,
             hooks: None,
+            structured_output_projection: None,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -193,6 +208,15 @@ where
     #[allow(dead_code)]
     pub fn with_hooks(mut self, hooks: Hooks) -> Self {
         self.hooks = Some(hooks);
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn with_structured_output_projection(
+        mut self,
+        projection: StructuredOutputProjection,
+    ) -> Self {
+        self.structured_output_projection = Some(projection);
         self
     }
 }
@@ -223,6 +247,7 @@ where
         let handler = self.handler.clone();
         let template = template.to_string();
         let context_registry = context_registry.clone();
+        let structured_output_projection = self.structured_output_projection.clone();
 
         Rc::new(RefCell::new(
             move |matches: &ArgMatches,
@@ -244,6 +269,7 @@ where
                     &context_registry,
                     &**template_engine,
                     output_mode,
+                    structured_output_projection.as_ref(),
                 )
             },
         ))
@@ -407,6 +433,7 @@ pub struct CommandConfig<H> {
     pub(crate) handler: H,
     pub(crate) template: Option<String>,
     pub(crate) hooks: Option<Hooks>,
+    pub(crate) structured_output_projection: Option<StructuredOutputProjection>,
 }
 
 impl<H> CommandConfig<H> {
@@ -416,6 +443,7 @@ impl<H> CommandConfig<H> {
             handler,
             template: None,
             hooks: None,
+            structured_output_projection: None,
         }
     }
 
@@ -431,6 +459,15 @@ impl<H> CommandConfig<H> {
     /// Sets hooks for this command.
     pub fn hooks(mut self, hooks: Hooks) -> Self {
         self.hooks = Some(hooks);
+        self
+    }
+
+    /// Attaches a presentation-layer projection for structured output.
+    ///
+    /// The projection consumes the serialized response after post-dispatch
+    /// hooks. It does not change handler data or human-rendered output.
+    pub fn structured_output_projection(mut self, projection: StructuredOutputProjection) -> Self {
+        self.structured_output_projection = Some(projection);
         self
     }
 
@@ -821,6 +858,7 @@ impl GroupBuilder {
                     handler: Rc::new(RefCell::new(config.handler)),
                     template: config.template,
                     hooks: config.hooks,
+                    structured_output_projection: config.structured_output_projection,
                 }),
             },
         );
@@ -852,6 +890,7 @@ impl GroupBuilder {
                     handler: Rc::new(RefCell::new(config.handler)),
                     template: config.template,
                     hooks: config.hooks,
+                    structured_output_projection: config.structured_output_projection,
                 }),
             },
         );
@@ -951,6 +990,7 @@ where
     handler: Rc<RefCell<FnHandler<F, T>>>,
     template: Option<String>,
     hooks: Option<Hooks>,
+    structured_output_projection: Option<StructuredOutputProjection>,
 }
 
 impl<F, T> ErasedCommandConfig for ClosureCommandConfig<F, T>
@@ -978,6 +1018,7 @@ where
         template_engine: Rc<Box<dyn standout_render::template::TemplateEngine>>,
     ) -> DispatchFn {
         let handler = self.handler;
+        let structured_output_projection = self.structured_output_projection;
 
         Rc::new(RefCell::new(
             move |matches: &ArgMatches,
@@ -999,6 +1040,7 @@ where
                     &context_registry,
                     &**template_engine,
                     output_mode,
+                    structured_output_projection.as_ref(),
                 )
             },
         ))
@@ -1018,6 +1060,7 @@ where
     handler: Rc<RefCell<H>>,
     template: Option<String>,
     hooks: Option<Hooks>,
+    structured_output_projection: Option<StructuredOutputProjection>,
 }
 
 impl<H, T> ErasedCommandConfig for StructCommandConfig<H, T>
@@ -1045,6 +1088,7 @@ where
         template_engine: Rc<Box<dyn standout_render::template::TemplateEngine>>,
     ) -> DispatchFn {
         let handler = self.handler;
+        let structured_output_projection = self.structured_output_projection;
 
         Rc::new(RefCell::new(
             move |matches: &ArgMatches,
@@ -1066,6 +1110,7 @@ where
                     &context_registry,
                     &**template_engine,
                     output_mode,
+                    structured_output_projection.as_ref(),
                 )
             },
         ))

--- a/crates/standout/src/cli/macros.rs
+++ b/crates/standout/src/cli/macros.rs
@@ -56,6 +56,7 @@
 ///         pre_dispatch: hook_fn,             // optional
 ///         post_dispatch: hook_fn,            // optional
 ///         post_output: hook_fn,              // optional
+///         structured_output_projection: projection, // optional
 ///     },
 ///
 ///     // Nested group
@@ -220,12 +221,25 @@ macro_rules! dispatch_apply_config {
     ($cfg:expr; post_output : $hook:expr) => {
         $cfg.post_output($hook)
     };
+
+    // Structured-output projection
+    ($cfg:expr; structured_output_projection : $projection:expr , $($rest:tt)*) => {
+        $crate::dispatch_apply_config!(
+            $cfg.structured_output_projection($projection);
+            $($rest)*
+        )
+    };
+    ($cfg:expr; structured_output_projection : $projection:expr) => {
+        $cfg.structured_output_projection($projection)
+    };
 }
 
 #[cfg(test)]
 mod tests {
     use crate::cli::handler::{CommandContext, Output};
     use crate::cli::GroupBuilder;
+    use crate::tabular::{Column, Width};
+    use crate::{CsvProjection, StructuredOutputProjection};
     use clap::ArgMatches;
     use serde_json::json;
 
@@ -269,6 +283,26 @@ mod tests {
             list => {
                 handler: |_m: &ArgMatches, _ctx: &CommandContext| Ok(Output::Render(json!({}))),
                 template: "custom.j2",
+            },
+        };
+
+        let builder = configure(GroupBuilder::new());
+        assert!(builder.entries.contains_key("list"));
+    }
+
+    #[test]
+    fn test_dispatch_command_with_structured_output_projection() {
+        let projection = StructuredOutputProjection::csv(
+            CsvProjection::builder("items")
+                .column(Column::new(Width::default()).key("name"))
+                .build(),
+        );
+        let configure = dispatch! {
+            list => {
+                handler: |_m: &ArgMatches, _ctx: &CommandContext| {
+                    Ok(Output::Render(json!({ "items": [{ "name": "one" }] })))
+                },
+                structured_output_projection: projection,
             },
         };
 

--- a/crates/standout/src/lib.rs
+++ b/crates/standout/src/lib.rs
@@ -254,6 +254,9 @@ pub use standout_render::{
 
 // Output module exports (from standout-render)
 pub use standout_render::{write_binary_output, write_output, OutputDestination, OutputMode};
+pub use standout_render::{
+    CsvProjection, CsvProjectionBuilder, ProjectionError, StructuredOutputProjection,
+};
 
 // Render module exports (from standout-render)
 pub use standout_render::{

--- a/crates/standout/tests/structured_output_projection.rs
+++ b/crates/standout/tests/structured_output_projection.rs
@@ -1,0 +1,185 @@
+//! App-path coverage for per-command structured-output projections.
+
+use clap::Command;
+use serde_json::{json, Value};
+use standout::cli::hooks::TextOutput;
+use standout::cli::{App, Output, RenderedOutput, RunResult};
+use standout::tabular::{Column, Width};
+use standout::{CsvProjection, OutputMode, StructuredOutputProjection};
+
+const EXPECTED_CSV: &str =
+    "LANGUAGE,FILES,CODE,NET\nRust,3,120,100\nPython,2,70,60\nTOTAL,5,190,160\nSKIPPED,1,-,-\n";
+
+fn column(key: &str, header: &str) -> Column {
+    Column::new(Width::default()).key(key).header(header)
+}
+
+fn rustloc_projection() -> StructuredOutputProjection {
+    StructuredOutputProjection::csv(
+        CsvProjection::builder("report.items")
+            .column(column("language", "LANGUAGE"))
+            .column(column("files", "FILES"))
+            .column(column("code", "CODE"))
+            .derived_column(column("net", "NET"), |row, _root| {
+                match row["language"].as_str() {
+                    Some("SKIPPED") => Value::Null,
+                    _ => json!(
+                        row["code"].as_i64().unwrap_or(0) - row["comments"].as_i64().unwrap_or(0)
+                    ),
+                }
+            })
+            .synthetic_row(|root| {
+                json!({
+                    "language": "TOTAL",
+                    "files": root["totals"]["files"],
+                    "code": root["totals"]["code"],
+                    "comments": root["totals"]["comments"]
+                })
+            })
+            .conditional_row(|root| {
+                (root["skipped"]["count"].as_u64().unwrap_or(0) > 0).then(|| {
+                    json!({
+                        "language": "SKIPPED",
+                        "files": root["skipped"]["count"]
+                    })
+                })
+            })
+            .build(),
+    )
+}
+
+fn response() -> Value {
+    json!({
+        "report": {
+            "items": [
+                { "language": "Rust", "files": 3, "code": 120, "comments": 20 },
+                { "language": "Python", "files": 2, "code": 70, "comments": 10 }
+            ]
+        },
+        "totals": { "files": 5, "code": 190, "comments": 30 },
+        "skipped": { "count": 1, "paths": ["vendor/generated.rs"] }
+    })
+}
+
+fn command() -> Command {
+    Command::new("rustloc").subcommand(Command::new("summary"))
+}
+
+fn app() -> App {
+    App::builder()
+        .command_with(
+            "summary",
+            |_matches, _ctx| Ok(Output::Render(response())),
+            |config| {
+                config
+                    .template("{{ totals.files }} files / {{ totals.code }} lines")
+                    .structured_output_projection(rustloc_projection())
+            },
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+fn direct_dispatch(app: &App, mode: OutputMode) -> String {
+    let matches = command()
+        .try_get_matches_from(["rustloc", "summary"])
+        .unwrap();
+    let RunResult::Handled(output) = app.dispatch(matches, mode) else {
+        panic!("expected handled output")
+    };
+    output
+}
+
+#[test]
+fn csv_projection_applies_to_direct_dispatch_only() {
+    let app = app();
+
+    assert_eq!(direct_dispatch(&app, OutputMode::Csv), EXPECTED_CSV);
+    assert_eq!(
+        direct_dispatch(&app, OutputMode::Text),
+        "5 files / 190 lines"
+    );
+
+    let json: Value = serde_json::from_str(&direct_dispatch(&app, OutputMode::Json)).unwrap();
+    assert_eq!(json, response());
+
+    let yaml = direct_dispatch(&app, OutputMode::Yaml);
+    assert!(yaml.contains("report:"));
+    assert!(yaml.contains("paths:"));
+
+    let xml = direct_dispatch(&app, OutputMode::Xml);
+    assert!(xml.contains("<report>"));
+    assert!(xml.contains("<skipped>"));
+}
+
+#[test]
+fn commands_without_a_projection_keep_automatic_csv_flattening() {
+    let app = App::builder()
+        .command(
+            "summary",
+            |_matches, _ctx| Ok(Output::Render(json!([{ "name": "alpha" }]))),
+            "unused",
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    assert_eq!(direct_dispatch(&app, OutputMode::Csv), "name\nalpha\n");
+}
+
+#[test]
+fn run_to_string_and_output_file_use_the_same_projection() {
+    let app = app();
+    let RunResult::Handled(output) =
+        app.run_to_string(command(), ["rustloc", "summary", "--output=csv"])
+    else {
+        panic!("expected handled output")
+    };
+    assert_eq!(output, EXPECTED_CSV);
+
+    let tempdir = tempfile::tempdir().unwrap();
+    let output_path = tempdir.path().join("summary.csv");
+    let output_arg = format!("--output-file-path={}", output_path.display());
+    let RunResult::Handled(stdout) = app.run_to_string(
+        command(),
+        ["rustloc", "summary", "--output=csv", &output_arg],
+    ) else {
+        panic!("expected handled output")
+    };
+    assert!(stdout.is_empty());
+    assert_eq!(std::fs::read_to_string(output_path).unwrap(), EXPECTED_CSV);
+}
+
+#[test]
+fn projection_runs_between_post_dispatch_and_post_output() {
+    let app = App::builder()
+        .command_with(
+            "summary",
+            |_matches, _ctx| Ok(Output::Render(response())),
+            |config| {
+                config
+                    .structured_output_projection(rustloc_projection())
+                    .post_dispatch(|_matches, _ctx, mut root| {
+                        root["report"]["items"][0]["language"] = json!("Rust (hooked)");
+                        Ok(root)
+                    })
+                    .post_output(|_matches, _ctx, output| {
+                        Ok(match output {
+                            RenderedOutput::Text(text) => RenderedOutput::Text(TextOutput::new(
+                                format!("{}POST-OUTPUT\n", text.formatted),
+                                format!("{}POST-OUTPUT\n", text.raw),
+                            )),
+                            output => output,
+                        })
+                    })
+            },
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let csv = direct_dispatch(&app, OutputMode::Csv);
+    assert!(csv.starts_with("LANGUAGE,FILES,CODE,NET\nRust (hooked),"));
+    assert!(csv.ends_with("POST-OUTPUT\n"));
+}

--- a/crates/standout/tests/structured_output_projection.rs
+++ b/crates/standout/tests/structured_output_projection.rs
@@ -92,7 +92,7 @@ fn direct_dispatch(app: &App, mode: OutputMode) -> String {
 }
 
 #[test]
-fn csv_projection_applies_to_direct_dispatch_only() {
+fn csv_projection_preserves_canonical_output_in_other_modes() {
     let app = app();
 
     assert_eq!(direct_dispatch(&app, OutputMode::Csv), EXPECTED_CSV);

--- a/docs/topics/app-configuration.md
+++ b/docs/topics/app-configuration.md
@@ -147,7 +147,10 @@ App::builder()
         .post_dispatch(log_deletion))
 ```
 
-Inline hook attachment without separate `.hooks()` call.
+Inline command configuration can also attach a
+`StructuredOutputProjection` for CSV shaping. The projection stays at the
+presentation boundary: it sees post-dispatch data, and handlers remain
+independent of the selected output mode. See [Output Modes](output-modes.md#csv-output).
 
 ### Nested Groups
 

--- a/docs/topics/output-modes.md
+++ b/docs/topics/output-modes.md
@@ -155,11 +155,52 @@ render_auto_with_spec(template, &data, &theme, OutputMode::Csv, Some(&spec))?
 
 The `key` field uses dot notation for nested paths (`"meta.role"` extracts `data["meta"]["role"]`).
 
-`FlatDataSpec` is not accepted as per-command configuration by normal `App`
-dispatch, so arbitrary per-command CSV projection is not currently integrated
-into that path. Prefer a stable CLI-owned output DTO. If the CLI requires a
-different projection, treat that as an explicit rendering integration or a
-framework gap rather than branching inside the handler.
+When a command's canonical response is an object containing the CSV rows,
+attach a presentation-layer projection through `CommandConfig`:
+
+```rust
+use serde_json::json;
+use standout::tabular::{Column, Width};
+use standout::{CsvProjection, StructuredOutputProjection};
+
+let projection = StructuredOutputProjection::csv(
+    CsvProjection::builder("items")
+        .column(Column::new(Width::default()).key("language").header("LANGUAGE"))
+        .column(Column::new(Width::default()).key("code").header("CODE"))
+        .derived_column(
+            Column::new(Width::default()).header("NET"),
+            |row, _root| json!(
+                row["code"].as_i64().unwrap_or(0)
+                    - row["comments"].as_i64().unwrap_or(0)
+            ),
+        )
+        .synthetic_row(|root| json!({
+            "language": "TOTAL",
+            "code": root["totals"]["code"],
+            "comments": root["totals"]["comments"]
+        }))
+        .conditional_row(|root| {
+            (root["skipped"].as_u64().unwrap_or(0) > 0)
+                .then(|| json!({ "language": "SKIPPED" }))
+        })
+        .build(),
+);
+
+App::builder().command_with("summary", summary_handler, |config| {
+    config.structured_output_projection(projection)
+});
+```
+
+Direct-column dot paths are resolved against each selected row. Derived
+columns receive both the current row and the root response. Synthetic-row
+callbacks receive the root response and run in registration order. Column
+ordering, headers, and `null_repr` use the existing `FlatDataSpec` behavior.
+
+The projection applies only to CSV. Text and terminal modes still use the
+template, while JSON, YAML, and XML serialize the canonical response. In the
+pipeline, post-dispatch hooks run before projection and post-output hooks run
+after it; `run_to_string`, output-file handling, and final emission therefore
+observe the same projected CSV.
 
 See [Introduction to Tabular](../crates/render/guides/intro-to-tabular.md) for
 tabular specifications and layout.


### PR DESCRIPTION
## Summary

- add a public StructuredOutputProjection and CsvProjection builder for nested row selection, direct and derived columns, and synthetic or conditional rows
- attach projections declaratively through CommandConfig while preserving canonical JSON, YAML, and XML plus existing human templates
- cover direct dispatch, run_to_string, TestHarness, hook ordering, output-file handling, null behavior, and unconfigured-command compatibility

## Context

Issue #200 needs CSV shaping at the presentation boundary without teaching handlers about output modes or redesigning canonical response DTOs. The projection is captured in command configuration, runs after post-dispatch hooks, and feeds the existing post-output and file-emission pipeline.

This PR intentionally does not redesign RunResult, error origin, stream routing, typed exit status, or framework-owned final writes; those remain in #201.

## Verification

- pixi run test (1,719 tests passed)
- pixi run lint (31 checks passed)

closes #200