### PR TITLE
Honor COLUMNS in terminal-width resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+- Resolve terminal width from a valid positive `$COLUMNS` value before probing the terminal, while preserving explicit detector overrides and the existing 80-column tabular fallback (issue #220).
+
 ## 7.9.1 - 2026-07-19
 
 - Cascade detected or test-injected terminal width through the render/template seam into `tabular()` and `table()` defaults (issue #215, PR #217), while explicit helper widths still take precedence and 80 columns remains the deterministic fallback only when width is unavailable; the framework list-view path and `TestHarness` cover the behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Unreleased
 
-- Resolve terminal width from a valid positive `$COLUMNS` value before probing the terminal, while preserving explicit detector overrides and the existing 80-column tabular fallback (issue #220).
+- Resolve terminal width from a valid positive `$COLUMNS` value before probing the terminal, while preserving explicit detector overrides and the existing 80-column tabular fallback (issue #220, PR #221).
 
 ## 7.9.1 - 2026-07-19
 

--- a/CHANGELOG/unreleased-220-columns-width.md
+++ b/CHANGELOG/unreleased-220-columns-width.md
@@ -1,0 +1,1 @@
+- Resolve terminal width from a valid positive `$COLUMNS` value before probing the terminal, while preserving explicit detector overrides and the existing 80-column tabular fallback (issue #220).

--- a/CHANGELOG/unreleased-220-columns-width.md
+++ b/CHANGELOG/unreleased-220-columns-width.md
@@ -1,1 +1,1 @@
-- Resolve terminal width from a valid positive `$COLUMNS` value before probing the terminal, while preserving explicit detector overrides and the existing 80-column tabular fallback (issue #220).
+- Resolve terminal width from a valid positive `$COLUMNS` value before probing the terminal, while preserving explicit detector overrides and the existing 80-column tabular fallback (issue #220, PR #221).

--- a/crates/standout-render/docs/guides/intro-to-tabular.md
+++ b/crates/standout-render/docs/guides/intro-to-tabular.md
@@ -308,8 +308,10 @@ the renderer or application policy automatically.
 
 MiniJinja `tabular()` and `table()` also use the terminal width supplied by the
 current application render context when `width` is omitted. An explicit
-`width=...` argument takes precedence. When terminal-width detection is
-unavailable, both helpers use a deterministic 80-column fallback.
+`width=...` argument takes precedence. The default terminal-width detector
+consults a valid positive `$COLUMNS` value before probing the terminal. When
+neither source resolves a width, both helpers use a deterministic 80-column
+fallback.
 
 Policy-aware counterparts are also available for direct construction, including
 `TabularFormatter::with_widths_and_ambiguous_width`,

--- a/crates/standout-render/src/environment.rs
+++ b/crates/standout-render/src/environment.rs
@@ -12,7 +12,7 @@
 //! # Usage
 //!
 //! In application code, call the `detect_*` functions. They resolve to real
-//! terminal queries by default:
+//! process and terminal state by default:
 //!
 //! ```rust
 //! use standout_render::{detect_terminal_width, detect_is_tty, detect_color_capability};
@@ -57,11 +57,13 @@ static COLOR_DETECTOR: Lazy<Mutex<ColorDetector>> =
 static AMBIGUOUS_WIDTH_DETECTOR: Lazy<Mutex<AmbiguousWidthDetector>> =
     Lazy::new(|| Mutex::new(default_ambiguous_width_detector));
 
-/// Overrides the detector used to query terminal width.
+/// Overrides the detector used to resolve terminal width.
 ///
-/// Accepts a `fn` pointer or a non-capturing closure. The detector returns
-/// `Some(cols)` when a width can be determined and `None` when output is not
-/// a terminal. Useful to force a fixed width in snapshot tests.
+/// The default detector consults a valid positive `$COLUMNS` value before
+/// probing the terminal. An override replaces that entire resolution, returning
+/// `Some(cols)` when a width should be used and `None` when it is unavailable.
+/// Accepts a `fn` pointer or a non-capturing closure; useful to force a fixed
+/// width in tests.
 pub fn set_terminal_width_detector(detector: WidthDetector) {
     *WIDTH_DETECTOR.lock().unwrap() = detector;
 }
@@ -91,7 +93,13 @@ pub fn set_ambiguous_width_detector(detector: AmbiguousWidthDetector) {
     *AMBIGUOUS_WIDTH_DETECTOR.lock().unwrap() = detector;
 }
 
-/// Returns the current terminal width in columns, or `None` when unavailable.
+/// Resolves the current terminal width in columns.
+///
+/// By default, a valid positive `$COLUMNS` value takes precedence over probing
+/// the terminal. Returns `None` when neither source provides a width. Layout
+/// helpers may apply their own documented fallback when width is unavailable.
+/// A detector installed with [`set_terminal_width_detector`] replaces this
+/// default resolution so tests and applications can control the result.
 pub fn detect_terminal_width() -> Option<usize> {
     // Copy the fn pointer out and release the lock before invoking the
     // detector. Holding the mutex across the call would poison it on panic
@@ -119,7 +127,20 @@ pub fn detect_ambiguous_width_override() -> Option<AmbiguousWidth> {
 }
 
 fn default_width_detector() -> Option<usize> {
-    terminal_size::terminal_size().map(|(w, _)| w.0 as usize)
+    resolve_terminal_width(std::env::var_os("COLUMNS").as_deref(), || {
+        terminal_size::terminal_size().map(|(width, _)| width.0 as usize)
+    })
+}
+
+fn resolve_terminal_width(
+    columns: Option<&std::ffi::OsStr>,
+    probe_terminal: impl FnOnce() -> Option<usize>,
+) -> Option<usize> {
+    columns
+        .and_then(std::ffi::OsStr::to_str)
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|&width| width > 0)
+        .or_else(probe_terminal)
 }
 
 fn default_tty_detector() -> bool {
@@ -135,7 +156,7 @@ fn default_ambiguous_width_detector() -> Option<AmbiguousWidth> {
 }
 
 /// Resets every environment detector in this module to its default
-/// (real-terminal) implementation.
+/// (real process-environment and terminal) implementation.
 ///
 /// Tests that installed overrides should call this in teardown to avoid
 /// leaking state into sibling tests. For panic-safe cleanup, prefer
@@ -188,7 +209,28 @@ impl Drop for DetectorGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use serial_test::serial;
+    use std::ffi::{OsStr, OsString};
+
+    struct ColumnsGuard(Option<OsString>);
+
+    impl ColumnsGuard {
+        fn set(value: &str) -> Self {
+            let original = std::env::var_os("COLUMNS");
+            std::env::set_var("COLUMNS", value);
+            Self(original)
+        }
+    }
+
+    impl Drop for ColumnsGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => std::env::set_var("COLUMNS", value),
+                None => std::env::remove_var("COLUMNS"),
+            }
+        }
+    }
 
     #[test]
     #[serial]
@@ -198,6 +240,17 @@ mod tests {
         assert_eq!(detect_terminal_width(), Some(42));
         set_terminal_width_detector(|| None);
         assert_eq!(detect_terminal_width(), None);
+    }
+
+    #[test]
+    #[serial]
+    fn default_width_resolution_honors_columns() {
+        let _guard = DetectorGuard::new();
+        let _columns = ColumnsGuard::set("47");
+
+        reset_detectors();
+
+        assert_eq!(detect_terminal_width(), Some(47));
     }
 
     #[test]
@@ -266,5 +319,32 @@ mod tests {
         set_terminal_width_detector(boom);
         drop(DetectorGuard::new());
         let _ = detect_terminal_width();
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(128))]
+
+        #[test]
+        fn columns_values_are_resolved_without_panicking(value in any::<String>()) {
+            let expected = value
+                .parse::<usize>()
+                .ok()
+                .filter(|&width| width > 0)
+                .or(Some(73));
+            prop_assert_eq!(
+                resolve_terminal_width(Some(OsStr::new(&value)), || Some(73)),
+                expected,
+            );
+        }
+
+        #[test]
+        fn every_positive_columns_width_precedes_the_terminal_probe(width in 1usize..) {
+            prop_assert_eq!(
+                resolve_terminal_width(Some(OsStr::new(&width.to_string())), || {
+                    panic!("valid COLUMNS must prevent terminal probing")
+                }),
+                Some(width),
+            );
+        }
     }
 }

--- a/crates/standout-render/src/tabular/filters.rs
+++ b/crates/standout-render/src/tabular/filters.rs
@@ -58,8 +58,21 @@ use super::util::{
 };
 use crate::width::RenderWidthSource;
 
-/// Deterministic helper width when the render boundary cannot detect a terminal.
-const DEFAULT_TABLE_WIDTH: usize = 80;
+/// Deterministic tabular width when the render boundary cannot resolve one.
+const DEFAULT_TABULAR_WIDTH: usize = 80;
+
+/// Resolves the width shared by `tabular()` and `table()`.
+///
+/// An explicit helper argument wins over the current render's terminal width;
+/// the deterministic tabular fallback applies only when neither is available.
+fn resolve_tabular_width(
+    explicit_width: Option<usize>,
+    render_widths: &RenderWidthSource,
+) -> usize {
+    explicit_width
+        .or_else(|| render_widths.terminal_width())
+        .unwrap_or(DEFAULT_TABULAR_WIDTH)
+}
 
 /// Register all tabular-related filters on a MiniJinja environment.
 ///
@@ -271,10 +284,8 @@ fn register_table_functions(env: &mut Environment<'static>, widths: RenderWidthS
             let separator = kwargs
                 .get::<Option<String>>("separator")?
                 .unwrap_or_default();
-            let width = kwargs
-                .get::<Option<usize>>("width")?
-                .or_else(|| tabular_widths.terminal_width())
-                .unwrap_or(DEFAULT_TABLE_WIDTH);
+            let width =
+                resolve_tabular_width(kwargs.get::<Option<usize>>("width")?, &tabular_widths);
             kwargs.assert_all_used()?;
 
             let mut builder = TabularSpec::builder();
@@ -311,10 +322,8 @@ fn register_table_functions(env: &mut Environment<'static>, widths: RenderWidthS
                 .get::<Option<bool>>("row_separator")?
                 .unwrap_or(false);
             let row_styles = kwargs.get::<Option<Value>>("row_styles")?;
-            let width = kwargs
-                .get::<Option<usize>>("width")?
-                .or_else(|| table_widths.terminal_width())
-                .unwrap_or(DEFAULT_TABLE_WIDTH);
+            let width =
+                resolve_tabular_width(kwargs.get::<Option<usize>>("width")?, &table_widths);
             kwargs.assert_all_used()?;
 
             let mut builder = TabularSpec::builder();

--- a/crates/standout-test/tests/harness.rs
+++ b/crates/standout-test/tests/harness.rs
@@ -120,7 +120,7 @@ fn terminal_width_cascades_through_the_framework_list_view_template() {
 
 #[test]
 #[serial]
-fn columns_environment_width_precedes_the_terminal_probe_across_the_render_pipeline() {
+fn columns_environment_width_cascades_through_the_framework_list_view_template() {
     let app = build_framework_list_view_app();
     let result = TestHarness::new()
         .env("COLUMNS", "37")

--- a/crates/standout-test/tests/harness.rs
+++ b/crates/standout-test/tests/harness.rs
@@ -120,6 +120,22 @@ fn terminal_width_cascades_through_the_framework_list_view_template() {
 
 #[test]
 #[serial]
+fn columns_environment_width_precedes_the_terminal_probe_across_the_render_pipeline() {
+    let app = build_framework_list_view_app();
+    let result = TestHarness::new()
+        .env("COLUMNS", "37")
+        .run(&app, list_command(), ["app", "list"]);
+    result.assert_success();
+    let row = result
+        .stdout()
+        .lines()
+        .find(|line| line.contains("cascade"))
+        .expect("framework list view should render its tabular row");
+    assert_eq!(row.chars().count(), 37);
+}
+
+#[test]
+#[serial]
 fn terminal_width_places_right_aligned_field_at_the_right_edge() {
     let app = build_framework_list_view_app();
     let field = "cascade";

--- a/docs/topics/testing.md
+++ b/docs/topics/testing.md
@@ -98,7 +98,7 @@ use standout_render::{
 
 Each takes a `fn() -> T` (function pointer or non-capturing closure). `DetectorGuard` is a RAII helper that resets all three on drop.
 
-These drive `OutputMode::Auto`'s color decision and the render context's terminal width. Install an override in any test that snapshots rendered output, and the result becomes deterministic across machines.
+These drive `OutputMode::Auto`'s color decision and the render context's terminal width. By default, terminal width resolves from a valid positive `$COLUMNS` value before probing the terminal. Installing a width detector replaces that full resolution, so an override keeps snapshot tests deterministic regardless of the process environment.
 
 ### `standout-input` default readers
 


### PR DESCRIPTION
for #220

## Context

- Why this approach: `detect_terminal_width()` remains the one public resolution interface. Its default implementation now accepts only a positive integer from `$COLUMNS`, then lazily probes the tty, and returns `None` when neither source resolves a width. Existing detector overrides still replace the full resolution so `TestHarness` and application overrides remain deterministic. The existing 80-column behavior remains a tabular fallback rather than being misrepresented as a detected terminal width.
- Category audit: all three framework-owned render entry points already converge on `detect_terminal_width()`, and lower-level render interfaces correctly receive an already-resolved optional width. The duplicated explicit helper width -> render terminal width -> 80 cascade in `tabular()` and `table()` was the contradictory remaining implementation, so it now lives behind one `resolve_tabular_width()` seam with terminology that distinguishes tabular fallback width from terminal detection.
- Regression coverage: an in-process `TestHarness` regression drives `$COLUMNS` through app dispatch, render context, the framework list-view template, and tabular layout. Proptests cover arbitrary strings without panics, positive-width acceptance, fallback for invalid values, and the invariant that a valid `$COLUMNS` value avoids tty probing. The sole process-environment unit test is serial and restores the prior value on drop.
- Self-check: reviewed issue #220 plus the Standout rendering/output, testing, project-ownership, and deep-module guidance before opening this PR. No issue-specific ADR or Spec was supplied in the implementer brief or found in the repository.

## Verification

- `pixi run test` — 1,841 tests passed
- commit and push hooks: `pixi run lint` — 31 checks passed
- `shipit changelog check` — passed

## Out of scope

This PR does not change style-tag truncation, add a template terminal-width escape hatch, or add per-glyph width overrides. The tag-preserving truncation need is intentionally owned by the sibling PR. It also does not change explicit detector override semantics or move the 80-column fallback into terminal detection.