### PR TITLE
Add terminal-width release note

### DIFF
--- a/CHANGELOG/unreleased-215-terminal-width.md
+++ b/CHANGELOG/unreleased-215-terminal-width.md
@@ -1,0 +1,1 @@
+- Cascade detected or test-injected terminal width through the render/template seam into `tabular()` and `table()` defaults (issue #215, PR #217), while explicit helper widths still take precedence and 80 columns remains the deterministic fallback only when width is unavailable; the framework list-view path and `TestHarness` cover the behavior.


### PR DESCRIPTION
Add the missing unreleased changelog fragment for the terminal-width behavior delivered by #215 / #217.

closes #218

## Context

The 7.9.1 release preparation correctly refused an empty release because the terminal-width fix had no unreleased fragment. This PR adds the repository-standard single-bullet fragment so the release tooling can render that already-delivered behavior.

The scope is intentionally release-note-only. It does not change code, versions, the generated changelog, workflows, or release configuration.

## Checks

- `shipit changelog render` — passed; rendered 1 unreleased fragment and 5 version sections
- `pixi run test` — passed; 1,837 tests
- `pixi run lint` — passed; 31 checks