### PR TITLE
Preserve typed exit status through framework-owned writes

### DIFF
--- a/crates/standout-dispatch/docs/topics/partial-adoption.md
+++ b/crates/standout-dispatch/docs/topics/partial-adoption.md
@@ -15,6 +15,38 @@ Many CLI frameworks require a complete rewrite:
 
 `standout-dispatch` is designed differently. It's a library, not a framework—you call it, it doesn't call you.
 
+## Current App handoff
+
+For a fallback that does not need parsed matches, keep the source-level
+`run() -> bool` contract:
+
+```rust
+if !app.run(command, args) {
+    legacy_dispatch();
+}
+```
+
+When the legacy path needs `ArgMatches`, capture the result instead:
+
+```rust
+match app.run_to_string(command, args) {
+    RunResult::NoMatch(matches) => legacy_dispatch(matches),
+    RunResult::Handled(output) => consume_text(output),
+    RunResult::Binary(bytes, filename) => consume_binary(bytes, filename),
+    RunResult::Error(error) => {
+        eprintln!("{}", error);
+        std::process::exit(error.exit_status().code().into());
+    }
+    RunResult::Silent => {}
+    _ => {}
+}
+```
+
+`NoMatch` is deliberately status-free and emits nothing. It does not become a
+Clap usage error; the fallback owns the command. All completed Standout paths
+expose typed status/origin metadata. See [Execution
+Outcomes](../../../topics/execution-outcomes.md).
+
 ---
 
 ## Strategy: Migrate One Command at a Time

--- a/crates/standout-dispatch/src/handler.rs
+++ b/crates/standout-dispatch/src/handler.rs
@@ -64,6 +64,7 @@
 //! - [`RunResult`]: The result of running the CLI dispatcher
 //! - [`Handler`]: Trait for command handlers (`&mut self`)
 
+use crate::hooks::HookPhase;
 use crate::verify::ExpectedArg;
 use clap::ArgMatches;
 use serde::Serialize;
@@ -427,6 +428,242 @@ impl<T: Serialize> IntoHandlerResult<T> for HandlerResult<T> {
     }
 }
 
