### PR TITLE
STANDOUT-WIZ02-WS01: Epic: Questionnaire Answer Sheets - Workstream: Round-trip a scalar prose answer sheet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,6 +1655,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1793,7 @@ dependencies = [
  "inquire",
  "once_cell",
  "serial_test",
+ "sha2",
  "shell-words",
  "tempfile",
  "thiserror 2.0.20",

--- a/crates/standout-input/Cargo.toml
+++ b/crates/standout-input/Cargo.toml
@@ -20,6 +20,7 @@ inquire = ["dep:inquire"]
 thiserror = "2"
 clap = { version = "4", default-features = false, features = ["std"] }
 once_cell = "1.19"
+sha2 = "0.10"
 
 # Optional: editor support
 tempfile = { version = "3", optional = true }

--- a/crates/standout-input/README.md
+++ b/crates/standout-input/README.md
@@ -128,6 +128,7 @@ let source = EnvSource::with_reader("TOKEN", env);
 
 - [Introduction to Input](docs/guides/intro-to-input.md) - Getting started guide
 - [Backends](docs/topics/backends.md) - Detailed backend documentation and custom implementations
+- [Answer Sheets](docs/topics/answer-sheets.md) - Editable prose questionnaires with stable identities
 
 ## License
 

--- a/crates/standout-input/docs/topics/answer-sheets.md
+++ b/crates/standout-input/docs/topics/answer-sheets.md
@@ -1,0 +1,97 @@
+# Questionnaire Answer Sheets
+
+Long questionnaires are awkward as a sequence of terminal prompts: you cannot see the whole thing before answering, edit long answers comfortably, or keep a sheet around for a repeatable workflow. The `questionnaire` module renders an application-defined questionnaire as a prose *answer sheet* — a document that reads as questions and answers — and parses the edited document back into raw answers.
+
+```text
+#! standout-answers 1
+#! questionnaire: demo.profile
+#! fingerprint: sha256:2a4c…
+
+1. What is your project called? [project.name] (string)
+-> wizard-question-generator
+
+2. Add any notes. [project.notes] (text, optional)
+->
+This answer may span several lines.
+Internal line breaks remain part of the answer.
+```
+
+---
+
+## Who owns what
+
+The boundary is deliberate and narrow:
+
+| `standout-input` owns                             | Your application owns                            |
+| ------------------------------------------------- | ------------------------------------------------ |
+| Definition validation (IDs, duplicates)           | The questionnaire definition itself              |
+| Deterministic rendering of the answer sheet       | Decoding raw answers into domain types           |
+| Parsing edited sheets into `RawAnswers`           | Whole-form validation and cross-field rules      |
+| Compatibility checking (version, ID, fingerprint) | Interactive flow, review, confirmation           |
+| Diagnostics with stable IDs and line numbers      | All side effects (file writes, generation, etc.) |
+
+Parsing stops at `RawAnswers`: trimmed answer text keyed by stable field ID. The library never sees your domain model, and your domain model never leaks into the format.
+
+## Stable identity
+
+The bracketed token (`[project.name]`) is the *only* machine identity in a question block. Display numbers, wording, indentation, and the parenthesized type hint are cosmetic — a user may reword, renumber, or re-indent a sheet freely, and a later release of your application may copy-edit its questions without invalidating sheets already in the wild.
+
+A field is recognized by the full header contract: a schema-recognized bracketed ID whose **next line begins with the `->` answer marker**. Everything after the marker, down to the next recognized header or end of file, is that field's answer — outer whitespace trimmed, internal line breaks preserved. Ordinary bracketed prose inside an answer (`see [project.name] above`) never opens a field, because it does not satisfy the header contract.
+
+Header-shaped lines that carry an *unknown* ID, or repeat a known one, are diagnostics rather than silently ignored text.
+
+## Compatibility: exact match, no migration
+
+Every sheet's preamble pins three things:
+
+- the answer-format version (`standout-answers 1`),
+- the questionnaire ID,
+- a semantic **fingerprint** of the definition.
+
+Parsing accepts only exact matches of all three. A stale or foreign sheet gets an actionable diagnostic asking for a freshly rendered sheet — never a guessed mapping from old fields to new ones.
+
+The fingerprint covers the *semantic* definition: field IDs, value kinds, and optionality. It ignores wording, help text, display numbers, and presentation order, so cosmetic edits keep old sheets valid while semantic changes reliably invalidate them.
+
+**The fingerprint is a compatibility checksum, not authentication.** It does not detect tampering and does not protect the document's content.
+
+## Sensitive content
+
+Answer sheets are plain text files holding whatever your questions ask for — possibly credentials, internal names, or personal data. Treat a saved sheet with the same care as the answers themselves: keep it out of version control and world-readable locations, and delete it when no longer needed. Diagnostics identify fields by stable ID and line number without echoing answer values.
+
+## Example
+
+```rust
+use standout_input::questionnaire::{Questionnaire, ScalarField, ScalarKind};
+
+// Application-owned definition. The IDs are the stable contract;
+// the wording is yours to edit at any time.
+let questionnaire = Questionnaire::new(
+    "demo.profile",
+    vec![
+        ScalarField::new("project.name", "What is your project called?", ScalarKind::String),
+        ScalarField::new("project.notes", "Add any notes.", ScalarKind::Text).optional(),
+    ],
+)?;
+
+// Render a blank sheet for the user to edit…
+let sheet = questionnaire.render_answer_sheet();
+
+// …and later, parse the edited document back.
+match questionnaire.parse_answer_sheet(&edited_text) {
+    Ok(answers) => {
+        // Raw text by stable ID; decoding into domain types is yours.
+        let name = answers.get("project.name");
+    }
+    Err(diagnostics) => {
+        for diagnostic in diagnostics {
+            eprintln!("{diagnostic}");
+        }
+    }
+}
+```
+
+Rendering is deterministic: the same definition always produces the same bytes, fingerprint included, so sheets are diffable and cache-friendly.
+
+## Current scope
+
+This first slice covers scalar fields (single- and multi-line prose answers). Nested and repeatable groups, shared decoding with interactive collection, and accumulated whole-form validation build on this same identity and compatibility model.

--- a/crates/standout-input/docs/topics/answer-sheets.md
+++ b/crates/standout-input/docs/topics/answer-sheets.md
@@ -71,12 +71,18 @@ let questionnaire = Questionnaire::new(
         ScalarField::new("project.name", "What is your project called?", ScalarKind::String),
         ScalarField::new("project.notes", "Add any notes.", ScalarKind::Text).optional(),
     ],
-)?;
+)
+.unwrap();
 
 // Render a blank sheet for the user to edit…
 let sheet = questionnaire.render_answer_sheet();
 
