### PR TITLE
Cascade terminal width into template table helpers

### DIFF
--- a/crates/standout-render/docs/guides/intro-to-tabular.md
+++ b/crates/standout-render/docs/guides/intro-to-tabular.md
@@ -306,6 +306,11 @@ sub-columns, borders, padding, truncation, and wrapping. MiniJinja `col`,
 `display_width`, padding, truncation, `tabular`, and `table` operations receive
 the renderer or application policy automatically.
 
+MiniJinja `tabular()` and `table()` also use the terminal width supplied by the
+current application render context when `width` is omitted. An explicit
+`width=...` argument takes precedence. When terminal-width detection is
+unavailable, both helpers use a deterministic 80-column fallback.
+
 Policy-aware counterparts are also available for direct construction, including
 `TabularFormatter::with_widths_and_ambiguous_width`,
 `TabularFormatter::from_type_with_ambiguous_width`,

--- a/crates/standout-render/src/tabular/filters.rs
+++ b/crates/standout-render/src/tabular/filters.rs
@@ -56,7 +56,10 @@ use super::util::{
     display_width_with_policy, pad_center_with_policy, pad_left_with_policy, pad_right_with_policy,
     truncate_end_with_policy, truncate_middle_with_policy, truncate_start_with_policy,
 };
-use crate::width::WidthPolicySource;
+use crate::width::RenderWidthSource;
+
+/// Deterministic helper width when the render boundary cannot detect a terminal.
+const DEFAULT_TABLE_WIDTH: usize = 80;
 
 /// Register all tabular-related filters on a MiniJinja environment.
 ///
@@ -85,16 +88,16 @@ pub fn register_tabular_filters_with_policy(
     env: &mut Environment<'static>,
     policy: crate::AmbiguousWidth,
 ) {
-    register_tabular_filters_with_source(env, WidthPolicySource::new(policy));
+    register_tabular_filters_with_source(env, RenderWidthSource::new(policy));
 }
 
 pub(crate) fn register_tabular_filters_with_source(
     env: &mut Environment<'static>,
-    policy: WidthPolicySource,
+    widths: RenderWidthSource,
 ) {
     // col filter: {{ value | col(width) }} or {{ value | col(width, align="right", truncate="middle") }}
     // "fill" support (Option B): {{ value | col("fill", width=80) }}
-    let col_policy = policy.clone();
+    let col_policy = widths.clone();
     env.add_filter(
         "col",
         move |value: Value,
@@ -143,18 +146,18 @@ pub(crate) fn register_tabular_filters_with_source(
                 &align,
                 &truncate,
                 &ellipsis,
-                col_policy.get(),
+                col_policy.ambiguous_width(),
             ))
         },
     );
 
     // pad_left filter: {{ value | pad_left(width) }}
     // BBCode tags are stripped for width measurement; padding preserves tags.