+/// Process exit status selected by Standout's execution policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ExitStatus(u8);
+
+impl ExitStatus {
+    /// Successful command, help, or version display.
+    pub const SUCCESS: Self = Self(0);
+    /// Runtime or final-write failure.
+    pub const FAILURE: Self = Self(1);
+    /// Clap command-line usage error.
+    pub const USAGE_ERROR: Self = Self(2);
+
+    /// Returns the numeric status reported to the operating system.
+    pub const fn code(self) -> u8 {
+        self.0
+    }
+}
+
+/// Successful text outcome carried by [`RunResult::Handled`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum SuccessKind {
+    /// A registered command completed successfully.
+    Command,
+    /// Clap requested a help display.
+    ClapHelp,
+    /// Clap requested a version display.
+    ClapVersion,
+}
+
+/// The final payload whose write failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum OutputKind {
+    /// Rendered text output.
+    Text,
+    /// Binary output.
+    Binary,
+}
+
+/// Typed origin for an unsuccessful framework run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum RunErrorKind {
+    /// Clap rejected the command line.
+    ClapUsage,
+    /// The application handler returned an error.
+    Handler,
+    /// A hook failed in the identified phase. Pipe failures are post-output hooks.
+    Hook(HookPhase),
+    /// Handler data serialization or presentation rendering failed.
+    Render,
+    /// A framework-owned file/stdout write failed.
+    FinalWrite(OutputKind),
+}
+
+/// Metadata-bearing successful text compatible with string-oriented access.
+#[derive(Debug, Clone)]
+pub struct RunOutput {
+    text: String,
+    kind: SuccessKind,
+}
+
+impl RunOutput {
+    /// Creates a successful command output.
+    pub fn command(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            kind: SuccessKind::Command,
+        }
+    }
+
+    /// Creates a Clap help display.
+    pub fn clap_help(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            kind: SuccessKind::ClapHelp,
+        }
+    }
+
+    /// Creates a Clap version display.
+    pub fn clap_version(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            kind: SuccessKind::ClapVersion,
+        }
+    }
+
+    /// Returns the captured text.
+    pub fn as_str(&self) -> &str {
+        &self.text
+    }
+
+    /// Returns the typed success origin.
+    pub const fn kind(&self) -> SuccessKind {
+        self.kind
+    }
+
+    /// Consumes the wrapper and returns the captured text.
+    pub fn into_string(self) -> String {
+        self.text
+    }
+}
+
+impl std::ops::Deref for RunOutput {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for RunOutput {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for RunOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl PartialEq<str> for RunOutput {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<&str> for RunOutput {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl PartialEq<String> for RunOutput {
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl From<String> for RunOutput {
+    fn from(text: String) -> Self {
+        Self::command(text)
+    }
+}
+
+impl From<&str> for RunOutput {
+    fn from(text: &str) -> Self {
+        Self::command(text)
+    }
+}
+
+impl From<RunOutput> for String {
+    fn from(output: RunOutput) -> Self {
+        output.into_string()
+    }
+}
+
+/// Metadata-bearing failure compatible with string-oriented access.
+#[derive(Debug, Clone)]
+pub struct RunError {
+    message: String,
+    kind: RunErrorKind,
+}
+
+impl RunError {
+    /// Creates a failure with its framework origin.
+    pub fn new(message: impl Into<String>, kind: RunErrorKind) -> Self {
+        Self {
+            message: message.into(),
+            kind,
+        }
+    }
+
+    /// Returns the existing human-readable diagnostic.
+    pub fn as_str(&self) -> &str {
+        &self.message
+    }
+
+    /// Returns the typed failure origin.
+    pub const fn kind(&self) -> RunErrorKind {
+        self.kind
+    }
+
+    /// Returns the shell status selected for this failure.
+    pub const fn exit_status(&self) -> ExitStatus {
+        match self.kind {
+            RunErrorKind::ClapUsage => ExitStatus::USAGE_ERROR,
+            _ => ExitStatus::FAILURE,
+        }
+    }
+
+    /// Consumes the wrapper and returns the diagnostic text.
+    pub fn into_string(self) -> String {
+        self.message
+    }
+}
+
+impl std::ops::Deref for RunError {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for RunError {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for RunError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<String> for RunError {
+    fn from(message: String) -> Self {
+        Self::new(message, RunErrorKind::Handler)
+    }
+}
+
+impl From<&str> for RunError {
+    fn from(message: &str) -> Self {
+        Self::new(message, RunErrorKind::Handler)
+    }
+}
+
+impl From<RunError> for String {
+    fn from(error: RunError) -> Self {
+        error.into_string()
+    }
+}
+
 /// Result of running the CLI dispatcher.
 ///
 /// After processing arguments, the dispatcher either handles a command,
@@ -438,14 +675,14 @@ impl<T: Serialize> IntoHandlerResult<T> for HandlerResult<T> {
 #[non_exhaustive]
 pub enum RunResult {
     /// A handler processed the command successfully; contains the rendered output
-    Handled(String),
+    Handled(RunOutput),
     /// A handler produced binary output (bytes, suggested filename)
     Binary(Vec<u8>, String),
     /// Silent output (handler completed but produced no output)
     Silent,
     /// A handler, hook, or output step failed; contains the formatted error message.
     /// Consumers should write this to stderr and exit non-zero.
-    Error(String),
+    Error(RunError),
     /// No handler matched; contains the ArgMatches for manual handling
     NoMatch(ArgMatches),
 }
@@ -484,6 +721,37 @@ impl RunResult {
         match self {
             RunResult::Error(s) => Some(s),
             _ => None,
+        }
+    }
+
+    /// Returns the typed success origin for captured text.
+    pub fn success_kind(&self) -> Option<SuccessKind> {
+        match self {
+            RunResult::Handled(output) => Some(output.kind()),
+            RunResult::Binary(_, _) | RunResult::Silent => Some(SuccessKind::Command),
+            _ => None,
+        }
+    }
+
+    /// Returns the typed error origin, if this run failed.
+    pub fn error_kind(&self) -> Option<RunErrorKind> {
+        match self {
+            RunResult::Error(error) => Some(error.kind()),
+            _ => None,
+        }
+    }
+
+    /// Returns the completed run's shell status.
+    ///
+    /// `NoMatch` returns `None`: it is a fallback handoff, not a completed
+    /// framework execution and is deliberately not treated as a usage error.
+    pub fn exit_status(&self) -> Option<ExitStatus> {
+        match self {
+            RunResult::Handled(_) | RunResult::Binary(_, _) | RunResult::Silent => {
+                Some(ExitStatus::SUCCESS)
+            }
+            RunResult::Error(error) => Some(error.exit_status()),
+            RunResult::NoMatch(_) => None,
         }
     }
 

--- a/crates/standout-dispatch/src/hooks.rs
+++ b/crates/standout-dispatch/src/hooks.rs
@@ -134,7 +134,7 @@ impl RenderedOutput {
 }
 
 /// The phase at which a hook error occurred.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum HookPhase {
     /// Error occurred during pre-dispatch phase
     PreDispatch,

--- a/crates/standout-dispatch/src/lib.rs
+++ b/crates/standout-dispatch/src/lib.rs
@@ -135,8 +135,8 @@ pub use dispatch::{
 
 // Re-export handler types
 pub use handler::{
-    CommandContext, Extensions, FnHandler, Handler, HandlerResult, IntoHandlerResult, Output,
-    RunResult, SimpleFnHandler,
+    CommandContext, ExitStatus, Extensions, FnHandler, Handler, HandlerResult, IntoHandlerResult,
+    Output, OutputKind, RunError, RunErrorKind, RunOutput, RunResult, SimpleFnHandler, SuccessKind,
 };
 
 // Re-export hook types

--- a/crates/standout-test/src/lib.rs
+++ b/crates/standout-test/src/lib.rs
@@ -47,7 +47,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use clap::Command;
-use standout::cli::{App, RunResult};
+use standout::cli::{App, ExitStatus, RunErrorKind, RunResult, SuccessKind};
 use standout_input::env::{MockClipboard, MockStdin};
 use standout_input::{
     reset_default_clipboard_reader, reset_default_prompt_responder, reset_default_stdin_reader,
@@ -559,6 +559,23 @@ impl TestResult {
         &self.outcome
     }
 
+    /// Returns the completed run's typed shell status.
+    ///
+    /// A no-match handoff has no framework status and returns `None`.
+    pub fn exit_status(&self) -> Option<ExitStatus> {
+        self.outcome.exit_status()
+    }
+
+    /// Returns the typed success origin for handled/help/version output.
+    pub fn success_kind(&self) -> Option<SuccessKind> {
+        self.outcome.success_kind()
+    }
+
+    /// Returns the typed error origin, if execution failed.
+    pub fn error_kind(&self) -> Option<RunErrorKind> {
+        self.outcome.error_kind()
+    }
+
     /// Returns the rendered text output, or `""` for `Silent` / `Binary` /
     /// `NoMatch`.
     pub fn stdout(&self) -> &str {
@@ -607,6 +624,28 @@ impl TestResult {
                 describe_outcome(&self.outcome)
             ),
         }
+    }
+
+    /// Panics unless the run exposes `expected` as its shell status.
+    #[track_caller]
+    pub fn assert_exit_status(&self, expected: ExitStatus) {
+        assert_eq!(
+            self.exit_status(),
+            Some(expected),
+            "unexpected exit status for {}",
+            describe_outcome(&self.outcome)
+        );
+    }
+
+    /// Panics unless the run exposes the expected typed error origin.
+    #[track_caller]
+    pub fn assert_error_kind(&self, expected: RunErrorKind) {
+        assert_eq!(
+            self.error_kind(),
+            Some(expected),
+            "unexpected error kind for {}",
+            describe_outcome(&self.outcome)
+        );
     }
 
     /// Returns `true` if the run produced an error.

--- a/crates/standout-test/tests/harness.rs
+++ b/crates/standout-test/tests/harness.rs
@@ -6,7 +6,7 @@
 use clap::Command;
 use serde_json::json;
 use serial_test::serial;
-use standout::cli::{App, Output};
+use standout::cli::{App, ExitStatus, HandlerResult, Output, RunErrorKind, SuccessKind};
 use standout::tabular::{Column, Width};
 use standout::{CsvProjection, StructuredOutputProjection};
 use standout_input::{ClipboardSource, EnvSource, InputChain, StdinSource};
@@ -43,6 +43,39 @@ fn simple_handler_returns_rendered_text() {
     let result = TestHarness::new().run(&app, echo_command(), vec!["app", "echo", "hello"]);
     result.assert_success();
     result.assert_stdout_eq("hello");
+    result.assert_exit_status(ExitStatus::SUCCESS);
+}
+
+#[test]
+#[serial]
+fn harness_exposes_typed_clap_and_handler_outcomes() {
+    let app = build_echo_app("{{ msg }}");
+    let help = TestHarness::new().run(&app, echo_command(), ["app", "--help"]);
+    help.assert_success();
+    help.assert_exit_status(ExitStatus::SUCCESS);
+    assert_eq!(help.success_kind(), Some(SuccessKind::ClapHelp));
+
+    let usage = TestHarness::new().run(&app, echo_command(), ["app", "--unknown"]);
+    usage.assert_error();
+    usage.assert_exit_status(ExitStatus::USAGE_ERROR);
+    usage.assert_error_kind(RunErrorKind::ClapUsage);
+
+    let failing = App::builder()
+        .command(
+            "fail",
+            |_matches, _ctx| -> HandlerResult<serde_json::Value> {
+                Err(std::io::Error::other("boom").into())
+            },
+            "",
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+    let failing_command = Command::new("app").subcommand(Command::new("fail"));
+    let failure = TestHarness::new().run(&failing, failing_command, ["app", "fail"]);
+    failure.assert_error();
+    failure.assert_exit_status(ExitStatus::FAILURE);
+    failure.assert_error_kind(RunErrorKind::Handler);
 }
 
 #[test]

--- a/crates/standout/examples/outcome_fixture.rs
+++ b/crates/standout/examples/outcome_fixture.rs
@@ -1,0 +1,96 @@
+use clap::Command;
+use serde_json::json;
+use standout::cli::{App, HandlerResult, Output};
+
+fn command() -> Command {
+    Command::new("outcome-fixture")
+        .version("1.2.3")
+        .subcommand(Command::new("ok"))
+        .subcommand(Command::new("fail"))
+        .subcommand(Command::new("silent"))
+        .subcommand(Command::new("binary"))
+        .subcommand(Command::new("huge"))
+        .subcommand(Command::new("binary-huge"))
+        .subcommand(Command::new("warn-ok"))
+        .subcommand(Command::new("warn-fail"))
+}
+
+fn app() -> App {
+    App::builder()
+        .command(
+            "ok",
+            |_, _| Ok(Output::Render(json!({ "message": "ok" }))),
+            "{{ message }}",
+        )
+        .unwrap()
+        .command(
+            "fail",
+            |_, _| -> HandlerResult<serde_json::Value> {
+                Err(anyhow::anyhow!("fixture handler failed"))
+            },
+            "",
+        )
+        .unwrap()
+        .command(
+            "silent",
+            |_, _| -> HandlerResult<()> { Ok(Output::Silent) },
+            "",
+        )
+        .unwrap()
+        .command(
+            "binary",
+            |_, _| -> HandlerResult<()> {
+                Ok(Output::Binary {
+                    data: vec![0, 1, 2],
+                    filename: "fixture.bin".into(),
+                })
+            },
+            "",
+        )
+        .unwrap()
+        .command(
+            "huge",
+            |_, _| {
+                Ok(Output::Render(
+                    json!({ "message": "x".repeat(1024 * 1024) }),
+                ))
+            },
+            "{{ message }}",
+        )
+        .unwrap()
+        .command(
+            "binary-huge",
+            |_, _| -> HandlerResult<()> {
+                Ok(Output::Binary {
+                    data: vec![7; 1024 * 1024],
+                    filename: "fixture.bin".into(),
+                })
+            },
+            "",
+        )
+        .unwrap()
+        .command(
+            "warn-ok",
+            |_, _| {
+                standout::warnings::push_warning("fixture warning");
+                Ok(Output::Render(json!({ "message": "ok" })))
+            },
+            "{{ message }}",
+        )
+        .unwrap()
+        .command(
+            "warn-fail",
+            |_, _| -> HandlerResult<serde_json::Value> {
+                standout::warnings::push_warning("fixture warning");
+                Err(anyhow::anyhow!("fixture handler failed"))
+            },
+            "",
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+fn main() {
+    app().run(command(), std::env::args());
+}

--- a/crates/standout/src/cli/builder/execution.rs
+++ b/crates/standout/src/cli/builder/execution.rs
@@ -9,6 +9,7 @@
 
 use crate::{write_binary_output, write_output, OutputDestination, OutputMode};
 use clap::{Arg, ArgAction, ArgMatches, Command};
+use std::io::Write;
 use std::path::PathBuf;
 
 use super::{AppBuilder, PendingCommand};
@@ -17,7 +18,9 @@ use crate::cli::dispatch::{
     DispatchOutput,
 };
 use crate::cli::group::{ErasedConfigRecipe, GroupBuilder, GroupEntry};
-use crate::cli::handler::{CommandContext, RunResult};
+use crate::cli::handler::{
+    CommandContext, OutputKind, RunError, RunErrorKind, RunOutput, RunResult,
+};
 use crate::cli::hooks::{RenderedOutput, TextOutput};
 use crate::SetupError;
 
@@ -99,9 +102,8 @@ impl AppBuilder {
     /// Returns:
     /// - `RunResult::Handled(output)` if a handler was found and executed successfully,
     /// - `RunResult::Binary(bytes, filename)` for binary output,
-    /// - `RunResult::Handled(String::new())` if the handler completed silently
-    ///   (silent completion is currently mapped onto an empty `Handled`; the
-    ///   8.0 overhaul will return a distinct `RunResult::Silent`),
+    /// - `RunResult::Handled(RunOutput::command(String::new()))` if the handler
+    ///   completed silently (preserving the capture compatibility accessor),
     /// - `RunResult::Error(msg)` if a handler, hook, or output step failed,
     /// - `RunResult::NoMatch(matches)` if no handler matched.
     ///
@@ -132,7 +134,10 @@ impl AppBuilder {
             // Run pre-dispatch hooks if registered (hooks can inject state via ctx.extensions)
             if let Some(hooks) = hooks {
                 if let Err(e) = hooks.run_pre_dispatch(&matches, &mut ctx) {
-                    return RunResult::Error(format!("Hook error: {}", e));
+                    return RunResult::Error(RunError::new(
+                        format!("Hook error: {}", e),
+                        RunErrorKind::Hook(e.phase),
+                    ));
                 }
             }
 
@@ -163,7 +168,12 @@ impl AppBuilder {
             let mut final_output = if let Some(hooks) = hooks {
                 match hooks.run_post_output(&matches, &ctx, output) {
                     Ok(o) => o,
-                    Err(e) => return RunResult::Error(format!("Hook error: {}", e)),
+                    Err(e) => {
+                        return RunResult::Error(RunError::new(
+                            format!("Hook error: {}", e),
+                            RunErrorKind::Hook(e.phase),
+                        ))
+                    }
                 }
             } else {
                 output
@@ -182,14 +192,20 @@ impl AppBuilder {
                         RenderedOutput::Text(t) => {
                             // Write raw output (without ANSI codes) to file
                             if let Err(e) = write_output(&t.raw, &dest) {
-                                return RunResult::Error(format!("Error writing output: {}", e));
+                                return RunResult::Error(RunError::new(
+                                    format!("Error writing output: {}", e),
+                                    RunErrorKind::FinalWrite(OutputKind::Text),
+                                ));
                             }
                             // Suppress further output
                             final_output = RenderedOutput::Silent;
                         }
                         RenderedOutput::Binary(b, _) => {
                             if let Err(e) = write_binary_output(b, &dest) {
-                                return RunResult::Error(format!("Error writing output: {}", e));
+                                return RunResult::Error(RunError::new(
+                                    format!("Error writing output: {}", e),
+                                    RunErrorKind::FinalWrite(OutputKind::Binary),
+                                ));
                             }
                             final_output = RenderedOutput::Silent;
                         }
@@ -200,9 +216,11 @@ impl AppBuilder {
 
             // Convert back to RunResult (using formatted for terminal display)
             match final_output {
-                RenderedOutput::Text(t) => RunResult::Handled(t.formatted),
+                RenderedOutput::Text(t) => RunResult::Handled(RunOutput::command(t.formatted)),
                 RenderedOutput::Binary(b, f) => RunResult::Binary(b, f),
-                RenderedOutput::Silent => RunResult::Handled(String::new()),
+                // Preserve the 7.x capture contract: silent success is an
+                // empty handled string. `run()` still emits nothing.
+                RenderedOutput::Silent => RunResult::Handled(RunOutput::command(String::new())),
             }
         } else {
             RunResult::NoMatch(matches)
@@ -259,9 +277,15 @@ impl AppBuilder {
             Ok(m) => m,
             Err(e) => {
                 if e.use_stderr() {
-                    return RunResult::Error(e.to_string());
+                    return RunResult::Error(RunError::new(e.to_string(), RunErrorKind::ClapUsage));
                 }
-                return RunResult::Handled(e.to_string());
+                let output = match e.kind() {
+                    clap::error::ErrorKind::DisplayVersion => {
+                        RunOutput::clap_version(e.to_string())
+                    }
+                    _ => RunOutput::clap_help(e.to_string()),
+                };
+                return RunResult::Handled(output);
             }
         };
 
@@ -278,9 +302,18 @@ impl AppBuilder {
                     Ok(m) => m,
                     Err(e) => {
                         if e.use_stderr() {
-                            return RunResult::Error(e.to_string());
+                            return RunResult::Error(RunError::new(
+                                e.to_string(),
+                                RunErrorKind::ClapUsage,
+                            ));
                         }
-                        return RunResult::Handled(e.to_string());
+                        let output = match e.kind() {
+                            clap::error::ErrorKind::DisplayVersion => {
+                                RunOutput::clap_version(e.to_string())
+                            }
+                            _ => RunOutput::clap_help(e.to_string()),
+                        };
+                        return RunResult::Handled(output);
                     }
                 }
             }
@@ -323,9 +356,10 @@ impl AppBuilder {
     ///
     /// # Errors and exit codes
     ///
-    /// On `RunResult::Error`, this function writes the error message to
-    /// stderr and calls `std::process::exit(1)` — it does not return.
-    /// Likewise, a binary write failure writes to stderr and exits 1.
+    /// On `RunResult::Error`, this function writes the diagnostic to stderr
+    /// and exits with its typed status: Clap usage errors use 2 and runtime
+    /// failures use 1. Final text and binary writes are framework-owned; a
+    /// write failure is diagnosed on stderr and exits 1.
     /// Callers needing fine-grained control over exit codes should use
     /// [`Self::run_to_string`] or [`Self::dispatch_from`] and match on
     /// `RunResult` themselves.
@@ -350,41 +384,14 @@ impl AppBuilder {
         T: Into<std::ffi::OsString> + Clone,
     {
         let result = self.dispatch_from(cmd, args);
-        // Track whether we need to terminate the process with a non-zero
-        // exit code. We can't return `ExitCode` from `run()` without a
-        // breaking signature change, so we exit explicitly after flushing
-        // warnings (see issue #141).
-        let mut exit_code: Option<i32> = None;
-        let handled = match result {
-            RunResult::Handled(ref output) => {
-                if !output.is_empty() {
-                    println!("{}", output);
-                }
-                true
-            }
-            RunResult::Binary(ref bytes, ref filename) => {
-                // For binary output, write to stdout or the suggested file
-                // By default, we write to the suggested filename
-                if let Err(e) = std::fs::write(filename, bytes) {
-                    eprintln!("Error writing {}: {}", filename, e);
-                    exit_code = Some(1);
-                } else {
-                    eprintln!("Wrote {} bytes to {}", bytes.len(), filename);
-                }
-                true
-            }
-            RunResult::Silent => true, // Handler ran successfully, no output
-            RunResult::Error(ref msg) => {
-                eprintln!("{}", msg);
-                exit_code = Some(1);
-                true
-            }
-            RunResult::NoMatch(_) => false,
-            // Required by `#[non_exhaustive]`. Conservative default: treat
-            // any future variant as "not handled" so the caller's fallback
-            // path runs.
-            _ => false,
-        };
+        let primary_status = result.exit_status();
+        let stdout = std::io::stdout();
+        let stderr = std::io::stderr();
+        let mut stdout = stdout.lock();
+        let mut stderr = stderr.lock();
+        let (handled, final_write_failure) = emit_run_result(&result, &mut stdout, &mut stderr);
+        drop(stdout);
+        drop(stderr);
 
         // After the primary output has been flushed to stdout, render any
         // framework warnings collected during setup/dispatch to stderr so
@@ -395,8 +402,12 @@ impl AppBuilder {
         let theme = self.theme.as_ref().unwrap_or(&default_theme);
         standout_render::warnings::flush_to_stderr(theme, OutputMode::Auto);
 
-        if let Some(code) = exit_code {
-            std::process::exit(code);
+        let status = final_write_failure
+            .as_ref()
+            .map(RunError::exit_status)
+            .or(primary_status);
+        if let Some(status) = status.filter(|status| status.code() != 0) {
+            std::process::exit(i32::from(status.code()));
         }
 
         handled
@@ -409,11 +420,10 @@ impl AppBuilder {
     ///
     /// # Returns
     ///
-    /// - `RunResult::Handled(output)` - Handler executed successfully, output is the rendered string.
-    ///   Note: silent completion currently surfaces as `Handled(String::new())` rather than a
-    ///   distinct `Silent` variant; that distinction returns in the 8.0 error-handling overhaul.
+    /// - `RunResult::Handled(output)` - Handler executed successfully, or Clap produced help/version.
+    ///   Silent completion remains an empty handled string for capture compatibility.
     /// - `RunResult::Binary(bytes, filename)` - Handler produced binary output
-    /// - `RunResult::Error(msg)` - A handler, hook, output step, or clap parse failed
+    /// - `RunResult::Error(error)` - A typed handler, hook, render, write, or Clap usage failure
     /// - `RunResult::NoMatch(matches)` - No handler matched
     ///
     /// # Example
@@ -429,9 +439,9 @@ impl AppBuilder {
     /// match result {
     ///     RunResult::Handled(output) => println!("{}", output),
     ///     RunResult::Binary(bytes, filename) => std::fs::write(filename, bytes)?,
-    ///     RunResult::Error(msg) => {
-    ///         eprintln!("{}", msg);
-    ///         std::process::exit(1);
+    ///     RunResult::Error(error) => {
+    ///         eprintln!("{}", error);
+    ///         std::process::exit(error.exit_status().code().into());
     ///     },
     ///     RunResult::NoMatch(matches) => { /* handle manually */ },
     ///     // RunResult is #[non_exhaustive]; cover Silent and any future variants.
@@ -485,6 +495,49 @@ impl AppBuilder {
 
         cmd
     }
+}
+
+/// Emits one captured result through framework-owned writers.
+///
+/// Keeping this as a writer seam makes final text/binary failures typed and
+/// unit-testable while `run()` retains its public `bool` contract.
+fn emit_run_result<W: Write, E: Write>(
+    result: &RunResult,
+    stdout: &mut W,
+    stderr: &mut E,
+) -> (bool, Option<RunError>) {
+    let failure = match result {
+        RunResult::Handled(output) if output.is_empty() => None,
+        RunResult::Handled(output) => writeln!(stdout, "{}", output).err().map(|error| {
+            RunError::new(
+                format!("Error writing stdout: {}", error),
+                RunErrorKind::FinalWrite(OutputKind::Text),
+            )
+        }),
+        RunResult::Binary(bytes, _) => stdout.write_all(bytes).err().map(|error| {
+            RunError::new(
+                format!("Error writing binary stdout: {}", error),
+                RunErrorKind::FinalWrite(OutputKind::Binary),
+            )
+        }),
+        RunResult::Silent => None,
+        RunResult::Error(error) => writeln!(stderr, "{}", error).err().map(|write_error| {
+            RunError::new(
+                format!("Error writing stderr: {}", write_error),
+                RunErrorKind::FinalWrite(OutputKind::Text),
+            )
+        }),
+        RunResult::NoMatch(_) => return (false, None),
+        _ => return (false, None),
+    };
+
+    if let Some(error) = &failure {
+        // Best effort: if stderr itself is broken there is nowhere else to
+        // report the final-write diagnostic, but the typed failure still
+        // determines status 1.
+        let _ = writeln!(stderr, "{}", error);
+    }
+    (true, failure)
 }
 
 #[cfg(test)]
@@ -2355,5 +2408,81 @@ header:
 
         assert!(result.is_handled());
         assert_eq!(result.output(), Some("https://api.example.com"));
+    }
+
+    struct FailingWriter;
+
+    impl std::io::Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "closed",
+            ))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "closed",
+            ))
+        }
+    }
+
+    #[test]
+    fn final_emission_routes_success_and_diagnostics_to_distinct_streams() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let (handled, failure) = emit_run_result(
+            &RunResult::Handled(RunOutput::command("hello")),
+            &mut stdout,
+            &mut stderr,
+        );
+        assert!(handled);
+        assert!(failure.is_none());
+        assert_eq!(stdout, b"hello\n");
+        assert!(stderr.is_empty());
+
+        stdout.clear();
+        let (handled, failure) = emit_run_result(
+            &RunResult::Error(RunError::new("bad argv", RunErrorKind::ClapUsage)),
+            &mut stdout,
+            &mut stderr,
+        );
+        assert!(handled);
+        assert!(failure.is_none());
+        assert!(stdout.is_empty());
+        assert_eq!(stderr, b"bad argv\n");
+    }
+
+    #[test]
+    fn final_text_and_binary_write_failures_keep_payload_kind() {
+        let mut stderr = Vec::new();
+        let (_, text_failure) = emit_run_result(
+            &RunResult::Handled(RunOutput::command("hello")),
+            &mut FailingWriter,
+            &mut stderr,
+        );
+        let text_failure = text_failure.unwrap();
+        assert_eq!(
+            text_failure.kind(),
+            RunErrorKind::FinalWrite(OutputKind::Text)
+        );
+        assert_eq!(text_failure.exit_status(), crate::cli::ExitStatus::FAILURE);
+
+        stderr.clear();
+        let (_, binary_failure) = emit_run_result(
+            &RunResult::Binary(vec![0, 1], "data.bin".into()),
+            &mut FailingWriter,
+            &mut stderr,
+        );
+        let binary_failure = binary_failure.unwrap();
+        assert_eq!(
+            binary_failure.kind(),
+            RunErrorKind::FinalWrite(OutputKind::Binary)
+        );
+        assert_eq!(
+            binary_failure.exit_status(),
+            crate::cli::ExitStatus::FAILURE
+        );
     }
 }

--- a/crates/standout/src/cli/builder/execution.rs
+++ b/crates/standout/src/cli/builder/execution.rs
@@ -508,25 +508,35 @@ fn emit_run_result<W: Write, E: Write>(
 ) -> (bool, Option<RunError>) {
     let failure = match result {
         RunResult::Handled(output) if output.is_empty() => None,
-        RunResult::Handled(output) => writeln!(stdout, "{}", output).err().map(|error| {
-            RunError::new(
-                format!("Error writing stdout: {}", error),
-                RunErrorKind::FinalWrite(OutputKind::Text),
-            )
-        }),
-        RunResult::Binary(bytes, _) => stdout.write_all(bytes).err().map(|error| {
-            RunError::new(
-                format!("Error writing binary stdout: {}", error),
-                RunErrorKind::FinalWrite(OutputKind::Binary),
-            )
-        }),
+        RunResult::Handled(output) => writeln!(stdout, "{}", output)
+            .and_then(|()| stdout.flush())
+            .err()
+            .map(|error| {
+                RunError::new(
+                    format!("Error writing stdout: {}", error),
+                    RunErrorKind::FinalWrite(OutputKind::Text),
+                )
+            }),
+        RunResult::Binary(bytes, _) => stdout
+            .write_all(bytes)
+            .and_then(|()| stdout.flush())
+            .err()
+            .map(|error| {
+                RunError::new(
+                    format!("Error writing binary stdout: {}", error),
+                    RunErrorKind::FinalWrite(OutputKind::Binary),
+                )
+            }),
         RunResult::Silent => None,
-        RunResult::Error(error) => writeln!(stderr, "{}", error).err().map(|write_error| {
-            RunError::new(
-                format!("Error writing stderr: {}", write_error),
-                RunErrorKind::FinalWrite(OutputKind::Text),
-            )
-        }),
+        RunResult::Error(error) => writeln!(stderr, "{}", error)
+            .and_then(|()| stderr.flush())
+            .err()
+            .map(|write_error| {
+                RunError::new(
+                    format!("Error writing stderr: {}", write_error),
+                    RunErrorKind::FinalWrite(OutputKind::Text),
+                )
+            }),
         RunResult::NoMatch(_) => return (false, None),
         _ => return (false, None),
     };
@@ -535,7 +545,7 @@ fn emit_run_result<W: Write, E: Write>(
         // Best effort: if stderr itself is broken there is nowhere else to
         // report the final-write diagnostic, but the typed failure still
         // determines status 1.
-        let _ = writeln!(stderr, "{}", error);
+        let _ = writeln!(stderr, "{}", error).and_then(|()| stderr.flush());
     }
     (true, failure)
 }
@@ -2428,6 +2438,25 @@ header:
         }
     }
 
+    #[derive(Default)]
+    struct FlushFailingWriter {
+        bytes: Vec<u8>,
+    }
+
+    impl std::io::Write for FlushFailingWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.bytes.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "flush closed",
+            ))
+        }
+    }
+
     #[test]
     fn final_emission_routes_success_and_diagnostics_to_distinct_streams() {
         let mut stdout = Vec::new();
@@ -2483,6 +2512,33 @@ header:
         assert_eq!(
             binary_failure.exit_status(),
             crate::cli::ExitStatus::FAILURE
+        );
+    }
+
+    #[test]
+    fn final_text_and_binary_flush_failures_keep_payload_kind() {
+        let mut text_stdout = FlushFailingWriter::default();
+        let (_, text_failure) = emit_run_result(
+            &RunResult::Handled(RunOutput::command("hello")),
+            &mut text_stdout,
+            &mut Vec::new(),
+        );
+        assert_eq!(text_stdout.bytes, b"hello\n");
+        assert_eq!(
+            text_failure.unwrap().kind(),
+            RunErrorKind::FinalWrite(OutputKind::Text)
+        );
+
+        let mut binary_stdout = FlushFailingWriter::default();
+        let (_, binary_failure) = emit_run_result(
+            &RunResult::Binary(vec![0, 1], "data.bin".into()),
+            &mut binary_stdout,
+            &mut Vec::new(),
+        );
+        assert_eq!(binary_stdout.bytes, [0, 1]);
+        assert_eq!(
+            binary_failure.unwrap().kind(),
+            RunErrorKind::FinalWrite(OutputKind::Binary)
         );
     }
 }

--- a/crates/standout/src/cli/dispatch.rs
+++ b/crates/standout/src/cli/dispatch.rs
@@ -10,8 +10,8 @@ use clap::ArgMatches;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::cli::handler::CommandContext;
 use crate::cli::handler::Output as HandlerOutput;
+use crate::cli::handler::{CommandContext, RunError, RunErrorKind};
 use crate::cli::hooks::Hooks;
 use crate::context::{ContextRegistry, RenderContext};
 use crate::StructuredOutputProjection;
@@ -57,17 +57,23 @@ pub(crate) fn render_handler_output<T: Serialize>(
     template_engine: &dyn standout_render::template::TemplateEngine,
     output_mode: crate::OutputMode,
     structured_output_projection: Option<&StructuredOutputProjection>,
-) -> Result<DispatchOutput, String> {
+) -> Result<DispatchOutput, RunError> {
     match result {
         Ok(output) => match output {
             HandlerOutput::Render(data) => {
-                let mut json_data = serde_json::to_value(&data)
-                    .map_err(|e| format!("Failed to serialize handler result: {}", e))?;
+                let mut json_data = serde_json::to_value(&data).map_err(|e| {
+                    RunError::new(
+                        format!("Failed to serialize handler result: {}", e),
+                        RunErrorKind::Render,
+                    )
+                })?;
 
                 if let Some(hooks) = hooks {
                     json_data = hooks
                         .run_post_dispatch(matches, ctx, json_data)
-                        .map_err(|e| format!("Hook error: {}", e))?;
+                        .map_err(|e| {
+                            RunError::new(format!("Hook error: {}", e), RunErrorKind::Hook(e.phase))
+                        })?;
                 }
 
                 let render_ctx = RenderContext::new(
@@ -85,7 +91,7 @@ pub(crate) fn render_handler_output<T: Serialize>(
                             projection
                                 .csv_projection()
                                 .render(&json_data)
-                                .map_err(|e| e.to_string())?,
+                                .map_err(|e| RunError::new(e.to_string(), RunErrorKind::Render))?,
                         )
                     }
                     _ => standout_render::template::render_auto_with_engine_split(
@@ -97,7 +103,7 @@ pub(crate) fn render_handler_output<T: Serialize>(
                         context_registry,
                         &render_ctx,
                     )
-                    .map_err(|e| e.to_string())?,
+                    .map_err(|e| RunError::new(e.to_string(), RunErrorKind::Render))?,
                 };
 
                 Ok(DispatchOutput::Text {
@@ -108,7 +114,10 @@ pub(crate) fn render_handler_output<T: Serialize>(
             HandlerOutput::Silent => Ok(DispatchOutput::Silent),
             HandlerOutput::Binary { data, filename } => Ok(DispatchOutput::Binary(data, filename)),
         },
-        Err(e) => Err(format!("Error: {}", e)),
+        Err(e) => Err(RunError::new(
+            format!("Error: {}", e),
+            RunErrorKind::Handler,
+        )),
     }
 }
 
@@ -129,7 +138,7 @@ pub type DispatchFn = Rc<
             Option<&Hooks>,
             crate::OutputMode,
             &crate::Theme,
-        ) -> Result<DispatchOutput, String>,
+        ) -> Result<DispatchOutput, RunError>,
     >,
 >;
 
@@ -141,7 +150,7 @@ pub fn dispatch(
     hooks: Option<&Hooks>,
     output_mode: crate::OutputMode,
     theme: &crate::Theme,
-) -> Result<DispatchOutput, String> {
+) -> Result<DispatchOutput, RunError> {
     (dispatch_fn.borrow_mut())(matches, ctx, hooks, output_mode, theme)
 }
 

--- a/crates/standout/src/cli/group.rs
+++ b/crates/standout/src/cli/group.rs
@@ -12,7 +12,9 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use super::dispatch::{render_handler_output, DispatchFn};
-use crate::cli::handler::{CommandContext, FnHandler, Handler, HandlerResult};
+use crate::cli::handler::{
+    CommandContext, FnHandler, Handler, HandlerResult, RunError, RunErrorKind,
+};
 use crate::cli::hooks::{Hooks, RenderedOutput, TextOutput};
 use crate::StructuredOutputProjection;
 use standout_dispatch::verify::ExpectedArg;
@@ -414,7 +416,10 @@ where
                 let result = (handler.borrow_mut())(matches, ctx);
                 match result {
                     Ok(()) => Ok(super::dispatch::DispatchOutput::Silent),
-                    Err(e) => Err(format!("Error: {}", e)),
+                    Err(e) => Err(RunError::new(
+                        format!("Error: {}", e),
+                        RunErrorKind::Handler,
+                    )),
                 }
             },
         ))
@@ -1163,7 +1168,10 @@ where
                 let result = (handler.borrow_mut())(matches, ctx);
                 match result {
                     Ok(()) => Ok(super::dispatch::DispatchOutput::Silent),
-                    Err(e) => Err(format!("Error: {}", e)),
+                    Err(e) => Err(RunError::new(
+                        format!("Error: {}", e),
+                        RunErrorKind::Handler,
+                    )),
                 }
             },
         ))

--- a/crates/standout/src/cli/handler.rs
+++ b/crates/standout/src/cli/handler.rs
@@ -55,7 +55,8 @@
 // Re-export all handler types from standout-dispatch.
 // These types are render-agnostic and focus on handler execution.
 pub use standout_dispatch::{
-    CommandContext, Extensions, FnHandler, Handler, HandlerResult, Output, RunResult,
+    CommandContext, ExitStatus, Extensions, FnHandler, Handler, HandlerResult, Output, OutputKind,
+    RunError, RunErrorKind, RunOutput, RunResult, SuccessKind,
 };
 
 use standout_input::{InputSourceKind, Inputs, MissingInput};

--- a/crates/standout/src/cli/mod.rs
+++ b/crates/standout/src/cli/mod.rs
@@ -92,12 +92,11 @@
 //!     RunResult::Handled(output) => println!("{}", output),
 //!     RunResult::NoMatch(matches) => legacy_dispatch(matches),
 //!     RunResult::Binary(bytes, filename) => std::fs::write(filename, bytes)?,
-//!     RunResult::Error(msg) => {
-//!         eprintln!("{}", msg);
-//!         std::process::exit(1);
+//!     RunResult::Error(error) => {
+//!         eprintln!("{}", error);
+//!         std::process::exit(error.exit_status().code().into());
 //!     },
-//!     // RunResult is #[non_exhaustive]; covers Silent (currently mapped to
-//!     // Handled(String::new()) in 7.x) and any future variants.
+//!     // RunResult is #[non_exhaustive]; cover Silent and future variants.
 //!     _ => {},
 //! }
 //! ```
@@ -109,7 +108,7 @@
 //! - [`FnHandler`]: Wrapper for `FnMut` closures
 //! - [`Output`]: What handlers produce (render data, silent, binary)
 //! - [`HandlerResult`]: `Result<Output<T>, Error>` — enables `?` for error handling
-//! - [`RunResult`]: Dispatch outcome (handled, binary, or no match)
+//! - [`RunResult`]: Typed dispatch outcome, status, and failure origin
 //! - [`Hooks`]: Pre/post execution hooks for validation and transformation
 //! - [`CommandContext`]: Runtime info passed to handlers (command path, app state)
 //!
@@ -155,7 +154,8 @@ pub use help::{
 
 // Re-export handler types
 pub use handler::{
-    CommandContext, CommandContextInput, FnHandler, Handler, HandlerResult, Output, RunResult,
+    CommandContext, CommandContextInput, ExitStatus, FnHandler, Handler, HandlerResult, Output,
+    OutputKind, RunError, RunErrorKind, RunOutput, RunResult, SuccessKind,
 };
 
 // Re-export hook types

--- a/crates/standout/tests/piping_integration.rs
+++ b/crates/standout/tests/piping_integration.rs
@@ -209,6 +209,7 @@ fn test_pipe_with_custom_target() {
 /// Test that piping a failed command propagates the error
 #[test]
 fn test_pipe_command_failure() {
+    use standout::cli::{ExitStatus, HookPhase, RunErrorKind};
     let app = App::builder()
         .commands(|g| {
             g.command_with(
@@ -225,6 +226,12 @@ fn test_pipe_command_failure() {
 
     let cmd = Command::new("test").subcommand(Command::new("fail"));
     let result = app.run_to_string(cmd, vec!["test", "fail"]);
+
+    assert_eq!(result.exit_status(), Some(ExitStatus::FAILURE));
+    assert_eq!(
+        result.error_kind(),
+        Some(RunErrorKind::Hook(HookPhase::PostOutput))
+    );
 
     // Hook error should produce RunResult::Error with the failure message
     match result {

--- a/crates/standout/tests/process_outcomes.rs
+++ b/crates/standout/tests/process_outcomes.rs
@@ -1,0 +1,146 @@
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+use std::sync::OnceLock;
+
+fn fixture_binary() -> PathBuf {
+    static BINARY: OnceLock<PathBuf> = OnceLock::new();
+    BINARY
+        .get_or_init(|| {
+            let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .to_path_buf();
+            let status = Command::new(env!("CARGO"))
+                .current_dir(&workspace)
+                .args([
+                    "build",
+                    "--quiet",
+                    "-p",
+                    "standout",
+                    "--example",
+                    "outcome_fixture",
+                ])
+                .status()
+                .unwrap();
+            assert!(status.success());
+
+            let target_dir = std::env::var_os("CARGO_TARGET_DIR")
+                .map(PathBuf::from)
+                .map(|path| {
+                    if path.is_absolute() {
+                        path
+                    } else {
+                        workspace.join(path)
+                    }
+                })
+                .unwrap_or_else(|| workspace.join("target"));
+            target_dir.join(format!(
+                "debug/examples/outcome_fixture{}",
+                std::env::consts::EXE_SUFFIX
+            ))
+        })
+        .clone()
+}
+
+fn run(binary: &PathBuf, args: &[&str]) -> Output {
+    Command::new(binary).args(args).output().unwrap()
+}
+
+#[test]
+fn real_process_status_and_stream_matrix() {
+    let binary = fixture_binary();
+
+    let help = run(&binary, &["--help"]);
+    assert_eq!(help.status.code(), Some(0));
+    assert!(String::from_utf8_lossy(&help.stdout).contains("Usage:"));
+    assert!(help.stderr.is_empty());
+
+    let version = run(&binary, &["--version"]);
+    assert_eq!(version.status.code(), Some(0));
+    assert!(String::from_utf8_lossy(&version.stdout).contains("1.2.3"));
+    assert!(version.stderr.is_empty());
+
+    let usage = run(&binary, &["--unknown"]);
+    assert_eq!(usage.status.code(), Some(2));
+    assert!(usage.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&usage.stderr).contains("unexpected argument"));
+
+    let success = run(&binary, &["ok"]);
+    assert_eq!(success.status.code(), Some(0));
+    assert_eq!(success.stdout, b"ok\n");
+    assert!(success.stderr.is_empty());
+
+    let handler = run(&binary, &["fail"]);
+    assert_eq!(handler.status.code(), Some(1));
+    assert!(handler.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&handler.stderr).contains("fixture handler failed"));
+
+    let silent = run(&binary, &["silent"]);
+    assert_eq!(silent.status.code(), Some(0));
+    assert!(silent.stdout.is_empty());
+    assert!(silent.stderr.is_empty());
+
+    let binary_output = run(&binary, &["binary"]);
+    assert_eq!(binary_output.status.code(), Some(0));
+    assert_eq!(binary_output.stdout, [0, 1, 2]);
+    assert!(binary_output.stderr.is_empty());
+
+    let no_match = run(&binary, &[]);
+    assert_eq!(no_match.status.code(), Some(0));
+    assert!(no_match.stdout.is_empty());
+    assert!(no_match.stderr.is_empty());
+
+    let warning_success = run(&binary, &["warn-ok"]);
+    assert_eq!(warning_success.status.code(), Some(0));
+    assert_eq!(warning_success.stdout, b"ok\n");
+    assert!(String::from_utf8_lossy(&warning_success.stderr).contains("fixture warning"));
+
+    let warning_failure = run(&binary, &["warn-fail"]);
+    assert_eq!(warning_failure.status.code(), Some(1));
+    assert!(warning_failure.stdout.is_empty());
+    let warning_stderr = String::from_utf8_lossy(&warning_failure.stderr);
+    assert!(warning_stderr.contains("fixture handler failed"));
+    assert!(warning_stderr.contains("fixture warning"));
+
+    let tempdir = tempfile::tempdir().unwrap();
+    let output_file = tempdir.path().join("out.txt");
+    let file_success = run(
+        &binary,
+        &["--output-file-path", output_file.to_str().unwrap(), "ok"],
+    );
+    assert_eq!(file_success.status.code(), Some(0));
+    assert!(file_success.stdout.is_empty());
+    assert!(file_success.stderr.is_empty());
+    assert_eq!(std::fs::read_to_string(output_file).unwrap(), "ok");
+
+    let file_failure = run(
+        &binary,
+        &["--output-file-path", tempdir.path().to_str().unwrap(), "ok"],
+    );
+    assert_eq!(file_failure.status.code(), Some(1));
+    assert!(file_failure.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&file_failure.stderr).contains("Error writing output"));
+}
+
+#[test]
+fn real_process_reports_broken_text_and_binary_stdout() {
+    let binary = fixture_binary();
+    for command in ["huge", "binary-huge"] {
+        let mut child = Command::new(&binary)
+            .arg(command)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        drop(child.stdout.take());
+        let output = child.wait_with_output().unwrap();
+        assert_eq!(output.status.code(), Some(1), "command: {command}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("Error writing"),
+            "command: {command}, stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/crates/standout/tests/structured_output_projection.rs
+++ b/crates/standout/tests/structured_output_projection.rs
@@ -3,7 +3,9 @@
 use clap::Command;
 use serde_json::{json, Value};
 use standout::cli::hooks::TextOutput;
-use standout::cli::{App, Output, RenderedOutput, RunResult};
+use standout::cli::{
+    App, ExitStatus, Output, RenderedOutput, RunErrorKind, RunResult, SuccessKind,
+};
 use standout::tabular::{Column, Width};
 use standout::{CsvProjection, OutputMode, StructuredOutputProjection};
 
@@ -88,7 +90,7 @@ fn direct_dispatch(app: &App, mode: OutputMode) -> String {
     let RunResult::Handled(output) = app.dispatch(matches, mode) else {
         panic!("expected handled output")
     };
-    output
+    output.into_string()
 }
 
 #[test]
@@ -131,9 +133,10 @@ fn commands_without_a_projection_keep_automatic_csv_flattening() {
 #[test]
 fn run_to_string_and_output_file_use_the_same_projection() {
     let app = app();
-    let RunResult::Handled(output) =
-        app.run_to_string(command(), ["rustloc", "summary", "--output=csv"])
-    else {
+    let result = app.run_to_string(command(), ["rustloc", "summary", "--output=csv"]);
+    assert_eq!(result.exit_status(), Some(ExitStatus::SUCCESS));
+    assert_eq!(result.success_kind(), Some(SuccessKind::Command));
+    let RunResult::Handled(output) = result else {
         panic!("expected handled output")
     };
     assert_eq!(output, EXPECTED_CSV);
@@ -141,14 +144,40 @@ fn run_to_string_and_output_file_use_the_same_projection() {
     let tempdir = tempfile::tempdir().unwrap();
     let output_path = tempdir.path().join("summary.csv");
     let output_arg = format!("--output-file-path={}", output_path.display());
-    let RunResult::Handled(stdout) = app.run_to_string(
+    let file_result = app.run_to_string(
         command(),
         ["rustloc", "summary", "--output=csv", &output_arg],
-    ) else {
+    );
+    assert_eq!(file_result.exit_status(), Some(ExitStatus::SUCCESS));
+    let RunResult::Handled(stdout) = file_result else {
         panic!("expected handled output")
     };
     assert!(stdout.is_empty());
     assert_eq!(std::fs::read_to_string(output_path).unwrap(), EXPECTED_CSV);
+}
+
+#[test]
+fn projection_failures_are_typed_render_errors() {
+    let projection = StructuredOutputProjection::csv(
+        CsvProjection::builder("missing.items")
+            .column(column("language", "LANGUAGE"))
+            .build(),
+    );
+    let app = App::builder()
+        .command_with(
+            "summary",
+            |_matches, _ctx| Ok(Output::Render(response())),
+            |config| config.structured_output_projection(projection),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = app.run_to_string(command(), ["rustloc", "summary", "--output=csv"]);
+
+    assert_eq!(result.exit_status(), Some(ExitStatus::FAILURE));
+    assert_eq!(result.error_kind(), Some(RunErrorKind::Render));
+    assert!(result.error().unwrap().contains("missing.items"));
 }
 
 #[test]

--- a/crates/standout/tests/typed_outcomes.rs
+++ b/crates/standout/tests/typed_outcomes.rs
@@ -1,0 +1,197 @@
+use clap::Command;
+use serde_json::json;
+use standout::cli::{
+    App, ExitStatus, HandlerResult, HookError, HookPhase, Hooks, Output, OutputKind, RunErrorKind,
+    RunResult, SuccessKind,
+};
+
+fn command() -> Command {
+    Command::new("app")
+        .version("1.2.3")
+        .subcommand(Command::new("go"))
+}
+
+fn success_app() -> App {
+    App::builder()
+        .command(
+            "go",
+            |_matches, _ctx| Ok(Output::Render(json!({ "message": "ok" }))),
+            "{{ message }}",
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn clap_help_and_version_are_typed_successes() {
+    let app = success_app();
+
+    let help = app.run_to_string(command(), ["app", "--help"]);
+    assert_eq!(help.exit_status(), Some(ExitStatus::SUCCESS));
+    assert_eq!(help.success_kind(), Some(SuccessKind::ClapHelp));
+    assert!(help.output().unwrap().contains("Usage:"));
+
+    let version = app.run_to_string(command(), ["app", "--version"]);
+    assert_eq!(version.exit_status(), Some(ExitStatus::SUCCESS));
+    assert_eq!(version.success_kind(), Some(SuccessKind::ClapVersion));
+    assert!(version.output().unwrap().contains("1.2.3"));
+}
+
+#[test]
+fn clap_usage_error_is_status_two() {
+    let result = success_app().run_to_string(command(), ["app", "--unknown"]);
+    assert_eq!(result.exit_status(), Some(ExitStatus::USAGE_ERROR));
+    assert_eq!(result.error_kind(), Some(RunErrorKind::ClapUsage));
+    assert!(result.error().unwrap().contains("unexpected argument"));
+}
+
+#[test]
+fn command_silent_and_binary_success_are_status_zero() {
+    let text = success_app().run_to_string(command(), ["app", "go"]);
+    assert_eq!(text.exit_status(), Some(ExitStatus::SUCCESS));
+    assert_eq!(text.output(), Some("ok"));
+
+    let silent = App::builder()
+        .command(
+            "go",
+            |_matches, _ctx| -> HandlerResult<()> { Ok(Output::Silent) },
+            "",
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+        .run_to_string(command(), ["app", "go"]);
+    assert_eq!(silent.exit_status(), Some(ExitStatus::SUCCESS));
+    assert_eq!(silent.output(), Some(""));
+
+    let binary = App::builder()
+        .command(
+            "go",
+            |_matches, _ctx| -> HandlerResult<()> {
+                Ok(Output::Binary {
+                    data: vec![0, 1, 2],
+                    filename: "data.bin".into(),
+                })
+            },
+            "",
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+        .run_to_string(command(), ["app", "go"]);
+    assert_eq!(binary.exit_status(), Some(ExitStatus::SUCCESS));
+    assert_eq!(binary.binary(), Some((&[0, 1, 2][..], "data.bin")));
+}
+
+#[test]
+fn handler_and_each_hook_phase_keep_their_origin() {
+    let handler = App::builder()
+        .command(
+            "go",
+            |_matches, _ctx| -> HandlerResult<serde_json::Value> {
+                Err(anyhow::anyhow!("handler failed"))
+            },
+            "",
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+        .run_to_string(command(), ["app", "go"]);
+    assert_eq!(handler.exit_status(), Some(ExitStatus::FAILURE));
+    assert_eq!(handler.error_kind(), Some(RunErrorKind::Handler));
+
+    for (hooks, phase) in [
+        (
+            Hooks::new().pre_dispatch(|_, _| Err(HookError::pre_dispatch("no"))),
+            HookPhase::PreDispatch,
+        ),
+        (
+            Hooks::new().post_dispatch(|_, _, _| Err(HookError::post_dispatch("no"))),
+            HookPhase::PostDispatch,
+        ),
+        (
+            Hooks::new().post_output(|_, _, _| Err(HookError::post_output("no"))),
+            HookPhase::PostOutput,
+        ),
+    ] {
+        let result = App::builder()
+            .command(
+                "go",
+                |_matches, _ctx| Ok(Output::Render(json!({ "message": "ok" }))),
+                "{{ message }}",
+            )
+            .unwrap()
+            .hooks("go", hooks)
+            .build()
+            .unwrap()
+            .run_to_string(command(), ["app", "go"]);
+        assert_eq!(result.exit_status(), Some(ExitStatus::FAILURE));
+        assert_eq!(result.error_kind(), Some(RunErrorKind::Hook(phase)));
+    }
+}
+
+#[test]
+fn render_and_output_file_write_failures_are_typed() {
+    let render = App::builder()
+        .command(
+            "go",
+            |_matches, _ctx| Ok(Output::Render(json!({ "message": "ok" }))),
+            "{{",
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+        .run_to_string(command(), ["app", "go"]);
+    assert_eq!(render.error_kind(), Some(RunErrorKind::Render));
+    assert_eq!(render.exit_status(), Some(ExitStatus::FAILURE));
+
+    let tempdir = tempfile::tempdir().unwrap();
+    let directory = tempdir.path().to_str().unwrap();
+    let write =
+        success_app().run_to_string(command(), ["app", "--output-file-path", directory, "go"]);
+    assert_eq!(
+        write.error_kind(),
+        Some(RunErrorKind::FinalWrite(OutputKind::Text))
+    );
+    assert_eq!(write.exit_status(), Some(ExitStatus::FAILURE));
+
+    let binary_app = App::builder()
+        .command(
+            "go",
+            |_matches, _ctx| -> HandlerResult<()> {
+                Ok(Output::Binary {
+                    data: vec![0, 1, 2],
+                    filename: "data.bin".into(),
+                })
+            },
+            "",
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+    let binary_write =
+        binary_app.run_to_string(command(), ["app", "--output-file-path", directory, "go"]);
+    assert_eq!(
+        binary_write.error_kind(),
+        Some(RunErrorKind::FinalWrite(OutputKind::Binary))
+    );
+    assert_eq!(binary_write.exit_status(), Some(ExitStatus::FAILURE));
+}
+
+#[test]
+fn output_file_success_is_silent_and_no_match_has_no_status() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let path = tempdir.path().join("output.txt");
+    let path_string = path.to_string_lossy().into_owned();
+    let result =
+        success_app().run_to_string(command(), ["app", "--output-file-path", &path_string, "go"]);
+    assert_eq!(result.exit_status(), Some(ExitStatus::SUCCESS));
+    assert_eq!(result.output(), Some(""));
+    assert_eq!(std::fs::read_to_string(path).unwrap(), "ok");
+
+    let no_match = success_app().run_to_string(command(), ["app"]);
+    assert!(matches!(&no_match, RunResult::NoMatch(_)));
+    assert_eq!(no_match.exit_status(), None);
+    assert_eq!(no_match.error_kind(), None);
+}

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -46,6 +46,7 @@
 
 ## Framework Topics
 
+- [Execution Outcomes](./topics/execution-outcomes.md)
 - [Output Modes](./topics/output-modes.md)
 - [App Configuration](./topics/app-configuration.md)
 - [Testing](./topics/testing.md)

--- a/docs/guides/intro-to-testing.md
+++ b/docs/guides/intro-to-testing.md
@@ -496,12 +496,22 @@ TestHarness::new()
 // TestResult
 result.assert_success();                // Handled / Silent / Binary
 result.assert_no_match();               // clap didn't match any subcommand
+result.assert_exit_status(ExitStatus::SUCCESS);
+result.assert_error_kind(RunErrorKind::Handler);
 result.assert_stdout_contains("hi");
 result.assert_stdout_eq("hi\n");
 result.stdout();                        // &str
 result.outcome();                       // &RunResult, for bespoke assertions
 result.binary();                        // Option<(&[u8], &str)> for Binary
+result.exit_status();                   // Option<ExitStatus>; None for NoMatch
+result.success_kind();                  // command / Clap help / Clap version
+result.error_kind();                    // typed failure origin
 ```
+
+The harness captures the pipeline before the real stdout/stderr write. Use it
+for typed parser, handler, hook, render, pipe, and output-file outcomes. Keep a
+small process-level test for OS exit codes, stream routing, and broken final
+writers.
 
 ## Appendix: common pitfalls
 

--- a/docs/guides/intro-to-testing.md
+++ b/docs/guides/intro-to-testing.md
@@ -493,13 +493,24 @@ TestHarness::new()
     // execute
     .run(&app, cmd, ["binname", "subcommand", "--flag"])
 
-// TestResult
+// TestResult: choose the assertion group that matches the observed outcome.
+
+// Success
 result.assert_success();                // Handled / Silent / Binary
-result.assert_no_match();               // clap didn't match any subcommand
 result.assert_exit_status(ExitStatus::SUCCESS);
-result.assert_error_kind(RunErrorKind::Handler);
 result.assert_stdout_contains("hi");
 result.assert_stdout_eq("hi\n");
+
+// No match
+result.assert_no_match();               // clap didn't match any subcommand
+assert_eq!(result.exit_status(), None);  // fallback owns the eventual status
+
+// Error
+result.assert_error();
+result.assert_exit_status(ExitStatus::FAILURE);
+result.assert_error_kind(RunErrorKind::Handler);
+
+// Accessors for any outcome
 result.stdout();                        // &str
 result.outcome();                       // &RunResult, for bespoke assertions
 result.binary();                        // Option<(&[u8], &str)> for Binary

--- a/docs/topics/app-configuration.md
+++ b/docs/topics/app-configuration.md
@@ -320,13 +320,16 @@ pub struct App {
 ### Standard Execution
 
 ```rust
-if let Some(matches) = app.run(Cli::command(), std::env::args()) {
-    // Standout didn't handle this command, fall back to legacy
-    legacy_dispatch(matches);
+if !app.run(Cli::command(), std::env::args()) {
+    // Standout did not handle this command; fall back to legacy dispatch.
+    legacy_dispatch();
 }
 ```
 
-Parses args, dispatches to handler, prints output. Returns `Option<ArgMatches>`—`None` if handled, `Some(matches)` for fallback.
+Parses args, dispatches to a handler, and performs the final write. It returns
+`true` when Standout handled the command and `false` for an unmatched fallback.
+Help/version and successes use stdout/status 0, usage errors use stderr/status
+2, and runtime/write failures use stderr/status 1.
 
 ### Capture Output
 
@@ -336,11 +339,15 @@ For testing, post-processing, or when you need the output string:
 match app.run_to_string(cmd, args) {
     RunResult::Handled(output) => { /* use output string */ }
     RunResult::Binary(bytes, filename) => { /* handle binary */ }
+    RunResult::Error(error) => { /* inspect error.kind() */ }
     RunResult::NoMatch(matches) => { /* fallback dispatch */ }
+    _ => {}
 }
 ```
 
-Returns `RunResult` instead of printing.
+Returns `RunResult` instead of printing. Use `exit_status()`, `success_kind()`,
+and `error_kind()` for typed assertions; see [Execution
+Outcomes](./execution-outcomes.md).
 
 ### Parse Only
 

--- a/docs/topics/execution-outcomes.md
+++ b/docs/topics/execution-outcomes.md
@@ -1,0 +1,69 @@
+# Execution Outcomes
+
+Standout carries shell semantics as typed data from argument parsing through
+dispatch, rendering, hooks, output files, and final writes. Applications can let
+`App::run` own output without losing the distinction between a usage error and a
+runtime failure.
+
+## Status and streams
+
+| Outcome | Stream used by `run()` | Status |
+| --- | --- | --- |
+| Help or version | stdout | `0` |
+| Successful rendered text or binary | stdout | `0` |
+| `Output::Silent` | none | `0` |
+| `--output-file-path` success | file only | `0` |
+| Clap usage error | stderr | `2` |
+| Handler, hook, render, pipe, or write failure | stderr | `1` |
+
+Warning flushing happens after the primary output and does not replace its
+status. A final text or binary write failure does replace a successful status
+with `1`.
+
+## Capturing typed metadata
+
+`run_to_string` keeps output in-process and returns `RunResult`. Existing
+string-oriented accessors remain available, while typed methods expose the
+semantics:
+
+```rust
+use standout::cli::{ExitStatus, RunResult, SuccessKind};
+
+let result = app.run_to_string(command, args);
+
+match &result {
+    RunResult::Handled(output) => println!("{}", output),
+    RunResult::Binary(bytes, filename) => consume(bytes, filename),
+    RunResult::Error(error) => eprintln!("{}", error),
+    RunResult::NoMatch(matches) => legacy_dispatch(matches),
+    RunResult::Silent => {}
+    _ => {}
+}
+
+assert_eq!(result.exit_status(), Some(ExitStatus::SUCCESS));
+assert_eq!(result.success_kind(), Some(SuccessKind::Command));
+assert_eq!(result.error_kind(), None);
+```
+
+`RunOutput` and `RunError` dereference to `str`, implement `Display`, and expose
+`as_str()` / `into_string()` for callers that used the tuple payloads as text.
+`RunError::kind()` identifies `ClapUsage`, `Handler`, `Hook(phase)`, `Render`, or
+`FinalWrite(Text|Binary)`.
+
+## No-match is a handoff, not an error
+
+`RunResult::NoMatch` retains the parsed `ArgMatches` for partial adoption. It has
+no framework exit status: `exit_status()` returns `None`, `run()` returns
+`false`, and Standout emits nothing. The fallback dispatcher still owns that
+command and its eventual status.
+
+## Framework-owned final writes
+
+`run()` writes successful text and binary bytes to stdout, diagnostics to
+stderr, and exits with the typed non-zero status when execution fails. The
+suggested filename on binary output remains available to capture callers; use
+`--output-file-path` when the framework should write either text or binary to a
+file instead of stdout.
+
+Capture APIs do not perform the final stdout/stderr write, but file redirection
+is part of dispatch and therefore reports typed `FinalWrite` failures directly.

--- a/docs/topics/output-modes.md
+++ b/docs/topics/output-modes.md
@@ -217,7 +217,7 @@ myapp list --output=json --output-file-path=data.json
 Behavior:
 
 - Text output: written to file, nothing printed to stdout
-- Binary output: written to file (same as without flag)
+- Binary output: written to the requested file instead of stdout
 - Silent output: no-op
 
 After writing to file, stdout output is suppressed to prevent double-printing.

--- a/docs/topics/testing.md
+++ b/docs/topics/testing.md
@@ -56,6 +56,11 @@ Argument parsing is clap's responsibility, and clap has an extensive test suite 
 
 `TestHarness` (in the `standout-test` crate) is the unified in-process runner. It wraps `App::run_to_string` with fluent setup for every injectable piece of state:
 
+Its `TestResult` also exposes `exit_status()`, `success_kind()`, and
+`error_kind()`, with assertions for typed status and failure origin. `NoMatch`
+returns no framework status because the fallback dispatcher still owns the
+command.
+
 - Env vars (real `std::env::set_var`, originals captured and restored on drop)
 - Working directory (real `std::env::set_current_dir`, original restored on drop)
 - Fixture files (written into a `tempfile::TempDir`)


### PR DESCRIPTION
## Summary

- carry typed success, error origin, and shell status through Clap parsing, handlers, hook phases, rendering, output-file writes, and capture results
- route framework-owned final text/binary writes through one checked writer seam with stdout/stderr and exit-code semantics
- expose typed TestHarness assertions and document execution, error, testing, and partial-adoption behavior
- add capture and real-process matrix coverage, including broken writers and warning flushing

## Context

This keeps the existing `run() -> bool` unmatched-command contract and the string-oriented `run_to_string()` accessors. The existing tuple variants now carry `RunOutput` / `RunError` wrappers that dereference to `str`, while typed metadata remains available without parsing messages.

`NoMatch` is intentionally status-free: it remains a handoff to legacy dispatch, never a synthesized usage error. Binary capture still preserves bytes and the suggested filename; framework-owned final binary output goes to stdout unless `--output-file-path` redirects it.

Out of scope: per-command structured-output projections and CSV shaping from #200. The integration hotspot is shared execution plumbing in `crates/standout/src/cli/builder/execution.rs` and `crates/standout/src/cli/dispatch.rs`; projection behavior itself is untouched.

## Verification

- `pixi run test` — 1,722 tests passed
- `pixi run lint` — 31 checks passed

closes #201