-// …and later, parse the edited document back.
+// …and later, parse the edited document back. In a real flow the edited
+// text comes back from the user's editor; here we answer in place.
+let edited_text = sheet.replace(
+    "[project.name] (string)\n->",
+    "[project.name] (string)\n-> wizard-question-generator",
+);
 match questionnaire.parse_answer_sheet(&edited_text) {
     Ok(answers) => {
         // Raw text by stable ID; decoding into domain types is yours.

--- a/crates/standout-input/src/lib.rs
+++ b/crates/standout-input/src/lib.rs
@@ -37,6 +37,14 @@
 //! └── DefaultSource  → (not reached)
 //! ```
 //!
+//! # Questionnaire answer sheets
+//!
+//! The [`questionnaire`] module renders an application-defined questionnaire
+//! as an editable prose answer sheet and parses the edited document back into
+//! raw answers by stable field identity. See the module documentation for the
+//! format, the application/library ownership boundary, and the exact-match
+//! compatibility contract.
+//!
 //! # Testing
 //!
 //! All sources accept mock implementations for testing:
@@ -53,6 +61,7 @@ mod collector;
 pub mod env;
 mod error;
 mod inputs;
+pub mod questionnaire;
 mod responder;
 pub mod sources;
 

--- a/crates/standout-input/src/questionnaire/definition.rs
+++ b/crates/standout-input/src/questionnaire/definition.rs
@@ -15,6 +15,8 @@
 //! empty or malformed IDs and duplicate field IDs, so every constructed
 //! questionnaire can render and parse without further checks.
 
+use std::collections::HashSet;
+
 use super::fingerprint::compute_fingerprint;
 
 /// The kind of value a scalar field collects.
@@ -176,15 +178,14 @@ impl Questionnaire {
         if fields.is_empty() {
             return Err(QuestionnaireError::NoFields);
         }
-        let mut seen: Vec<&str> = Vec::with_capacity(fields.len());
+        let mut seen: HashSet<&str> = HashSet::with_capacity(fields.len());
         for field in &fields {
             if !valid_id(&field.id) {
                 return Err(QuestionnaireError::InvalidFieldId(field.id.clone()));
             }
-            if seen.contains(&field.id.as_str()) {
+            if !seen.insert(&field.id) {
                 return Err(QuestionnaireError::DuplicateFieldId(field.id.clone()));
             }
-            seen.push(&field.id);
         }
         let fingerprint = compute_fingerprint(&id, &fields);
         Ok(Self {

--- a/crates/standout-input/src/questionnaire/definition.rs
+++ b/crates/standout-input/src/questionnaire/definition.rs
@@ -1,0 +1,223 @@
+//! Questionnaire definitions: stable identities plus cosmetic wording.
+//!
+//! A [`Questionnaire`] is an application-owned, static description of the
+//! information to collect. The definition carries two very different kinds of
+//! data and the split is the point:
+//!
+//! - **Semantic** (identity-bearing): the questionnaire ID, each field's
+//!   stable ID, its [`ScalarKind`], and its optionality. These feed the
+//!   [fingerprint](Questionnaire::fingerprint) and determine how a rendered
+//!   sheet is parsed.
+//! - **Cosmetic** (presentation-only): question wording and field order.
+//!   Changing them never changes answer identity or the fingerprint.
+//!
+//! Definitions are validated at construction: [`Questionnaire::new`] rejects
+//! empty or malformed IDs and duplicate field IDs, so every constructed
+//! questionnaire can render and parse without further checks.
+
+use super::fingerprint::compute_fingerprint;
+
+/// The kind of value a scalar field collects.
+///
+/// The kind is *semantic*: it participates in the questionnaire
+/// [fingerprint](Questionnaire::fingerprint) and drives the rendered type
+/// hint. It does not change how raw answer text is captured — both kinds
+/// round-trip text with outer whitespace trimmed and internal line breaks
+/// preserved. Decoding raw text into typed values is application/later-stage
+/// work, not part of the answer-sheet boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScalarKind {
+    /// A short, single-line-oriented value (rendered hint: `string`).
+    String,
+    /// Free-form prose that may span several lines (rendered hint: `text`).
+    Text,
+}
+
+impl ScalarKind {
+    /// Stable name used in the fingerprint canonical form and type hints.
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            ScalarKind::String => "string",
+            ScalarKind::Text => "text",
+        }
+    }
+}
+
+/// One scalar question in a questionnaire.
+///
+/// The `id` is the stable machine identity rendered as the bracketed token
+/// (`[project.name]`); the `prompt` is human wording and may be edited freely
+/// without affecting compatibility.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScalarField {
+    pub(crate) id: String,
+    pub(crate) prompt: String,
+    pub(crate) kind: ScalarKind,
+    pub(crate) optional: bool,
+}
+
+impl ScalarField {
+    /// Create a required scalar field with a stable `id`, human `prompt`
+    /// wording, and answer `kind`.
+    ///
+    /// The `id` is validated when the field is passed to
+    /// [`Questionnaire::new`], not here.
+    pub fn new(id: impl Into<String>, prompt: impl Into<String>, kind: ScalarKind) -> Self {
+        Self {
+            id: id.into(),
+            prompt: prompt.into(),
+            kind,
+            optional: false,
+        }
+    }
+
+    /// Mark this field as optional (a blank answer means omission).
+    ///
+    /// Optionality is semantic: it changes the fingerprint.
+    pub fn optional(mut self) -> Self {
+        self.optional = true;
+        self
+    }
+
+    /// The stable field ID.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// The human wording (cosmetic).
+    pub fn prompt(&self) -> &str {
+        &self.prompt
+    }
+
+    /// The answer kind (semantic).
+    pub fn kind(&self) -> ScalarKind {
+        self.kind
+    }
+
+    /// Whether a blank answer means omission rather than a missing value.
+    pub fn is_optional(&self) -> bool {
+        self.optional
+    }
+
+    /// The cosmetic type hint rendered after the bracketed ID.
+    pub(crate) fn type_hint(&self) -> String {
+        if self.optional {
+            format!("{}, optional", self.kind.name())
+        } else {
+            self.kind.name().to_string()
+        }
+    }
+}
+
+/// A definition-time validation error.
+///
+/// Produced by [`Questionnaire::new`]; a constructed questionnaire is always
+/// internally consistent.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum QuestionnaireError {
+    /// The questionnaire ID is empty or contains characters outside
+    /// `a-z`, `0-9`, `.`, `_`, `-`.
+    #[error("Invalid questionnaire ID '{0}': IDs must be non-empty and use only a-z, 0-9, '.', '_', '-'.")]
+    InvalidQuestionnaireId(String),
+
+    /// A field ID is empty or contains characters outside
+    /// `a-z`, `0-9`, `.`, `_`, `-`.
+    #[error("Invalid field ID '{0}': IDs must be non-empty and use only a-z, 0-9, '.', '_', '-'.")]
+    InvalidFieldId(String),
+
+    /// Two fields declare the same stable ID.
+    #[error("Duplicate field ID '{0}': stable IDs must be unique within a questionnaire.")]
+    DuplicateFieldId(String),
+
+    /// The questionnaire declares no fields.
+    #[error("A questionnaire must declare at least one field.")]
+    NoFields,
+}
+
+/// An application-owned questionnaire definition.
+///
+/// See the [module documentation](crate::questionnaire) for the ownership
+/// boundary and the rendered answer-sheet format.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Questionnaire {
+    id: String,
+    fields: Vec<ScalarField>,
+    fingerprint: String,
+}
+
+/// Returns `true` when `id` is a valid stable identifier.
+fn valid_id(id: &str) -> bool {
+    !id.is_empty()
+        && id
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '_' | '-'))
+}
+
+impl Questionnaire {
+    /// Create a validated questionnaire definition.
+    ///
+    /// `id` is the stable questionnaire identity written into every rendered
+    /// sheet's preamble. `fields` are rendered and parsed in the given order,
+    /// but order is cosmetic: reordering fields does not change the
+    /// [fingerprint](Self::fingerprint).
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`QuestionnaireError`] for an invalid questionnaire or field
+    /// ID, a duplicate field ID, or an empty field list.
+    pub fn new(
+        id: impl Into<String>,
+        fields: Vec<ScalarField>,
+    ) -> Result<Self, QuestionnaireError> {
+        let id = id.into();
+        if !valid_id(&id) {
+            return Err(QuestionnaireError::InvalidQuestionnaireId(id));
+        }
+        if fields.is_empty() {
+            return Err(QuestionnaireError::NoFields);
+        }
+        let mut seen: Vec<&str> = Vec::with_capacity(fields.len());
+        for field in &fields {
+            if !valid_id(&field.id) {
+                return Err(QuestionnaireError::InvalidFieldId(field.id.clone()));
+            }
+            if seen.contains(&field.id.as_str()) {
+                return Err(QuestionnaireError::DuplicateFieldId(field.id.clone()));
+            }
+            seen.push(&field.id);
+        }
+        let fingerprint = compute_fingerprint(&id, &fields);
+        Ok(Self {
+            id,
+            fields,
+            fingerprint,
+        })
+    }
+
+    /// The stable questionnaire ID.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// The declared fields, in presentation order.
+    pub fn fields(&self) -> &[ScalarField] {
+        &self.fields
+    }
+
+    /// The semantic fingerprint (`sha256:<hex>`).
+    ///
+    /// The fingerprint is a compatibility checksum over the *semantic*
+    /// definition — questionnaire ID, field IDs, kinds, and optionality. It
+    /// deliberately excludes wording, presentation order, and everything else
+    /// cosmetic, so copy-editing a questionnaire never invalidates existing
+    /// answer sheets. It is **not** an authenticity or tamper-proofing
+    /// mechanism.
+    pub fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    /// Look up a field by stable ID.
+    pub(crate) fn field(&self, id: &str) -> Option<&ScalarField> {
+        self.fields.iter().find(|f| f.id == id)
+    }
+}

