### PR TITLE
STANDOUT-WIZ01: Epic: Standout Bootstrap Wizard - Documentation convergence

### DIFF
--- a/docs/specs/wizard.md
+++ b/docs/specs/wizard.md
@@ -130,7 +130,8 @@ It does not ask:
 Before generation, summarize the resolved policy in plain language:
 
 > `document` comes from `--document`, then `--document-file`, then piped stdin.
-> Empty contents are rejected before the operation runs.
+> Because `document` is a required string, empty contents are rejected before
+> the operation runs.
 
 ### 3. Core operation
 

--- a/docs/specs/wizard.md
+++ b/docs/specs/wizard.md
@@ -110,8 +110,7 @@ For each logical input, ask for:
 - Rust value type from a deliberately small supported set;
 - required, optional, repeated, or boolean cardinality;
 - allowed sources;
-- precedence when more than one source is allowed;
-- a core validation demonstrated by the generated example.
+- precedence when more than one source is allowed.
 
 Initial source support is narrow:
 
@@ -130,20 +129,21 @@ It does not ask:
 
 Before generation, summarize the resolved policy in plain language:
 
-> `document` comes from `--document`, then `--file`, then piped stdin. Empty
-> contents are rejected before the operation runs.
+> `document` comes from `--document`, then `--document-file`, then piped stdin.
+> Empty contents are rejected before the operation runs.
 
 ### 3. Core operation
 
-Ask for:
+Derive the operation name as `process_<command>` rather than asking the user to
+name it. Ask for:
 
-- operation name;
 - whether it returns a message or record;
-- a small set of result fields;
-- one validation or error case worth demonstrating.
+- a small set of result fields.
 
 The generated library interface accepts explicit values and dependencies,
-return typed results, and contain no CLI concepts.
+returns typed results, and contains no CLI concepts. It emits a fixed
+blank-value validation only for required string inputs; the wizard does not ask
+the user to choose an arbitrary validation or error case.
 
 ### 4. Presentation
 
@@ -195,7 +195,8 @@ Every generated project must include:
 Calls `<name>lib` directly and proves:
 
 - valid input produces the expected typed result;
-- the selected validation case produces a core error.
+- a blank required string produces the fixed core error when that input shape
+  is present.
 
 ### Typed-handler test
 


### PR DESCRIPTION
## Context

The final epic #228 documentation audit found four related statements in the Implemented Spec that still described planned configurability instead of the shipped wizard. This correction documents that the operation name is derived as `process_<command>`, removes claims that users choose an arbitrary validation/error case, states that blank-value validation is fixed and limited to required strings (including the generated core-test description), and changes the source-precedence example from `--file` to the delivered `--<name>-file` form.

I self-checked the one-file diff against the durable epic #228 audit comment, the accepted WIZ01 contract already recorded in the Spec, and the implementation state represented by `origin/WIZ01/umbrella` at `305c247f595a39f7f4b8ba6cf73f704482c9ec28`.

Verification: `mdbook build` and `pixi run lint` (31 checks). The requested `pixi run mdbook build docs` form is not available because this repository defines no mdBook Pixi task; `book.toml` at the repository root and the docs workflow establish root-level `mdbook build` as the actual command.

Out of scope: ADR changes, generator behavior, code, templates, generated artifacts, or any expansion of the accepted input/result contract. Reviewers should not reopen those WIZ01 boundaries; this PR only makes the Implemented Spec truthful about the already shipped behavior.

for #228