-    let pad_left_policy = policy.clone();
+    let pad_left_policy = widths.clone();
     env.add_filter("pad_left", move |value: Value, width: usize| -> String {
         let text = value.to_string();
         let stripped = strip_tags(&text);
-        let visible_width = display_width_with_policy(&stripped, pad_left_policy.get());
+        let visible_width = display_width_with_policy(&stripped, pad_left_policy.ambiguous_width());
         if visible_width >= width {
             text
         } else {
@@ -164,11 +167,12 @@ pub(crate) fn register_tabular_filters_with_source(
 
     // pad_right filter: {{ value | pad_right(width) }}
     // BBCode tags are stripped for width measurement; padding preserves tags.
-    let pad_right_policy = policy.clone();
+    let pad_right_policy = widths.clone();
     env.add_filter("pad_right", move |value: Value, width: usize| -> String {
         let text = value.to_string();
         let stripped = strip_tags(&text);
-        let visible_width = display_width_with_policy(&stripped, pad_right_policy.get());
+        let visible_width =
+            display_width_with_policy(&stripped, pad_right_policy.ambiguous_width());
         if visible_width >= width {
             text
         } else {
@@ -178,11 +182,12 @@ pub(crate) fn register_tabular_filters_with_source(
 
     // pad_center filter: {{ value | pad_center(width) }}
     // BBCode tags are stripped for width measurement; padding preserves tags.
-    let pad_center_policy = policy.clone();
+    let pad_center_policy = widths.clone();
     env.add_filter("pad_center", move |value: Value, width: usize| -> String {
         let text = value.to_string();
         let stripped = strip_tags(&text);
-        let visible_width = display_width_with_policy(&stripped, pad_center_policy.get());
+        let visible_width =
+            display_width_with_policy(&stripped, pad_center_policy.ambiguous_width());
         if visible_width >= width {
             text
         } else {
@@ -195,7 +200,7 @@ pub(crate) fn register_tabular_filters_with_source(
 
     // truncate_at filter: {{ value | truncate_at(width, "middle") }}
     // BBCode tags are stripped before truncation.
-    let truncate_policy = policy.clone();
+    let truncate_policy = widths.clone();
     env.add_filter(
         "truncate_at",
         move |value: Value,
@@ -209,21 +214,34 @@ pub(crate) fn register_tabular_filters_with_source(
             let ell = ellipsis.as_deref().unwrap_or("…");
 
             match pos {
-                "start" => truncate_start_with_policy(&stripped, width, ell, truncate_policy.get()),
-                "middle" => {
-                    truncate_middle_with_policy(&stripped, width, ell, truncate_policy.get())
-                }
-                _ => truncate_end_with_policy(&stripped, width, ell, truncate_policy.get()),
+                "start" => truncate_start_with_policy(
+                    &stripped,
+                    width,
+                    ell,
+                    truncate_policy.ambiguous_width(),
+                ),
+                "middle" => truncate_middle_with_policy(
+                    &stripped,
+                    width,
+                    ell,
+                    truncate_policy.ambiguous_width(),
+                ),
+                _ => truncate_end_with_policy(
+                    &stripped,
+                    width,
+                    ell,
+                    truncate_policy.ambiguous_width(),
+                ),
             }
         },
     );
 
     // display_width filter: {{ value | display_width }}
     // BBCode tags are stripped before measuring width.
-    let display_policy = policy.clone();
+    let display_policy = widths.clone();
     env.add_filter("display_width", move |value: Value| -> usize {
         let stripped = strip_tags(&value.to_string());
-        display_width_with_policy(&stripped, display_policy.get())
+        display_width_with_policy(&stripped, display_policy.ambiguous_width())
     });
 
     // style_as filter: {{ value | style_as("error") }} => [error]value[/error]
@@ -237,13 +255,13 @@ pub(crate) fn register_tabular_filters_with_source(
     });
 
     // Register global functions for creating formatters
-    register_table_functions(env, policy);
+    register_table_functions(env, widths);
 }
 
 /// Register global functions for creating table formatters.
-fn register_table_functions(env: &mut Environment<'static>, policy: WidthPolicySource) {
+fn register_table_functions(env: &mut Environment<'static>, widths: RenderWidthSource) {
     // tabular(columns, separator=?, width=?) -> TabularFormatter
-    let tabular_policy = policy.clone();
+    let tabular_widths = widths.clone();
     env.add_function(
         "tabular",
         move |columns: Value,
@@ -253,7 +271,10 @@ fn register_table_functions(env: &mut Environment<'static>, policy: WidthPolicyS
             let separator = kwargs
                 .get::<Option<String>>("separator")?
                 .unwrap_or_default();
-            let width = kwargs.get::<Option<usize>>("width")?.unwrap_or(80);
+            let width = kwargs
+                .get::<Option<usize>>("width")?
+                .or_else(|| tabular_widths.terminal_width())
+                .unwrap_or(DEFAULT_TABLE_WIDTH);
             kwargs.assert_all_used()?;
 
             let mut builder = TabularSpec::builder();
@@ -265,14 +286,17 @@ fn register_table_functions(env: &mut Environment<'static>, policy: WidthPolicyS
             }
 
             let spec = builder.build();
-            let formatter =
-                TabularFormatter::with_ambiguous_width(&spec, width, tabular_policy.get());
+            let formatter = TabularFormatter::with_ambiguous_width(
+                &spec,
+                width,
+                tabular_widths.ambiguous_width(),
+            );
             Ok(Value::from_object(formatter))
         },
     );
 
     // table(columns, border=?, header=?, header_style=?, width=?) -> Table
-    let table_policy = policy;
+    let table_widths = widths;
     env.add_function(
         "table",
         move |columns: Value, kwargs: minijinja::value::Kwargs| -> Result<Value, minijinja::Error> {
@@ -287,7 +311,10 @@ fn register_table_functions(env: &mut Environment<'static>, policy: WidthPolicyS
                 .get::<Option<bool>>("row_separator")?
                 .unwrap_or(false);
             let row_styles = kwargs.get::<Option<Value>>("row_styles")?;
-            let width = kwargs.get::<Option<usize>>("width")?.unwrap_or(80);
+            let width = kwargs
+                .get::<Option<usize>>("width")?
+                .or_else(|| table_widths.terminal_width())
+                .unwrap_or(DEFAULT_TABLE_WIDTH);
             kwargs.assert_all_used()?;
 
             let mut builder = TabularSpec::builder();
@@ -299,8 +326,12 @@ fn register_table_functions(env: &mut Environment<'static>, policy: WidthPolicyS
             }
 
             let spec = builder.build();
-            let mut table = Table::with_ambiguous_width(spec, width, table_policy.get())
-                .border(parse_border_style(&border));
+            let mut table = Table::with_ambiguous_width(
+                spec,
+                width,
+                table_widths.ambiguous_width(),
+            )
+            .border(parse_border_style(&border));
 
             // Set header if provided
             if let Some(h) = header {
@@ -368,10 +399,18 @@ fn register_table_functions(env: &mut Environment<'static>, policy: WidthPolicyS
 
 /// Parse column definitions from a template array value.
 fn parse_columns(columns: &Value) -> Result<Vec<Column>, minijinja::Error> {
+    // The framework list view passes the serialized TabularSpec, while direct
+    // helper calls commonly pass the columns array itself.
+    let columns = columns
+        .get_attr("columns")
+        .ok()
+        .filter(|value| !value.is_undefined() && !value.is_none())
+        .unwrap_or_else(|| columns.clone());
+
     let iter = columns.try_iter().map_err(|_| {
         minijinja::Error::new(
             minijinja::ErrorKind::InvalidOperation,
-            "columns must be an array",
+            "columns must be an array or a tabular spec",
         )
     })?;
 

--- a/crates/standout-render/src/tabular/formatter.rs
+++ b/crates/standout-render/src/tabular/formatter.rs
@@ -844,6 +844,16 @@ impl Object for TabularFormatter {
                     Ok(Value::from(formatted))
                 }
             }
+            "row_from" => {
+                if args.is_empty() {
+                    return Err(minijinja::Error::new(
+                        minijinja::ErrorKind::MissingArgument,
+                        "row_from() requires an object argument",
+                    ));
+                }
+
+                Ok(Value::from(self.row_from(&args[0])))
+            }
             "column_width" => {
                 // column_width(index) - get width of a specific column
                 if args.is_empty() {

--- a/crates/standout-render/src/template/engine.rs
+++ b/crates/standout-render/src/template/engine.rs
@@ -9,7 +9,7 @@ use minijinja::{Environment, Value};
 use std::collections::HashMap;
 
 use crate::error::RenderError;
-use crate::width::WidthPolicySource;
+use crate::width::RenderWidthSource;
 use crate::AmbiguousWidth;
 
 /// A template engine that can render templates with data.
@@ -44,6 +44,17 @@ pub trait TemplateEngine {
         self.render_template(template, data)
     }
 
+    /// Renders with terminal columns and an explicit ambiguous-width policy.
+    fn render_template_with_render_widths(
+        &self,
+        template: &str,
+        data: &serde_json::Value,
+        _terminal_width: Option<usize>,
+        policy: AmbiguousWidth,
+    ) -> Result<String, RenderError> {
+        self.render_template_with_width(template, data, policy)
+    }
+
     /// Adds a named template to the engine.
     ///
     /// The template is compiled and cached for later use via [`render_named`](Self::render_named).
@@ -62,6 +73,18 @@ pub trait TemplateEngine {
         _policy: AmbiguousWidth,
     ) -> Result<String, RenderError> {
         self.render_named(name, data)
+    }
+
+    /// Renders a named template with terminal columns and an explicit
+    /// ambiguous-width policy.
+    fn render_named_with_render_widths(
+        &self,
+        name: &str,
+        data: &serde_json::Value,
+        _terminal_width: Option<usize>,
+        policy: AmbiguousWidth,
+    ) -> Result<String, RenderError> {
+        self.render_named_with_width(name, data, policy)
     }
 
     /// Checks if a template with the given name exists.
@@ -87,6 +110,19 @@ pub trait TemplateEngine {
         _policy: AmbiguousWidth,
     ) -> Result<String, RenderError> {
         self.render_with_context(template, data, context)
+    }
+
+    /// Renders with additional context, terminal columns, and an explicit
+    /// ambiguous-width policy.
+    fn render_with_context_and_render_widths(
+        &self,
+        template: &str,
+        data: &serde_json::Value,
+        context: HashMap<String, serde_json::Value>,
+        _terminal_width: Option<usize>,
+        policy: AmbiguousWidth,
+    ) -> Result<String, RenderError> {
+        self.render_with_context_and_width(template, data, context, policy)
     }
 
     /// Whether this engine supports template includes (`{% include %}`).
@@ -130,16 +166,16 @@ pub trait TemplateEngine {
 /// ```
 pub struct MiniJinjaEngine {
     env: Environment<'static>,
-    width_policy: WidthPolicySource,
+    render_widths: RenderWidthSource,
 }
 
 impl MiniJinjaEngine {
     /// Creates a new MiniJinja engine with default filters registered.
     pub fn new() -> Self {
         let mut env = Environment::new();
-        let width_policy = WidthPolicySource::new(AmbiguousWidth::Narrow);
-        register_filters_with_source(&mut env, width_policy.clone());
-        Self { env, width_policy }
+        let render_widths = RenderWidthSource::new(AmbiguousWidth::Narrow);
+        register_filters_with_source(&mut env, render_widths.clone());
+        Self { env, render_widths }
     }
 
     /// Returns a reference to the underlying MiniJinja environment.
@@ -171,7 +207,7 @@ impl TemplateEngine for MiniJinjaEngine {
         template: &str,
         data: &serde_json::Value,
     ) -> Result<String, RenderError> {
-        let _policy = self.width_policy.scoped(AmbiguousWidth::Narrow);
+        let _widths = self.render_widths.scoped(AmbiguousWidth::Narrow, None);
         self.render_template_inner(template, data)
     }
 
@@ -181,7 +217,18 @@ impl TemplateEngine for MiniJinjaEngine {
         data: &serde_json::Value,
         policy: AmbiguousWidth,
     ) -> Result<String, RenderError> {
-        let _policy = self.width_policy.scoped(policy);
+        let _widths = self.render_widths.scoped(policy, None);
+        self.render_template_inner(template, data)
+    }
+
+    fn render_template_with_render_widths(
+        &self,
+        template: &str,
+        data: &serde_json::Value,
+        terminal_width: Option<usize>,
+        policy: AmbiguousWidth,
+    ) -> Result<String, RenderError> {
+        let _widths = self.render_widths.scoped(policy, terminal_width);
         self.render_template_inner(template, data)
     }
 
@@ -192,7 +239,7 @@ impl TemplateEngine for MiniJinjaEngine {
     }
 
     fn render_named(&self, name: &str, data: &serde_json::Value) -> Result<String, RenderError> {
-        let _policy = self.width_policy.scoped(AmbiguousWidth::Narrow);
+        let _widths = self.render_widths.scoped(AmbiguousWidth::Narrow, None);
         self.render_named_inner(name, data)
     }
 
@@ -202,7 +249,18 @@ impl TemplateEngine for MiniJinjaEngine {
         data: &serde_json::Value,
         policy: AmbiguousWidth,
     ) -> Result<String, RenderError> {
-        let _policy = self.width_policy.scoped(policy);
+        let _widths = self.render_widths.scoped(policy, None);
+        self.render_named_inner(name, data)
+    }
+
+    fn render_named_with_render_widths(
+        &self,
+        name: &str,
+        data: &serde_json::Value,
+        terminal_width: Option<usize>,
+        policy: AmbiguousWidth,
+    ) -> Result<String, RenderError> {
+        let _widths = self.render_widths.scoped(policy, terminal_width);
         self.render_named_inner(name, data)
     }
 
@@ -216,7 +274,7 @@ impl TemplateEngine for MiniJinjaEngine {
         data: &serde_json::Value,
         context: HashMap<String, serde_json::Value>,
     ) -> Result<String, RenderError> {
-        let _policy = self.width_policy.scoped(AmbiguousWidth::Narrow);
+        let _widths = self.render_widths.scoped(AmbiguousWidth::Narrow, None);
         self.render_with_context_inner(template, data, context)
     }
 
@@ -227,7 +285,19 @@ impl TemplateEngine for MiniJinjaEngine {
         context: HashMap<String, serde_json::Value>,
         policy: AmbiguousWidth,
     ) -> Result<String, RenderError> {
-        let _policy = self.width_policy.scoped(policy);
+        let _widths = self.render_widths.scoped(policy, None);
+        self.render_with_context_inner(template, data, context)
+    }
+
+    fn render_with_context_and_render_widths(
+        &self,
+        template: &str,
+        data: &serde_json::Value,
+        context: HashMap<String, serde_json::Value>,
+        terminal_width: Option<usize>,
+        policy: AmbiguousWidth,
+    ) -> Result<String, RenderError> {
+        let _widths = self.render_widths.scoped(policy, terminal_width);
         self.render_with_context_inner(template, data, context)
     }
 
@@ -296,10 +366,10 @@ pub fn register_filters(env: &mut Environment<'static>) {
 
 /// Registers Standout's custom filters with an explicit ambiguous-width policy.
 pub fn register_filters_with_policy(env: &mut Environment<'static>, policy: AmbiguousWidth) {
-    register_filters_with_source(env, WidthPolicySource::new(policy));
+    register_filters_with_source(env, RenderWidthSource::new(policy));
 }
 
-fn register_filters_with_source(env: &mut Environment<'static>, policy: WidthPolicySource) {
+fn register_filters_with_source(env: &mut Environment<'static>, widths: RenderWidthSource) {
     use minijinja::{Error, ErrorKind};
 
     // Newline filter
@@ -318,7 +388,7 @@ fn register_filters_with_source(env: &mut Environment<'static>, policy: WidthPol
     );
 
     // Register tabular filters
-    crate::tabular::filters::register_tabular_filters_with_source(env, policy);
+    crate::tabular::filters::register_tabular_filters_with_source(env, widths);
 }
 
 #[cfg(test)]
@@ -523,5 +593,57 @@ mod tests {
                 .unwrap(),
             "2"
         );
+    }
+
+    #[test]
+    fn table_helpers_use_render_width_unless_explicitly_overridden() {
+        let engine = MiniJinjaEngine::new();
+        let data = serde_json::Value::Null;
+        let tabular = r#"{% set t = tabular([{"width": "fill"}]) %}{{ t.row(["x"]) }}"#;
+        let table = r#"{% set t = table([{"width": "fill"}]) %}{{ t.row(["x"]) }}"#;
+        let explicit_tabular =
+            r#"{% set t = tabular([{"width": "fill"}], width=23) %}{{ t.row(["x"]) }}"#;
+        let explicit_table =
+            r#"{% set t = table([{"width": "fill"}], width=23) %}{{ t.row(["x"]) }}"#;
+
+        for template in [tabular, table] {
+            let output = engine
+                .render_template_with_render_widths(
+                    template,
+                    &data,
+                    Some(37),
+                    AmbiguousWidth::Narrow,
+                )
+                .unwrap();
+            assert_eq!(output.chars().count(), 37);
+        }
+
+        for template in [explicit_tabular, explicit_table] {
+            let output = engine
+                .render_template_with_render_widths(
+                    template,
+                    &data,
+                    Some(37),
+                    AmbiguousWidth::Narrow,
+                )
+                .unwrap();
+            assert_eq!(output.chars().count(), 23);
+        }
+    }
+
+    #[test]
+    fn table_helpers_fall_back_to_eighty_columns_without_a_render_width() {
+        let engine = MiniJinjaEngine::new();
+        let data = serde_json::Value::Null;
+
+        for template in [
+            r#"{% set t = tabular([{"width": "fill"}]) %}{{ t.row(["x"]) }}"#,
+            r#"{% set t = table([{"width": "fill"}]) %}{{ t.row(["x"]) }}"#,
+        ] {
+            let output = engine
+                .render_template_with_render_widths(template, &data, None, AmbiguousWidth::Narrow)
+                .unwrap();
+            assert_eq!(output.chars().count(), 80);
+        }
     }
 }

--- a/crates/standout-render/src/template/functions.rs
+++ b/crates/standout-render/src/template/functions.rs
@@ -706,7 +706,13 @@ pub fn render_with_context<T: Serialize>(
 
     // Pass 1: Template rendering with context
     let data_value = serde_json::to_value(data)?;
-    let template_output = engine.render_with_context(&template_content, &data_value, context)?;
+    let template_output = engine.render_with_context_and_render_widths(
+        &template_content,
+        &data_value,
+        context,
+        render_context.terminal_width,
+        render_context.ambiguous_width(),
+    )?;
 
     // Pass 2: BBParser style tag processing
     let final_output = apply_style_tags(&template_output, &styles, mode);
@@ -924,9 +930,19 @@ pub fn render_auto_with_engine(
 
         // Render template
         let template_output = if engine.has_template(template) {
-            engine.render_named(template, &combined_value)?
+            engine.render_named_with_render_widths(
+                template,
+                &combined_value,
+                render_context.terminal_width,
+                render_context.ambiguous_width(),
+            )?
         } else {
-            engine.render_template(template, &combined_value)?
+            engine.render_template_with_render_widths(
+                template,
+                &combined_value,
+                render_context.terminal_width,
+                render_context.ambiguous_width(),
+            )?
         };
 
         // Apply styles
@@ -993,15 +1009,17 @@ pub fn render_auto_with_engine_split(
 
         // Pass 1: Render template (this is the raw/intermediate output)
         let raw_output = if engine.has_template(template) {
-            engine.render_named_with_width(
+            engine.render_named_with_render_widths(
                 template,
                 &combined_value,
+                render_context.terminal_width,
                 render_context.ambiguous_width(),
             )?
         } else {
-            engine.render_template_with_width(
+            engine.render_template_with_render_widths(
                 template,
                 &combined_value,
+                render_context.terminal_width,
                 render_context.ambiguous_width(),
             )?
         };

--- a/crates/standout-render/src/template/renderer.rs
+++ b/crates/standout-render/src/template/renderer.rs
@@ -469,6 +469,7 @@ impl Renderer {
     pub fn render<T: Serialize>(&mut self, name: &str, data: &T) -> Result<String, RenderError> {
         let ambiguous_width =
             crate::detect_ambiguous_width_override().unwrap_or(self.ambiguous_width);
+        let terminal_width = crate::detect_terminal_width();
         // First, check if it's an inline template
         // We check this first to avoid filesystem lookups for known templates.
         // In debug mode, if it's a file-based template, we want to skip this check
@@ -498,18 +499,24 @@ impl Renderer {
         // In debug mode: only use engine cache if it's an inline template (which doesn't change on disk).
         let template_output = if !cfg!(debug_assertions) || is_inline {
             // Try to render with the engine's cached template
-            match self
-                .engine
-                .render_named_with_width(name, &data_value, ambiguous_width)
-            {
+            match self.engine.render_named_with_render_widths(
+                name,
+                &data_value,
+                terminal_width,
+                ambiguous_width,
+            ) {
                 Ok(output) => output,
                 Err(_) => {
                     // Template not in cache, load and render
                     self.ensure_registry_initialized()?;
                     let content = self.get_template_content(name)?;
                     self.engine.add_template(name, &content)?;
-                    self.engine
-                        .render_named_with_width(name, &data_value, ambiguous_width)?
+                    self.engine.render_named_with_render_widths(
+                        name,
+                        &data_value,
+                        terminal_width,
+                        ambiguous_width,
+                    )?
                 }
             }
         } else {
@@ -517,8 +524,12 @@ impl Renderer {
             self.ensure_registry_initialized()?;
             let content = self.get_template_content(name)?;
             self.engine.add_template(name, &content)?;
-            self.engine
-                .render_named_with_width(name, &data_value, ambiguous_width)?
+            self.engine.render_named_with_render_widths(
+                name,
+                &data_value,
+                terminal_width,
+                ambiguous_width,
+            )?
         };
 
         // Pass 2: BBParser style tag processing

--- a/crates/standout-render/src/width.rs
+++ b/crates/standout-render/src/width.rs
@@ -9,7 +9,7 @@ use console::strip_ansi_codes;
 use serde::{Deserialize, Serialize};
 use standout_bbparser::strip_tags;
 use std::sync::{
-    atomic::{AtomicU8, Ordering},
+    atomic::{AtomicU8, AtomicUsize, Ordering},
     Arc, Mutex, MutexGuard,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
@@ -34,60 +34,88 @@ pub struct WidthCalculator {
 }
 
 #[derive(Debug)]
-struct WidthPolicyState {
-    current: AtomicU8,
+struct RenderWidthState {
+    ambiguous_width: AtomicU8,
+    terminal_width: AtomicUsize,
     render_lock: Mutex<()>,
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct WidthPolicySource(Arc<WidthPolicyState>);
+pub(crate) struct RenderWidthSource(Arc<RenderWidthState>);
 
-pub(crate) struct WidthPolicyGuard<'a> {
-    source: &'a WidthPolicySource,
-    previous: AmbiguousWidth,
+pub(crate) struct RenderWidthGuard<'a> {
+    source: &'a RenderWidthSource,
+    previous_ambiguous_width: AmbiguousWidth,
+    previous_terminal_width: Option<usize>,
     _render_lock: MutexGuard<'a, ()>,
 }
 
-impl Drop for WidthPolicyGuard<'_> {
+impl Drop for RenderWidthGuard<'_> {
     fn drop(&mut self) {
-        self.source.store(self.previous);
+        self.source
+            .store_ambiguous_width(self.previous_ambiguous_width);
+        self.source
+            .store_terminal_width(self.previous_terminal_width);
     }
 }
 
-impl WidthPolicySource {
+impl RenderWidthSource {
     pub(crate) fn new(policy: AmbiguousWidth) -> Self {
-        Self(Arc::new(WidthPolicyState {
-            current: AtomicU8::new(policy as u8),
+        Self(Arc::new(RenderWidthState {
+            ambiguous_width: AtomicU8::new(policy as u8),
+            terminal_width: AtomicUsize::new(0),
             render_lock: Mutex::new(()),
         }))
     }
 
-    pub(crate) fn get(&self) -> AmbiguousWidth {
-        if self.0.current.load(Ordering::Relaxed) == AmbiguousWidth::Wide as u8 {
+    pub(crate) fn ambiguous_width(&self) -> AmbiguousWidth {
+        if self.0.ambiguous_width.load(Ordering::Relaxed) == AmbiguousWidth::Wide as u8 {
             AmbiguousWidth::Wide
         } else {
             AmbiguousWidth::Narrow
         }
     }
 
-    fn store(&self, policy: AmbiguousWidth) {
-        self.0.current.store(policy as u8, Ordering::Relaxed);
+    pub(crate) fn terminal_width(&self) -> Option<usize> {
+        match self.0.terminal_width.load(Ordering::Relaxed) {
+            0 => None,
+            width => Some(width),
+        }
     }
 
-    pub(crate) fn scoped(&self, policy: AmbiguousWidth) -> WidthPolicyGuard<'_> {
+    fn store_ambiguous_width(&self, policy: AmbiguousWidth) {
+        self.0
+            .ambiguous_width
+            .store(policy as u8, Ordering::Relaxed);
+    }
+
+    fn store_terminal_width(&self, width: Option<usize>) {
+        self.0
+            .terminal_width
+            .store(width.unwrap_or(0), Ordering::Relaxed);
+    }
+
+    pub(crate) fn scoped(
+        &self,
+        policy: AmbiguousWidth,
+        terminal_width: Option<usize>,
+    ) -> RenderWidthGuard<'_> {
         // A render that unwinds poisons the standard mutex. Recover its guard:
-        // policy restoration is handled by WidthPolicyGuard, so the protected
+        // restoration is handled by RenderWidthGuard, so the protected
         // state remains valid after a template/filter panic.
         let render_lock = self
             .0
             .render_lock
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let previous = self.get();
-        self.store(policy);
-        WidthPolicyGuard {
+        let previous_ambiguous_width = self.ambiguous_width();
+        let previous_terminal_width = self.terminal_width();
+        self.store_ambiguous_width(policy);
+        self.store_terminal_width(terminal_width);
+        RenderWidthGuard {
             source: self,
-            previous,
+            previous_ambiguous_width,
+            previous_terminal_width,
             _render_lock: render_lock,
         }
     }

--- a/crates/standout-test/tests/harness.rs
+++ b/crates/standout-test/tests/harness.rs
@@ -11,6 +11,7 @@ use standout::cli::{
     OutputKind, RunErrorKind, SuccessKind,
 };
 use standout::tabular::{Column, Width};
+use standout::views::list_view;
 use standout::{CsvProjection, StructuredOutputProjection};
 use standout_input::{ClipboardSource, EnvSource, InputChain, StdinSource};
 use standout_render::{AmbiguousWidth, OutputMode};
@@ -39,6 +40,36 @@ fn echo_command() -> Command {
         .subcommand(Command::new("echo").arg(clap::Arg::new("msg").required(false).index(1)))
 }
 
+#[derive(Clone, serde::Serialize)]
+struct WidthSensitiveItem {
+    name: &'static str,
+}
+
+fn build_framework_list_view_app() -> App {
+    App::builder()
+        .command(
+            "list",
+            |_matches, _ctx| {
+                let spec = standout::tabular::TabularSpec::builder()
+                    .column(Column::new(Width::Fill).key("name"))
+                    .build();
+                Ok(Output::Render(
+                    list_view(vec![WidthSensitiveItem { name: "cascade" }])
+                        .tabular_spec(spec)
+                        .build(),
+                ))
+            },
+            "standout/list-view",
+        )
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+fn list_command() -> Command {
+    Command::new("app").subcommand(Command::new("list"))
+}
+
 #[test]
 #[serial]
 fn simple_handler_returns_rendered_text() {
@@ -64,6 +95,43 @@ fn ambiguous_width_policy_can_be_injected_for_the_same_app_fixture() {
         .ambiguous_width(AmbiguousWidth::Wide)
         .run(&app, echo_command(), ["app", "echo", "↦≈Δ"]);
     wide.assert_stdout_eq("5");
+}
+
+#[test]
+#[serial]
+fn terminal_width_cascades_through_the_framework_list_view_template() {
+    let app = build_framework_list_view_app();
+
+    for width in [31, 47] {
+        let result =
+            TestHarness::new()
+                .terminal_width(width)
+                .run(&app, list_command(), ["app", "list"]);
+        result.assert_success();
+        let row = result
+            .stdout()
+            .lines()
+            .find(|line| line.contains("cascade"))
+            .expect("framework list view should render its tabular row");
+        assert_eq!(row.chars().count(), width);
+        drop(result);
+    }
+}
+
+#[test]
+#[serial]
+fn unknown_terminal_width_uses_the_framework_list_view_fallback() {
+    let app = build_framework_list_view_app();
+    let result = TestHarness::new()
+        .no_terminal_width()
+        .run(&app, list_command(), ["app", "list"]);
+    result.assert_success();
+    let row = result
+        .stdout()
+        .lines()
+        .find(|line| line.contains("cascade"))
+        .expect("framework list view should render its tabular row");
+    assert_eq!(row.chars().count(), 80);
 }
 
 #[test]

--- a/crates/standout-test/tests/harness.rs
+++ b/crates/standout-test/tests/harness.rs
@@ -51,7 +51,7 @@ fn build_framework_list_view_app() -> App {
             "list",
             |_matches, _ctx| {
                 let spec = standout::tabular::TabularSpec::builder()
-                    .column(Column::new(Width::Fill).key("name"))
+                    .column(Column::new(Width::Fill).right().key("name"))
                     .build();
                 Ok(Output::Render(
                     list_view(vec![WidthSensitiveItem { name: "cascade" }])
@@ -114,6 +114,30 @@ fn terminal_width_cascades_through_the_framework_list_view_template() {
             .find(|line| line.contains("cascade"))
             .expect("framework list view should render its tabular row");
         assert_eq!(row.chars().count(), width);
+        drop(result);
+    }
+}
+
+#[test]
+#[serial]
+fn terminal_width_places_right_aligned_field_at_the_right_edge() {
+    let app = build_framework_list_view_app();
+    let field = "cascade";
+
+    for width in [80, 120] {
+        let result =
+            TestHarness::new()
+                .terminal_width(width)
+                .run(&app, list_command(), ["app", "list"]);
+        result.assert_success();
+        let row = result
+            .stdout()
+            .lines()
+            .find(|line| line.contains(field))
+            .expect("framework list view should render its right-aligned field");
+        assert_eq!(row.chars().count(), width);
+        assert_eq!(row.find(field), Some(width - field.len()));
+        assert!(row.ends_with(field));
         drop(result);
     }
 }

--- a/crates/standout/src/cli/builder/rendering.rs
+++ b/crates/standout/src/cli/builder/rendering.rs
@@ -123,9 +123,10 @@ impl AppBuilder {
         // Pass 1: Template rendering via engine
         let minijinja_output = self
             .template_engine
-            .render_template_with_width(
+            .render_template_with_render_widths(
                 template,
                 &serde_json::Value::Object(combined_json_map),
+                render_ctx.terminal_width,
                 ambiguous_width,
             )
             .map_err(|e| SetupError::Template(e.to_string()))?;


### PR DESCRIPTION
## Summary

- carry detected terminal columns through the render-context/template-engine seam
- default `tabular()` and `table()` to that render width while preserving explicit `width=...` precedence and the documented 80-column fallback
- make the framework `standout/list-view` path consume its serialized tabular spec and row objects as intended
- cover direct helpers and real `TestHarness` application rendering at multiple widths

## Context

The root cause was that the MiniJinja helper closures only shared the render-scoped ambiguous-character policy; terminal columns stopped at `RenderContext`, so each helper independently chose 80. The implementation extends that same guarded per-render source with terminal width and adds defaulted `TemplateEngine` entry points so custom engines remain source-compatible.

The framework-path acceptance test exposed two missing pieces in the existing list-view seam: `tabular()` did not accept the serialized `TabularSpec` that the framework passes, and the formatter already had Rust `row_from` behavior but did not expose it to MiniJinja. Those compatibility fixes are limited to enabling the named acceptance path.

Out of scope: handlers, reusable application libraries, terminal detection policy, and structured output modes.

## Verification

- `pixi run test` — 1,836 tests passed
- `pixi run lint` — 31 checks passed
- focused helper and `TestHarness` width/fallback tests passed

closes #215