--- a/crates/standout-input/src/questionnaire/fingerprint.rs
+++ b/crates/standout-input/src/questionnaire/fingerprint.rs
@@ -1,0 +1,51 @@
+//! Semantic fingerprinting for questionnaire definitions.
+//!
+//! The fingerprint answers one question at parse time: "was this sheet
+//! rendered from a semantically identical definition?" Version 1 accepts only
+//! an exact match; a mismatch asks the user for a fresh sheet rather than
+//! guessing how old answers map onto new semantics.
+//!
+//! The canonical form hashed here includes exactly the semantic surface of a
+//! definition — questionnaire ID, and each field's stable ID, kind, and
+//! optionality — with fields sorted by stable ID so presentation order stays
+//! cosmetic. Wording, numbering, and styling never appear in the canonical
+//! form, so copy edits cannot invalidate existing sheets.
+
+use std::fmt::Write as _;
+
+use sha2::{Digest, Sha256};
+
+use super::definition::ScalarField;
+
+/// Version tag for the canonical form itself, distinct from the rendered
+/// answer-format version: changing how the fingerprint is computed must
+/// change every fingerprint.
+const CANONICAL_FORM_VERSION: &str = "1";
+
+/// Compute the `sha256:<hex>` fingerprint of a definition's semantic surface.
+///
+/// Deterministic for a given semantic definition and independent of field
+/// presentation order.
+pub(crate) fn compute_fingerprint(questionnaire_id: &str, fields: &[ScalarField]) -> String {
+    let mut canonical = format!(
+        "standout-answers-canonical {CANONICAL_FORM_VERSION}\nquestionnaire={questionnaire_id}\n"
+    );
+    let mut sorted: Vec<&ScalarField> = fields.iter().collect();
+    sorted.sort_by(|a, b| a.id().cmp(b.id()));
+    for field in sorted {
+        let _ = writeln!(
+            canonical,
+            "field={}|kind={}|optional={}",
+            field.id(),
+            field.kind().name(),
+            field.is_optional()
+        );
+    }
+    let digest = Sha256::digest(canonical.as_bytes());
+    let mut out = String::with_capacity(7 + digest.len() * 2);
+    out.push_str("sha256:");
+    for byte in digest {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}

--- a/crates/standout-input/src/questionnaire/mod.rs
+++ b/crates/standout-input/src/questionnaire/mod.rs
@@ -1,0 +1,102 @@
+//! Questionnaire answer sheets: render a prose questionnaire, let a human
+//! edit it as text, and parse the answers back by stable identity.
+//!
+//! Long questionnaires are awkward as a sequence of terminal prompts. This
+//! module renders an application-defined questionnaire as a prose *answer
+//! sheet* — a document that reads as questions and answers, not as a
+//! configuration format — and parses an edited sheet back into raw answers.
+//!
+//! # Ownership boundary
+//!
+//! `standout-input` owns the reusable machinery: definition validation,
+//! deterministic rendering, parsing, and diagnostics. The application owns
+//! everything else — its questionnaire definition, decoding raw answers into
+//! domain types, whole-form validation, interactive flow, review,
+//! confirmation, and side effects. Parsing stops at [`RawAnswers`]: trimmed
+//! answer text keyed by stable field ID, deliberately short of any
+//! application model.
+//!
+//! # The rendered format
+//!
+//! ```text
+//! #! standout-answers 1
+//! #! questionnaire: demo.profile
+//! #! fingerprint: sha256:…
+//!
+//! 1. What is your project called? [project.name] (string)
+//! ->
+//!
+//! 2. Add any notes. [project.notes] (text, optional)
+//! ->
+//! ```
+//!
+//! The bracketed token is the stable machine identity. Everything else in a
+//! question block — the display number, the wording, indentation, and the
+//! parenthesized type hint — is cosmetic: a user (or a later release of the
+//! application) may reword, renumber, or re-indent freely without changing
+//! what the document means. A field is recognized only by a
+//! schema-recognized bracketed ID whose next line begins with the `->`
+//! answer marker; ordinary bracketed prose inside an answer never opens a
+//! field. Answers keep internal line breaks and lose only outer whitespace.
+//!
+//! # Compatibility: exact match, no migration
+//!
+//! The preamble pins an answer-format version, the questionnaire ID, and a
+//! semantic *fingerprint* of the definition. Parsing accepts only exact
+//! matches of all three; a stale sheet gets a diagnostic asking for a
+//! freshly rendered one, never a guessed field mapping. The fingerprint
+//! covers the semantic definition (IDs, kinds, optionality) and ignores
+//! wording, numbering, and ordering — so copy edits keep old sheets valid,
+//! while semantic changes reliably invalidate them.
+//!
+//! The fingerprint is a compatibility checksum only. It does not
+//! authenticate a document, detect tampering, or protect its content.
+//!
+//! # Sensitive content
+//!
+//! Answer sheets are plain text files that may hold whatever the questions
+//! ask for — including private or sensitive values. Treat a saved sheet with
+//! the same care as the answers themselves: keep it out of version control
+//! and world-readable locations, and delete it when done. Diagnostics from
+//! this module identify fields by ID and line number without echoing answer
+//! values.
+//!
+//! # Round-trip example
+//!
+//! ```
+//! use standout_input::questionnaire::{Questionnaire, ScalarField, ScalarKind};
+//!
+//! // The application owns this definition; IDs are the stable contract.
+//! let questionnaire = Questionnaire::new(
+//!     "demo.profile",
+//!     vec![
+//!         ScalarField::new("project.name", "What is your project called?", ScalarKind::String),
+//!         ScalarField::new("project.notes", "Add any notes.", ScalarKind::Text).optional(),
+//!     ],
+//! )
+//! .unwrap();
+//!
+//! // Render the blank sheet, then simulate a user editing answers in.
+//! let sheet = questionnaire.render_answer_sheet();
+//! let edited = sheet
+//!     .replace(
+//!         "1. What is your project called? [project.name] (string)\n->",
+//!         "1. What is your project called? [project.name] (string)\n-> demo",
+//!     )
+//!     .replace(
+//!         "2. Add any notes. [project.notes] (text, optional)\n->",
+//!         "2. Add any notes. [project.notes] (text, optional)\n-> Spans two lines,\nlike [this] one.",
+//!     );
+//!
+//! let answers = questionnaire.parse_answer_sheet(&edited).unwrap();
+//! assert_eq!(answers.get("project.name"), Some("demo"));
+//! assert_eq!(answers.get("project.notes"), Some("Spans two lines,\nlike [this] one."));
+//! ```
+
+mod definition;
+mod fingerprint;
+mod parse;
+mod render;
+
+pub use definition::{Questionnaire, QuestionnaireError, ScalarField, ScalarKind};
+pub use parse::{AnswerSheetDiagnostic, RawAnswers};

--- a/crates/standout-input/src/questionnaire/parse.rs
+++ b/crates/standout-input/src/questionnaire/parse.rs
@@ -1,0 +1,316 @@
+//! Parsing edited answer sheets back into raw answers.
+//!
+//! Parsing recognizes structure only from stable identities: a field opens
+//! when a header-shaped line carries a schema-recognized bracketed ID and the
+//! following line begins with the `->` answer marker. Everything cosmetic —
+//! display numbers, wording, indentation, type hints — is ignored, so a user
+//! may freely reword or renumber a sheet without changing what it means.
+//!
+//! Compatibility is exact-version: the preamble's answer-format version,
+//! questionnaire ID, and fingerprint must all match the parsing definition,
+//! or parsing stops with diagnostics that ask for a freshly rendered sheet.
+//! No migration or fuzzy matching is attempted.
+
+use std::collections::BTreeMap;
+
+use super::definition::Questionnaire;
+use super::render::{ANSWER_MARKER, FINGERPRINT_PREFIX, FORMAT_LINE, QUESTIONNAIRE_PREFIX};
+
+/// The raw answers parsed from one answer sheet.
+///
+/// Values are the verbatim answer text with outer whitespace trimmed and
+/// internal line breaks preserved. A field absent from the document is absent
+/// here; a field whose marker was left blank is present with an empty string.
+/// Decoding raw text into typed values (defaults, omission, validation) is a
+/// later stage, shared with interactive collection.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RawAnswers {
+    values: BTreeMap<String, String>,
+}
+
+impl RawAnswers {
+    /// The raw answer text for a stable field ID, if the field appeared.
+    pub fn get(&self, field_id: &str) -> Option<&str> {
+        self.values.get(field_id).map(String::as_str)
+    }
+
+    /// Iterate over `(field_id, raw_answer)` pairs, ordered by field ID.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.values.iter().map(|(k, v)| (k.as_str(), v.as_str()))
+    }
+
+    /// Number of fields that appeared in the document.
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Whether no fields appeared in the document.
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
+/// One problem found while parsing an answer sheet.
+///
+/// Diagnostics identify locations by 1-based line number and fields by stable
+/// ID; they never echo full answer values, since answer sheets may contain
+/// sensitive content. Compatibility diagnostics deliberately point at
+/// re-rendering: version 1 rejects incompatible sheets instead of migrating
+/// them.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum AnswerSheetDiagnostic {
+    /// The `#!` metadata preamble is missing or malformed.
+    #[error("Line {line}: malformed answer-sheet preamble: {detail}. Render a fresh answer sheet and copy your answers into it.")]
+    MalformedPreamble {
+        /// 1-based line number of the malformed or missing preamble line.
+        line: usize,
+        /// What was expected at that line.
+        detail: String,
+    },
+
+    /// The sheet declares an answer-format version other than 1.
+    #[error("Unsupported answer-format version '{found}' (this release reads only version 1). Render a fresh answer sheet; old sheets are not migrated.")]
+    UnsupportedAnswerFormat {
+        /// The version token found in the document.
+        found: String,
+    },
+
+    /// The sheet was rendered for a different questionnaire.
+    #[error("This answer sheet is for questionnaire '{found}', not '{expected}'. Render a fresh answer sheet for '{expected}'.")]
+    QuestionnaireMismatch {
+        /// The questionnaire ID this parser expects.
+        expected: String,
+        /// The questionnaire ID found in the document.
+        found: String,
+    },
+
+    /// The sheet was rendered from a semantically different definition.
+    #[error("This answer sheet was rendered from a different version of questionnaire semantics (fingerprint '{found}', expected '{expected}'). The questionnaire changed since this sheet was rendered; render a fresh answer sheet and copy your answers into it. Answers are not migrated.")]
+    FingerprintMismatch {
+        /// The fingerprint of the parsing definition.
+        expected: String,
+        /// The fingerprint found in the document.
+        found: String,
+    },
+
+    /// A header-shaped line carries a bracketed ID the schema does not know.
+    #[error("Line {line}: unknown field ID '[{id}]'. This questionnaire does not define that field; if the line is prose, remove the following '->' marker line, otherwise render a fresh answer sheet.")]
+    UnknownFieldId {
+        /// The unrecognized bracketed ID.
+        id: String,
+        /// 1-based line number of the header-shaped line.
+        line: usize,
+    },
+
+    /// A field header appears more than once.
+    #[error("Line {line}: duplicate field '[{id}]'. Each field may be answered once; remove the extra occurrence.")]
+    DuplicateField {
+        /// The duplicated stable field ID.
+        id: String,
+        /// 1-based line number of the second occurrence.
+        line: usize,
+    },
+}
+
+/// The field (or discard sink) currently accumulating answer lines.
+struct OpenAnswer {
+    /// `Some(id)` for a recognized field; `None` discards the answer text of
+    /// an unknown or duplicate header so it cannot leak into a neighbor.
+    id: Option<String>,
+    lines: Vec<String>,
+}
+
+impl OpenAnswer {
+    fn flush_into(self, values: &mut BTreeMap<String, String>) {
+        if let Some(id) = self.id {
+            values.insert(id, self.lines.join("\n").trim().to_string());
+        }
+    }
+}
+
+/// Returns the last bracketed token on `line` when it is shaped like a stable
+/// ID (non-empty, only `a-z`, `0-9`, `.`, `_`, `-`).
+///
+/// Ordinary prose brackets (`[like this]`, `[Maybe?]`) do not qualify, so
+/// they can never make a line header-shaped.
+fn header_candidate(line: &str) -> Option<&str> {
+    let close = line.rfind(']')?;
+    let open = line[..close].rfind('[')?;
+    let token = &line[open + 1..close];
+    let valid = !token.is_empty()
+        && token
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '_' | '-'));
+    valid.then_some(token)
+}
+
+impl Questionnaire {
+    /// Parse an edited answer sheet back into [`RawAnswers`].
+    ///
+    /// The document must have been rendered by
+    /// [`render_answer_sheet`](Self::render_answer_sheet) for this exact
+    /// definition: the preamble's answer-format version, questionnaire ID,
+    /// and fingerprint are checked exactly, and any mismatch returns
+    /// diagnostics asking for a fresh sheet without reading the body.
+    ///
+    /// Within the body, a field is recognized only by a schema-recognized
+    /// bracketed ID whose *next* line begins with the `->` answer marker.
+    /// The answer is everything after the marker up to the next recognized
+    /// header or end of file, outer whitespace trimmed, internal line breaks
+    /// preserved. Bracketed prose inside an answer is answer text unless it
+    /// satisfies that full header contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns every accumulated [`AnswerSheetDiagnostic`]: compatibility
+    /// mismatches, malformed preambles, and unknown or duplicate IDs on
+    /// header-shaped lines.
+    pub fn parse_answer_sheet(&self, text: &str) -> Result<RawAnswers, Vec<AnswerSheetDiagnostic>> {
+        let lines: Vec<&str> = text.lines().collect();
+        let body_start = self.check_preamble(&lines)?;
+
+        let mut diagnostics = Vec::new();
+        let mut values = BTreeMap::new();
+        let mut open: Option<OpenAnswer> = None;
+        let mut i = body_start;
+        while i < lines.len() {
+            let line = lines[i];
+            let marker_follows = lines
+                .get(i + 1)
+                .is_some_and(|next| next.trim_start().starts_with(ANSWER_MARKER));
+            if let (true, Some(candidate)) = (marker_follows, header_candidate(line)) {
+                if let Some(previous) = open.take() {
+                    previous.flush_into(&mut values);
+                }
+                let id = if self.field(candidate).is_none() {
+                    diagnostics.push(AnswerSheetDiagnostic::UnknownFieldId {
+                        id: candidate.to_string(),
+                        line: i + 1,
+                    });
+                    None
+                } else if values.contains_key(candidate) {
+                    diagnostics.push(AnswerSheetDiagnostic::DuplicateField {
+                        id: candidate.to_string(),
+                        line: i + 1,
+                    });
+                    None
+                } else {
+                    Some(candidate.to_string())
+                };
+                let marker_line = lines[i + 1].trim_start();
+                let first = marker_line[ANSWER_MARKER.len()..].to_string();
+                open = Some(OpenAnswer {
+                    id,
+                    lines: vec![first],
+                });
+                i += 2;
+            } else {
+                if let Some(current) = open.as_mut() {
+                    current.lines.push(line.to_string());
+                }
+                i += 1;
+            }
+        }
+        if let Some(last) = open {
+            last.flush_into(&mut values);
+        }
+
+        if diagnostics.is_empty() {
+            Ok(RawAnswers { values })
+        } else {
+            Err(diagnostics)
+        }
+    }
+
+    /// Validate the three-line `#!` preamble against this definition.
+    ///
+    /// Returns the index of the first body line, or every compatibility and
+    /// shape diagnostic found. Blank lines before and between preamble lines
+    /// are tolerated; the preamble content itself is matched exactly.
+    fn check_preamble(&self, lines: &[&str]) -> Result<usize, Vec<AnswerSheetDiagnostic>> {
+        let mut diagnostics = Vec::new();
+        let mut i = 0;
+
+        let next_content = |i: &mut usize| -> Option<usize> {
+            while *i < lines.len() && lines[*i].trim().is_empty() {
+                *i += 1;
+            }
+            (*i < lines.len()).then(|| {
+                let at = *i;
+                *i += 1;
+                at
+            })
+        };
+
+        match next_content(&mut i) {
+            Some(at) => {
+                let line = lines[at].trim();
+                if line != FORMAT_LINE {
+                    match line.strip_prefix("#! standout-answers ") {
+                        Some(version) => {
+                            diagnostics.push(AnswerSheetDiagnostic::UnsupportedAnswerFormat {
+                                found: version.trim().to_string(),
+                            })
+                        }
+                        None => diagnostics.push(AnswerSheetDiagnostic::MalformedPreamble {
+                            line: at + 1,
+                            detail: format!("expected '{FORMAT_LINE}'"),
+                        }),
+                    }
+                }
+            }
+            None => diagnostics.push(AnswerSheetDiagnostic::MalformedPreamble {
+                line: lines.len() + 1,
+                detail: format!("expected '{FORMAT_LINE}'"),
+            }),
+        }
+
+        let expect_keyed = |i: &mut usize,
+                            prefix: &str,
+                            diagnostics: &mut Vec<AnswerSheetDiagnostic>|
+         -> Option<String> {
+            match next_content(i) {
+                Some(at) => match lines[at].trim().strip_prefix(prefix) {
+                    Some(value) => Some(value.trim().to_string()),
+                    None => {
+                        diagnostics.push(AnswerSheetDiagnostic::MalformedPreamble {
+                            line: at + 1,
+                            detail: format!("expected '{prefix} ...'"),
+                        });
+                        None
+                    }
+                },
+                None => {
+                    diagnostics.push(AnswerSheetDiagnostic::MalformedPreamble {
+                        line: lines.len() + 1,
+                        detail: format!("expected '{prefix} ...'"),
+                    });
+                    None
+                }
+            }
+        };
+
+        if let Some(found) = expect_keyed(&mut i, QUESTIONNAIRE_PREFIX, &mut diagnostics) {
+            if found != self.id() {
+                diagnostics.push(AnswerSheetDiagnostic::QuestionnaireMismatch {
+                    expected: self.id().to_string(),
+                    found,
+                });
+            }
+        }
+        if let Some(found) = expect_keyed(&mut i, FINGERPRINT_PREFIX, &mut diagnostics) {
+            if found != self.fingerprint() {
+                diagnostics.push(AnswerSheetDiagnostic::FingerprintMismatch {
+                    expected: self.fingerprint().to_string(),
+                    found,
+                });
+            }
+        }
+
+        if diagnostics.is_empty() {
+            Ok(i)
+        } else {
+            Err(diagnostics)
+        }
+    }
+}

--- a/crates/standout-input/src/questionnaire/render.rs
+++ b/crates/standout-input/src/questionnaire/render.rs
@@ -1,0 +1,50 @@
+//! Deterministic rendering of blank answer sheets.
+//!
+//! Rendering writes the prose document described in the
+//! [module documentation](crate::questionnaire): a three-line `#!` metadata
+//! preamble followed by one numbered question block per field. The same
+//! definition always renders byte-identical output.
+
+use std::fmt::Write as _;
+
+use super::definition::Questionnaire;
+
+/// The exact first preamble line of a version-1 answer sheet.
+pub(crate) const FORMAT_LINE: &str = "#! standout-answers 1";
+/// Preamble key prefix for the questionnaire ID line.
+pub(crate) const QUESTIONNAIRE_PREFIX: &str = "#! questionnaire:";
+/// Preamble key prefix for the fingerprint line.
+pub(crate) const FINGERPRINT_PREFIX: &str = "#! fingerprint:";
+/// The marker introducing answer text under a field header.
+pub(crate) const ANSWER_MARKER: &str = "->";
+
+impl Questionnaire {
+    /// Render a blank answer sheet for this questionnaire.
+    ///
+    /// The output is deterministic: rendering the same definition always
+    /// produces the same document, including the fingerprint in the preamble.
+    /// Each field renders as a header line — cosmetic display number and
+    /// wording, the bracketed stable ID, and a parenthesized type hint —
+    /// followed by a bare `->` answer marker awaiting the answer.
+    pub fn render_answer_sheet(&self) -> String {
+        let mut out = String::new();
+        out.push_str(FORMAT_LINE);
+        out.push('\n');
+        let _ = writeln!(out, "{QUESTIONNAIRE_PREFIX} {}", self.id());
+        let _ = writeln!(out, "{FINGERPRINT_PREFIX} {}", self.fingerprint());
+        for (index, field) in self.fields().iter().enumerate() {
+            out.push('\n');
+            let _ = writeln!(
+                out,
+                "{}. {} [{}] ({})",
+                index + 1,
+                field.prompt(),
+                field.id(),
+                field.type_hint()
+            );
+            out.push_str(ANSWER_MARKER);
+            out.push('\n');
+        }
+        out
+    }
+}

--- a/crates/standout-input/tests/questionnaire.rs
+++ b/crates/standout-input/tests/questionnaire.rs
@@ -1,0 +1,513 @@
+//! Pure answer-sheet engine tests: deterministic rendering, round trips,
+//! multiline and whitespace behavior, cosmetic edits, malformed headers,
+//! unknown or duplicate IDs, and compatibility failures.
+
+use standout_input::questionnaire::{
+    AnswerSheetDiagnostic, Questionnaire, QuestionnaireError, ScalarField, ScalarKind,
+};
+
+fn one_field() -> Questionnaire {
+    Questionnaire::new(
+        "demo.profile",
+        vec![ScalarField::new(
+            "project.name",
+            "What is the project name?",
+            ScalarKind::String,
+        )],
+    )
+    .unwrap()
+}
+
+fn two_fields() -> Questionnaire {
+    Questionnaire::new(
+        "demo.profile",
+        vec![
+            ScalarField::new(
+                "project.name",
+                "What is the project name?",
+                ScalarKind::String,
+            ),
+            ScalarField::new("project.notes", "Add any notes.", ScalarKind::Text).optional(),
+        ],
+    )
+    .unwrap()
+}
+
+/// Replace a field's bare marker with a marker carrying `answer`.
+fn answer(sheet: &str, id: &str, answer: &str) -> String {
+    let needle = format!("[{id}]");
+    let mut out = String::new();
+    let mut lines = sheet.lines().peekable();
+    while let Some(line) = lines.next() {
+        out.push_str(line);
+        out.push('\n');
+        if line.contains(&needle) {
+            let marker = lines.next().expect("marker follows header");
+            assert_eq!(marker, "->");
+            out.push_str("-> ");
+            out.push_str(answer);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+// ============================================================================
+// Definition validation
+// ============================================================================
+
+#[test]
+fn definition_rejects_invalid_questionnaire_id() {
+    let err = Questionnaire::new(
+        "Has Spaces",
+        vec![ScalarField::new("a", "A?", ScalarKind::String)],
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        QuestionnaireError::InvalidQuestionnaireId("Has Spaces".into())
+    );
+
+    let err =
+        Questionnaire::new("", vec![ScalarField::new("a", "A?", ScalarKind::String)]).unwrap_err();
+    assert_eq!(err, QuestionnaireError::InvalidQuestionnaireId("".into()));
+}
+
+#[test]
+fn definition_rejects_invalid_field_id() {
+    let err = Questionnaire::new(
+        "demo",
+        vec![ScalarField::new("Project.Name", "A?", ScalarKind::String)],
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        QuestionnaireError::InvalidFieldId("Project.Name".into())
+    );
+}
+
+#[test]
+fn definition_rejects_duplicate_field_ids() {
+    let err = Questionnaire::new(
+        "demo",
+        vec![
+            ScalarField::new("a", "First?", ScalarKind::String),
+            ScalarField::new("a", "Second?", ScalarKind::Text),
+        ],
+    )
+    .unwrap_err();
+    assert_eq!(err, QuestionnaireError::DuplicateFieldId("a".into()));
+}
+
+#[test]
+fn definition_rejects_empty_field_list() {
+    let err = Questionnaire::new("demo", vec![]).unwrap_err();
+    assert_eq!(err, QuestionnaireError::NoFields);
+}
+
+// ============================================================================
+// Deterministic rendering
+// ============================================================================
+
+#[test]
+fn rendering_is_deterministic_and_carries_all_declared_parts() {
+    let q = two_fields();
+    let sheet = q.render_answer_sheet();
+    assert_eq!(
+        sheet,
+        q.render_answer_sheet(),
+        "same definition, same bytes"
+    );
+
+    let expected = format!(
+        "#! standout-answers 1\n\
+         #! questionnaire: demo.profile\n\
+         #! fingerprint: {}\n\
+         \n\
+         1. What is the project name? [project.name] (string)\n\
+         ->\n\
+         \n\
+         2. Add any notes. [project.notes] (text, optional)\n\
+         ->\n",
+        q.fingerprint()
+    );
+    assert_eq!(sheet, expected);
+    assert!(q.fingerprint().starts_with("sha256:"));
+}
+
+// ============================================================================
+// Round trips
+// ============================================================================
+
+#[test]
+fn blank_sheet_round_trips_to_empty_answers() {
+    let q = two_fields();
+    let answers = q.parse_answer_sheet(&q.render_answer_sheet()).unwrap();
+    assert_eq!(answers.get("project.name"), Some(""));
+    assert_eq!(answers.get("project.notes"), Some(""));
+    assert_eq!(answers.len(), 2);
+}
+
+#[test]
+fn scalar_answer_round_trips() {
+    let q = one_field();
+    let edited = answer(&q.render_answer_sheet(), "project.name", "wizard");
+    let answers = q.parse_answer_sheet(&edited).unwrap();
+    assert_eq!(answers.get("project.name"), Some("wizard"));
+}
+
+#[test]
+fn multiline_answer_preserves_internal_breaks_and_trims_outer_whitespace() {
+    let q = two_fields();
+    let edited = answer(
+        &q.render_answer_sheet(),
+        "project.notes",
+        "\nFirst line.\n\nThird line, after a kept blank.\n\n",
+    );
+    let answers = q.parse_answer_sheet(&edited).unwrap();
+    assert_eq!(
+        answers.get("project.notes"),
+        Some("First line.\n\nThird line, after a kept blank.")
+    );
+}
+
+#[test]
+fn bracketed_prose_inside_answer_is_not_a_field() {
+    let q = two_fields();
+    // Contains a bracketed known ID and a bracketed unknown token, neither
+    // followed by a marker line: both are ordinary answer text.
+    let edited = answer(
+        &q.render_answer_sheet(),
+        "project.notes",
+        "see [project.name] above\nand [some prose] too",
+    );
+    let answers = q.parse_answer_sheet(&edited).unwrap();
+    assert_eq!(
+        answers.get("project.notes"),
+        Some("see [project.name] above\nand [some prose] too")
+    );
+}
+
+#[test]
+fn answer_on_marker_line_and_following_lines_belong_together() {
+    let q = one_field();
+    let sheet = q.render_answer_sheet();
+    let edited = sheet.replace("->\n", "->   spaced out   \n");
+    let answers = q.parse_answer_sheet(&edited).unwrap();
+    assert_eq!(answers.get("project.name"), Some("spaced out"));
+}
+
+// ============================================================================
+// Cosmetic freedom: numbers, wording, indentation, hints
+// ============================================================================
+
+#[test]
+fn display_edits_do_not_change_parsing() {
+    let q = two_fields();
+    let cosmetic = format!(
+        "#! standout-answers 1\n\
+         #! questionnaire: demo.profile\n\
+         #! fingerprint: {}\n\
+         \n\
+         Some guidance prose the renderer never wrote.\n\
+         \n\
+         99. Totally reworded question! [project.name] (whatever hint)\n\
+         -> demo\n\
+         \n\
+         \t 1.1 Indented and renumbered. [project.notes]\n\
+         \t -> noted\n",
+        q.fingerprint()
+    );
+    let answers = q.parse_answer_sheet(&cosmetic).unwrap();
+    assert_eq!(answers.get("project.name"), Some("demo"));
+    assert_eq!(answers.get("project.notes"), Some("noted"));
+}
+
+#[test]
+fn field_order_in_document_is_cosmetic() {
+    let q = two_fields();
+    let reordered = format!(
+        "#! standout-answers 1\n\
+         #! questionnaire: demo.profile\n\
+         #! fingerprint: {}\n\
+         \n\
+         2. Add any notes. [project.notes] (text, optional)\n\
+         -> noted\n\
+         \n\
+         1. What is the project name? [project.name] (string)\n\
+         -> demo\n",
+        q.fingerprint()
+    );
+    let answers = q.parse_answer_sheet(&reordered).unwrap();
+    assert_eq!(answers.get("project.name"), Some("demo"));
+    assert_eq!(answers.get("project.notes"), Some("noted"));
+}
+
+// ============================================================================
+// Fingerprint semantics
+// ============================================================================
+
+#[test]
+fn fingerprint_ignores_wording_and_field_order() {
+    let base = two_fields();
+    let reworded = Questionnaire::new(
+        "demo.profile",
+        vec![
+            ScalarField::new("project.name", "Reworded entirely?", ScalarKind::String),
+            ScalarField::new("project.notes", "Different help text.", ScalarKind::Text).optional(),
+        ],
+    )
+    .unwrap();
+    assert_eq!(base.fingerprint(), reworded.fingerprint());
+
+    let reordered = Questionnaire::new(
+        "demo.profile",
+        vec![
+            ScalarField::new("project.notes", "Add any notes.", ScalarKind::Text).optional(),
+            ScalarField::new(
+                "project.name",
+                "What is the project name?",
+                ScalarKind::String,
+            ),
+        ],
+    )
+    .unwrap();
+    assert_eq!(base.fingerprint(), reordered.fingerprint());
+}
+
+#[test]
+fn fingerprint_changes_on_semantic_edits() {
+    let base = two_fields();
+
+    let renamed = Questionnaire::new(
+        "demo.profile",
+        vec![
+            ScalarField::new(
+                "project.title",
+                "What is the project name?",
+                ScalarKind::String,
+            ),
+            ScalarField::new("project.notes", "Add any notes.", ScalarKind::Text).optional(),
+        ],
+    )
+    .unwrap();
+    assert_ne!(base.fingerprint(), renamed.fingerprint());
+
+    let rekinded = Questionnaire::new(
+        "demo.profile",
+        vec![
+            ScalarField::new(
+                "project.name",
+                "What is the project name?",
+                ScalarKind::Text,
+            ),
+            ScalarField::new("project.notes", "Add any notes.", ScalarKind::Text).optional(),
+        ],
+    )
+    .unwrap();
+    assert_ne!(base.fingerprint(), rekinded.fingerprint());
+
+    let required = Questionnaire::new(
+        "demo.profile",
+        vec![
+            ScalarField::new(
+                "project.name",
+                "What is the project name?",
+                ScalarKind::String,
+            ),
+            ScalarField::new("project.notes", "Add any notes.", ScalarKind::Text),
+        ],
+    )
+    .unwrap();
+    assert_ne!(base.fingerprint(), required.fingerprint());
+
+    let other_questionnaire = Questionnaire::new(
+        "demo.other",
+        vec![
+            ScalarField::new(
+                "project.name",
+                "What is the project name?",
+                ScalarKind::String,
+            ),
+            ScalarField::new("project.notes", "Add any notes.", ScalarKind::Text).optional(),
+        ],
+    )
+    .unwrap();
+    assert_ne!(base.fingerprint(), other_questionnaire.fingerprint());
+}
+
+// ============================================================================
+// Compatibility failures
+// ============================================================================
+
+#[test]
+fn wrong_answer_format_version_is_rejected() {
+    let q = one_field();
+    let sheet = q
+        .render_answer_sheet()
+        .replace("#! standout-answers 1", "#! standout-answers 2");
+    let diags = q.parse_answer_sheet(&sheet).unwrap_err();
+    assert_eq!(
+        diags,
+        vec![AnswerSheetDiagnostic::UnsupportedAnswerFormat { found: "2".into() }]
+    );
+    assert!(diags[0].to_string().contains("Render a fresh answer sheet"));
+}
+
+#[test]
+fn wrong_questionnaire_id_is_rejected() {
+    let q = one_field();
+    let sheet = q
+        .render_answer_sheet()
+        .replace("questionnaire: demo.profile", "questionnaire: other.app");
+    let diags = q.parse_answer_sheet(&sheet).unwrap_err();
+    assert_eq!(
+        diags,
+        vec![AnswerSheetDiagnostic::QuestionnaireMismatch {
+            expected: "demo.profile".into(),
+            found: "other.app".into(),
+        }]
+    );
+    assert!(diags[0].to_string().contains("Render a fresh answer sheet"));
+}
+
+#[test]
+fn stale_fingerprint_is_rejected_not_migrated() {
+    let old = one_field();
+    let sheet = answer(&old.render_answer_sheet(), "project.name", "kept");
+    // The application later renames the field: a semantic change.
+    let new = Questionnaire::new(
+        "demo.profile",
+        vec![ScalarField::new(
+            "project.title",
+            "What is the project name?",
+            ScalarKind::String,
+        )],
+    )
+    .unwrap();
+    let diags = new.parse_answer_sheet(&sheet).unwrap_err();
+    assert_eq!(
+        diags,
+        vec![AnswerSheetDiagnostic::FingerprintMismatch {
+            expected: new.fingerprint().to_string(),
+            found: old.fingerprint().to_string(),
+        }]
+    );
+    let message = diags[0].to_string();
+    assert!(message.contains("render a fresh answer sheet"));
+    assert!(message.contains("not migrated"));
+}
+
+#[test]
+fn malformed_preamble_is_diagnosed_per_line() {
+    let q = one_field();
+
+    let diags = q.parse_answer_sheet("").unwrap_err();
+    assert!(matches!(
+        diags[0],
+        AnswerSheetDiagnostic::MalformedPreamble { line: 1, .. }
+    ));
+
+    let diags = q
+        .parse_answer_sheet("not a preamble\nstill not\nnope\n")
+        .unwrap_err();
+    assert_eq!(diags.len(), 3, "each preamble line diagnosed: {diags:?}");
+    assert!(diags
+        .iter()
+        .all(|d| matches!(d, AnswerSheetDiagnostic::MalformedPreamble { .. })));
+}
+
+#[test]
+fn compatibility_failure_skips_body_parsing() {
+    let q = one_field();
+    let sheet = q
+        .render_answer_sheet()
+        .replace("#! standout-answers 1", "#! standout-answers 9")
+        .replace("[project.name]", "[unknown.field]");
+    let diags = q.parse_answer_sheet(&sheet).unwrap_err();
+    // Only the compatibility diagnostic: the body is never interpreted.
+    assert_eq!(
+        diags,
+        vec![AnswerSheetDiagnostic::UnsupportedAnswerFormat { found: "9".into() }]
+    );
+}
+
+// ============================================================================
+// Unknown and duplicate IDs
+// ============================================================================
+
+#[test]
+fn unknown_id_in_header_shaped_line_is_a_diagnostic() {
+    let q = one_field();
+    let sheet = format!(
+        "{}\n3. Bonus question? [project.bonus] (string)\n-> surprise\n",
+        q.render_answer_sheet()
+    );
+    let diags = q.parse_answer_sheet(&sheet).unwrap_err();
+    assert_eq!(
+        diags,
+        vec![AnswerSheetDiagnostic::UnknownFieldId {
+            id: "project.bonus".into(),
+            line: 8,
+        }]
+    );
+}
+
+#[test]
+fn duplicate_field_header_is_a_diagnostic() {
+    let q = one_field();
+    let sheet = format!(
+        "{}\n1. What is the project name? [project.name] (string)\n-> again\n",
+        q.render_answer_sheet()
+    );
+    let diags = q.parse_answer_sheet(&sheet).unwrap_err();
+    assert_eq!(
+        diags,
+        vec![AnswerSheetDiagnostic::DuplicateField {
+            id: "project.name".into(),
+            line: 8,
+        }]
+    );
+}
+
+#[test]
+fn diagnostics_accumulate_across_the_body() {
+    let q = two_fields();
+    let sheet = format!(
+        "{}\n\
+         9. Mystery. [who.knows] (string)\n\
+         -> x\n\
+         \n\
+         1. Again. [project.name] (string)\n\
+         -> y\n",
+        answer(&q.render_answer_sheet(), "project.name", "first")
+    );
+    let diags = q.parse_answer_sheet(&sheet).unwrap_err();
+    assert_eq!(diags.len(), 2, "both problems reported: {diags:?}");
+    assert!(matches!(
+        diags[0],
+        AnswerSheetDiagnostic::UnknownFieldId { .. }
+    ));
+    assert!(matches!(
+        diags[1],
+        AnswerSheetDiagnostic::DuplicateField { .. }
+    ));
+}
+
+#[test]
+fn header_without_marker_is_ordinary_text() {
+    let q = two_fields();
+    // A known-ID, header-shaped-looking line with no following marker line is
+    // absorbed into the surrounding answer, not treated as a field.
+    let edited = answer(
+        &q.render_answer_sheet(),
+        "project.notes",
+        "quoting the header:\n1. What is the project name? [project.name] (string)\ndone",
+    );
+    let answers = q.parse_answer_sheet(&edited).unwrap();
+    assert_eq!(
+        answers.get("project.notes"),
+        Some("quoting the header:\n1. What is the project name? [project.name] (string)\ndone")
+    );
+    assert_eq!(answers.get("project.name"), Some(""));
+}


### PR DESCRIPTION
for #253

## What

Adds the first complete, reusable answer-sheet path to `standout-input`: a public `questionnaire` module where an adopter can define a questionnaire with stable IDs and scalar fields, render the human-oriented prose document deterministically, edit answers as text, and parse them back by stable identity.

- **Definition** (`Questionnaire`, `ScalarField`, `ScalarKind`): validated at construction (ID charset, duplicates, empty lists); wording and field order are cosmetic, IDs/kinds/optionality are semantic.
- **Rendering**: deterministic; emits answer-format version 1, the questionnaire ID, a `sha256:` semantic fingerprint, cosmetic display numbers and type hints, bracketed stable IDs, and the `->` answer marker.
- **Parsing**: a field is recognized only by a schema-recognized bracketed ID whose next line begins with `->`; display numbers, wording, indentation, and hints stay cosmetic. Answers trim outer whitespace and preserve internal line breaks; bracketed prose inside answers never opens a field. Unknown/duplicate IDs on header-shaped lines are accumulated diagnostics.
- **Compatibility**: exact-match on version, questionnaire ID, and fingerprint, with actionable render-a-fresh-sheet diagnostics; no migration or fuzzy matching. The fingerprint sorts fields by ID so ordering/wording edits never invalidate a sheet; semantic edits always do.
- **Docs**: module rustdoc with a runnable round-trip doctest, plus `docs/topics/answer-sheets.md` covering the ownership boundary, stable identity, compatibility, fingerprint limits, and sensitive-content guidance.

## Context

- **Why this approach**: follows `docs/spec/questionnaire-answer-sheets.md` and ADR-0014 directly — prose-first document, identity only from bracketed IDs + `->` markers, exact-version compatibility. The header contract is made precise and testable: a line opens a field only when its last bracketed token is ID-shaped (lowercase/digits/`._-`) *and* the next line starts with `->`; everything else is answer text or ignorable cosmetic prose. Parsing stops at `RawAnswers` (trimmed text keyed by stable ID) so no application-owned types enter the library. `sha2` is added as the one new dependency for the spec's `sha256:` fingerprint format.
- **Self-check**: completed diff checked against the Spec and ADR-0014 — all eight WS01 acceptance criteria have implementation plus tests (23 pure engine tests + doctest); decision boundaries respected (no app types, no fuzzy matching, fingerprint documented as checksum-not-authentication, diagnostics never echo answer values).
- **Out of scope — do not "fix" here**: decoding/validation and shared adapters (#254), nested/repeatable groups (#255), bootstrap-wizard adoption (#256), stdin/confirmation policy (#257). The fingerprint canonical form has its own version tag so later workstreams can extend it deliberately.
- **Verification**: `pixi run test` green (1925 tests), `cargo test -p standout-input --doc` green, commit hook ran the full `pixi run lint` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)