### PR TITLE
STANDOUT-WIZ02-WS02: Epic: Questionnaire Answer Sheets - Workstream: Decode and validate complete scalar answer sheets

### DIFF
--- a/crates/standout-input/docs/topics/answer-sheets.md
+++ b/crates/standout-input/docs/topics/answer-sheets.md
@@ -1,6 +1,6 @@
 # Questionnaire Answer Sheets
 
-Long questionnaires are awkward as a sequence of terminal prompts: you cannot see the whole thing before answering, edit long answers comfortably, or keep a sheet around for a repeatable workflow. The `questionnaire` module renders an application-defined questionnaire as a prose *answer sheet* — a document that reads as questions and answers — and parses the edited document back into raw answers.
+Long questionnaires are awkward as a sequence of terminal prompts: you cannot see the whole thing before answering, edit long answers comfortably, or keep a sheet around for a repeatable workflow. The `questionnaire` module renders an application-defined questionnaire as a prose *answer sheet* — a document that reads as questions and answers — collects answers interactively or from a document, and decodes every submission through one shared validation pipeline.
 
 ```text
 #! standout-answers 1
@@ -10,7 +10,10 @@ Long questionnaires are awkward as a sequence of terminal prompts: you cannot se
 1. What is your project called? [project.name] (string)
 -> wizard-question-generator
 
-2. Add any notes. [project.notes] (text, optional)
+2. License. [project.license] (mit, bsd, or gpl)
+-> mit
+
+3. Add any notes. [project.notes] (text, optional)
 ->
 This answer may span several lines.
 Internal line breaks remain part of the answer.
@@ -22,15 +25,42 @@ Internal line breaks remain part of the answer.
 
 The boundary is deliberate and narrow:
 
-| `standout-input` owns                             | Your application owns                            |
-| ------------------------------------------------- | ------------------------------------------------ |
-| Definition validation (IDs, duplicates)           | The questionnaire definition itself              |
-| Deterministic rendering of the answer sheet       | Decoding raw answers into domain types           |
-| Parsing edited sheets into `RawAnswers`           | Whole-form validation and cross-field rules      |
-| Compatibility checking (version, ID, fingerprint) | Interactive flow, review, confirmation           |
-| Diagnostics with stable IDs and line numbers      | All side effects (file writes, generation, etc.) |
+| `standout-input` owns                              | Your application owns                             |
+| -------------------------------------------------- | ------------------------------------------------- |
+| Definition validation (IDs, defaults, conditions)  | The questionnaire definition itself               |
+| Deterministic rendering of the answer sheet        | Converting decoded `Answers` into domain types    |
+| Parsing edited sheets into `RawAnswers`            | Whole-form rule *content* (a closure you supply)  |
+| Collection adapters (interactive, file, stdin)     | Field-validator rule *content* (with a revision)  |
+| Shared field decoding, constraints, blank rules    | Interactive flow, review, confirmation            |
+| Compatibility checking (version, ID, fingerprint)  | All side effects (file writes, generation, etc.)  |
+| Diagnostics with stable IDs and line numbers       |                                                   |
 
-Parsing stops at `RawAnswers`: trimmed answer text keyed by stable field ID. The library never sees your domain model, and your domain model never leaks into the format.
+Every collection path stops at the same two waypoints: `RawAnswers` (trimmed answer text keyed by stable field ID) and, after `decode_answers`, typed `Answers`. The library never sees your domain model, and your domain model never leaks into the format.
+
+## Defining scalar fields
+
+A `ScalarField` declares everything semantic about one question:
+
+- **Kind** — `String` (single line), `Text` (multiline), `Bool` (decodes `true`/`false`/`yes`/`no`/`y`/`n`, case-insensitive), `Path` (single line, no filesystem checks at decode time).
+- **Optionality** — `.optional()`: a blank answer without a default means omission rather than an error.
+- **Default** — `.with_default("mit")`: rendered pre-filled on the marker line; during decoding, any blank answer resolves to the default *before* optionality is considered. Defaults must decode cleanly themselves.
+- **Constraint** — `.one_of(["mit", "bsd", "gpl"])`: the decoded answer must be one of the choices. Enforced by the shared decoder on every path.
+- **Conditional applicability** — `.active_when("project.docker", "yes")`: the field is asked and enforced only while the (earlier-declared) controller holds the expected value.
+- **Application validator** — `.with_validator(FieldValidator::new("name-rules-1", …))`: your closure runs inside the shared decode stage; the *revision string* is its semantic identity (see fingerprinting below).
+
+## Collecting answers
+
+Three adapters, one representation — every path normalizes to `RawAnswers` and uses the same decoders and validators, so equivalent answers behave identically everywhere. Sources never merge: one submission comes from exactly one source.
+
+- **Interactive** — `collect_interactive()` walks applicable fields through the existing prompt abstractions (and the `PromptResponder` test seam, so tests need no TTY). A decode or validation failure is local and retryable: the one question re-prompts with the diagnostic, and previously accepted answers are kept. Inactive conditional fields are skipped without prompting. EOF / Ctrl+D cancels the collection.
+- **Named file** — `read_answer_sheet_file(path)` reads one complete document.
+- **Explicit stdin** — `read_answer_sheet_stdin()` reads one complete document from piped stdin (for an `--answers -` style flag). An interactive terminal on stdin is an error, not a hang.
+
+## Decoding and batch diagnostics
+
+`decode_answers` (or `decode_answers_with`, which also runs your whole-form closure) applies one blank rule everywhere: blank → declared default → otherwise omission if optional, missing-value error if required. Conditional fields must be answered when active; an inactive field may stay blank (or keep its untouched pre-filled default), while a *populated* inactive field is an error — stale intent is never silently discarded.
+
+Batch submissions accumulate every independent diagnostic — syntax and identity problems from parsing, then missing values, conversion failures, constraint violations, field-validator rejections, and your whole-form errors — so a sheet can be repaired in one editing pass. Diagnostics identify fields by stable ID and never echo submitted values.
 
 ## Stable identity
 
@@ -50,18 +80,20 @@ Every sheet's preamble pins three things:
 
 Parsing accepts only exact matches of all three. A stale or foreign sheet gets an actionable diagnostic asking for a freshly rendered sheet — never a guessed mapping from old fields to new ones.
 
-The fingerprint covers the *semantic* definition: field IDs, value kinds, and optionality. It ignores wording, help text, display numbers, and presentation order, so cosmetic edits keep old sheets valid while semantic changes reliably invalidate them.
+The fingerprint covers every semantic property that changes which answers are accepted: field IDs, kinds, optionality, defaults, constraint choices, conditions, and declared validator revisions. It ignores wording, help text, display numbers, presentation order, and choice order, so cosmetic edits keep old sheets valid while semantic changes reliably invalidate them. Because a validator closure's behavior cannot be observed, its revision string stands in for it — bump the revision whenever the validator's accepted values change.
 
 **The fingerprint is a compatibility checksum, not authentication.** It does not detect tampering and does not protect the document's content.
 
 ## Sensitive content
 
-Answer sheets are plain text files holding whatever your questions ask for — possibly credentials, internal names, or personal data. Treat a saved sheet with the same care as the answers themselves: keep it out of version control and world-readable locations, and delete it when no longer needed. Diagnostics identify fields by stable ID and line number without echoing answer values.
+Answer sheets are plain text files holding whatever your questions ask for — possibly credentials, internal names, or personal data. Treat a saved sheet with the same care as the answers themselves: keep it out of version control and world-readable locations, and delete it when no longer needed. Diagnostics identify fields by stable ID and line number without echoing answer values; your validator and form messages should follow the same rule.
 
 ## Example
 
 ```rust
-use standout_input::questionnaire::{Questionnaire, ScalarField, ScalarKind};
+use standout_input::questionnaire::{
+    FormError, Questionnaire, ScalarField, ScalarKind,
+};
 
 // Application-owned definition. The IDs are the stable contract;
 // the wording is yours to edit at any time.
@@ -69,24 +101,53 @@ let questionnaire = Questionnaire::new(
     "demo.profile",
     vec![
         ScalarField::new("project.name", "What is your project called?", ScalarKind::String),
+        ScalarField::new("project.license", "License.", ScalarKind::String)
+            .one_of(["mit", "bsd", "gpl"])
+            .with_default("mit"),
+        ScalarField::new("project.docker", "Use Docker?", ScalarKind::Bool)
+            .with_default("no"),
+        ScalarField::new("project.docker_image", "Base image?", ScalarKind::String)
+            .active_when("project.docker", "yes"),
         ScalarField::new("project.notes", "Add any notes.", ScalarKind::Text).optional(),
     ],
 )
 .unwrap();
 
-// Render a blank sheet for the user to edit…
+// Render a blank sheet for the user to edit (defaults pre-filled)…
 let sheet = questionnaire.render_answer_sheet();
 
-// …and later, parse the edited document back. In a real flow the edited
-// text comes back from the user's editor; here we answer in place.
+// …and later, collect from wherever the caller chose — a file, piped
+// stdin, or interactive prompts — then decode through the shared pipeline
+// plus your whole-form rules.
 let edited_text = sheet.replace(
     "[project.name] (string)\n->",
     "[project.name] (string)\n-> wizard-question-generator",
 );
-match questionnaire.parse_answer_sheet(&edited_text) {
+
+// Stage 1: document → raw answers (syntax, identity, compatibility).
+let raw = match questionnaire.parse_answer_sheet(&edited_text) {
+    Ok(raw) => raw,
+    Err(diagnostics) => {
+        for diagnostic in diagnostics {
+            eprintln!("{diagnostic}");
+        }
+        return;
+    }
+};
+
+// Stage 2: raw answers → typed values (defaults, kinds, constraints,
+// conditions, your field validators, your whole-form rules).
+match questionnaire.decode_answers_with(&raw, |answers| {
+    let mut errors = Vec::new();
+    if answers.get_text("project.name") == Some("reserved") {
+        errors.push(FormError::new(["project.name"], "that name is reserved"));
+    }
+    errors
+}) {
     Ok(answers) => {
-        // Raw text by stable ID; decoding into domain types is yours.
-        let name = answers.get("project.name");
+        // Typed values by stable ID; domain conversion is yours.
+        let name = answers.get_text("project.name");
+        let docker = answers.get_bool("project.docker");
     }
     Err(diagnostics) => {
         for diagnostic in diagnostics {
@@ -100,4 +161,4 @@ Rendering is deterministic: the same definition always produces the same bytes, 
 
 ## Current scope
 
-This first slice covers scalar fields (single- and multi-line prose answers). Nested and repeatable groups, shared decoding with interactive collection, and accumulated whole-form validation build on this same identity and compatibility model.
+This slice covers scalar fields end to end: definition, rendering with defaults, interactive / file / stdin collection, shared decoding with constraints, conditions, and application validators, and accumulated batch diagnostics. Nested and repeatable groups build on this same identity and compatibility model.

--- a/crates/standout-input/src/lib.rs
+++ b/crates/standout-input/src/lib.rs
@@ -40,10 +40,11 @@
 //! # Questionnaire answer sheets
 //!
 //! The [`questionnaire`] module renders an application-defined questionnaire
-//! as an editable prose answer sheet and parses the edited document back into
-//! raw answers by stable field identity. See the module documentation for the
-//! format, the application/library ownership boundary, and the exact-match
-//! compatibility contract.
+//! as an editable prose answer sheet, collects answers interactively or from
+//! a named file or explicit stdin, and decodes every submission through one
+//! shared validation pipeline keyed by stable field identity. See the module
+//! documentation for the format, the application/library ownership boundary,
+//! and the exact-match compatibility contract.
 //!
 //! # Testing
 //!

--- a/crates/standout-input/src/questionnaire/collect.rs
+++ b/crates/standout-input/src/questionnaire/collect.rs
@@ -1,0 +1,209 @@
+//! Collection adapters: named file, explicit stdin, and interactive prompts.
+//!
+//! Each adapter is a thin normalizer. The file and stdin adapters read one
+//! complete answer-sheet document and hand it to the shared parser; the
+//! interactive adapter walks the fields through the existing prompt
+//! abstractions ([`TextPromptSource`] plus the process-global
+//! [`PromptResponder`](crate::PromptResponder) test seam). All three end at
+//! the same place — [`RawAnswers`] — and every answer they capture runs
+//! through the same field decoders and validators in
+//! [`decode`](super::decode). There is deliberately no adapter-specific
+//! conversion, message wording, or answer-source merging: one submission
+//! comes from exactly one source.
+//!
+//! Interactive collection keeps the immediate feedback loop: a decode or
+//! field-validation failure re-prompts the current question with the
+//! diagnostic, keeping every previously accepted answer. Cancellation (EOF /
+//! Ctrl+D or a responder `Cancel`) aborts the whole collection with
+//! [`InputError::PromptCancelled`].
+
+use std::path::Path;
+
+use crate::env::{DefaultStdin, StdinReader};
+
+use super::definition::Questionnaire;
+use super::parse::{AnswerSheetDiagnostic, RawAnswers};
+
+#[cfg(feature = "simple-prompts")]
+use std::collections::BTreeMap;
+#[cfg(feature = "simple-prompts")]
+use std::sync::Arc;
+
+#[cfg(feature = "simple-prompts")]
+use super::definition::{Constraint, ScalarKind};
+
+#[cfg(feature = "simple-prompts")]
+use crate::sources::{RealTerminal, TerminalIO, TextPromptSource};
+#[cfg(feature = "simple-prompts")]
+use crate::InputError;
+
+#[cfg(feature = "simple-prompts")]
+use super::decode::{decode_field, is_active, FieldOutcome};
+
+impl Questionnaire {
+    /// Read one complete answer sheet from a named file.
+    ///
+    /// The whole document is read and parsed in one pass; the result is the
+    /// same [`RawAnswers`] representation every collection path produces.
+    /// Validate it with [`decode_answers`](Self::decode_answers) (or
+    /// [`decode_answers_with`](Self::decode_answers_with)).
+    ///
+    /// # Errors
+    ///
+    /// [`AnswerSheetDiagnostic::UnreadableDocument`] when the file cannot be
+    /// read, otherwise the parser's accumulated diagnostics.
+    pub fn read_answer_sheet_file(
+        &self,
+        path: impl AsRef<Path>,
+    ) -> Result<RawAnswers, Vec<AnswerSheetDiagnostic>> {
+        let path = path.as_ref();
+        let text = std::fs::read_to_string(path).map_err(|error| {
+            vec![AnswerSheetDiagnostic::UnreadableDocument {
+                detail: format!("{}: {error}", path.display()),
+            }]
+        })?;
+        self.parse_answer_sheet(&text)
+    }
+
+    /// Read one complete answer sheet from explicitly requested stdin
+    /// (e.g. an `--answers -` style flag).
+    ///
+    /// Reads through the process-default stdin reader, which honors a test
+    /// override installed via
+    /// [`set_default_stdin_reader`](crate::env::set_default_stdin_reader).
+    /// Selecting stdin is an explicit caller decision — this adapter never
+    /// merges stdin answers with any other source.
+    ///
+    /// # Errors
+    ///
+    /// [`AnswerSheetDiagnostic::UnreadableDocument`] when stdin is an
+    /// interactive terminal (there is no piped document to read) or fails to
+    /// read, otherwise the parser's accumulated diagnostics.
+    pub fn read_answer_sheet_stdin(&self) -> Result<RawAnswers, Vec<AnswerSheetDiagnostic>> {
+        self.read_answer_sheet_stdin_with(&DefaultStdin)
+    }
+
+    /// [`read_answer_sheet_stdin`](Self::read_answer_sheet_stdin) against an
+    /// explicit [`StdinReader`], for callers and tests that inject their own.
+    pub fn read_answer_sheet_stdin_with(
+        &self,
+        reader: &dyn StdinReader,
+    ) -> Result<RawAnswers, Vec<AnswerSheetDiagnostic>> {
+        if reader.is_terminal() {
+            return Err(vec![AnswerSheetDiagnostic::UnreadableDocument {
+                detail: "stdin is an interactive terminal; pipe an answer sheet or pass a file"
+                    .to_string(),
+            }]);
+        }
+        let text = reader.read_to_string().map_err(|error| {
+            vec![AnswerSheetDiagnostic::UnreadableDocument {
+                detail: format!("stdin: {error}"),
+            }]
+        })?;
+        self.parse_answer_sheet(&text)
+    }
+
+    /// Collect answers interactively, one prompt per applicable field.
+    ///
+    /// Prompts through [`TextPromptSource`] on the real terminal — and
+    /// therefore through any installed
+    /// [`PromptResponder`](crate::PromptResponder), which is how tests drive
+    /// this without a TTY. Every entered answer runs through the same field
+    /// decoders and validators as file and stdin answers; a failure is a
+    /// *local, retryable* error — the question re-prompts with the
+    /// diagnostic and all previously accepted answers are kept. A blank
+    /// entry follows the shared blank rule (default first, then omission or
+    /// a required-answer retry), and inactive conditional fields are skipped
+    /// without prompting.
+    ///
+    /// The result is the same [`RawAnswers`] representation the document
+    /// adapters produce (each entry already field-valid); run
+    /// [`decode_answers`](Self::decode_answers) or
+    /// [`decode_answers_with`](Self::decode_answers_with) on it for typed
+    /// values and whole-form rules.
+    ///
+    /// # Errors
+    ///
+    /// - [`InputError::PromptCancelled`] when the user cancels (EOF/Ctrl+D).
+    /// - [`InputError::NoInput`] when stdin is not a terminal and no
+    ///   responder is installed (interactive collection needs one or the
+    ///   other; it never silently reads a piped document).
+    /// - Any terminal I/O failure from the underlying prompt source.
+    #[cfg(feature = "simple-prompts")]
+    pub fn collect_interactive(&self) -> Result<RawAnswers, InputError> {
+        self.collect_interactive_with_terminal(Arc::new(RealTerminal))
+    }
+
+    /// [`collect_interactive`](Self::collect_interactive) against an
+    /// explicit shared terminal, for callers and tests that inject their own
+    /// [`TerminalIO`] (e.g. [`MockTerminal`](crate::MockTerminal)).
+    #[cfg(feature = "simple-prompts")]
+    pub fn collect_interactive_with_terminal<T: TerminalIO + 'static>(
+        &self,
+        terminal: Arc<T>,
+    ) -> Result<RawAnswers, InputError> {
+        if crate::responder::current_prompt_responder().is_none() && !terminal.is_terminal() {
+            return Err(InputError::NoInput);
+        }
+
+        let mut raw: BTreeMap<String, String> = BTreeMap::new();
+        let mut outcomes: BTreeMap<String, FieldOutcome> = BTreeMap::new();
+
+        for field in self.fields() {
+            // Interactive fields either decode or retry, so controllers are
+            // never in an errored state and applicability is always known.
+            if is_active(field, &outcomes) != Some(true) {
+                outcomes.insert(field.id().to_string(), FieldOutcome::Inactive);
+                continue;
+            }
+
+            let base = interactive_message(field);
+            let mut message = base.clone();
+            loop {
+                let source = TextPromptSource::with_terminal(message.clone(), terminal.clone());
+                let entered = match source.prompt() {
+                    Ok(text) => text,
+                    // Blank entry (or a responder `Skip`): the shared blank
+                    // rule decides between default, omission, and retry.
+                    Err(InputError::NoInput) => String::new(),
+                    Err(error) => return Err(error),
+                };
+                match decode_field(field, Some(&entered)) {
+                    Ok(outcome) => {
+                        raw.insert(field.id().to_string(), entered.trim().to_string());
+                        outcomes.insert(
+                            field.id().to_string(),
+                            match outcome {
+                                Some(value) => FieldOutcome::Answered(value),
+                                None => FieldOutcome::Omitted,
+                            },
+                        );
+                        break;
+                    }
+                    Err(diagnostic) => {
+                        message = format!("{diagnostic} Try again: {base}");
+                    }
+                }
+            }
+        }
+
+        Ok(RawAnswers::from_values(raw))
+    }
+}
+
+/// The cosmetic prompt message for one field: its wording plus entry hints
+/// (choices, the yes/no vocabulary, the pre-filled default).
+#[cfg(feature = "simple-prompts")]
+fn interactive_message(field: &super::definition::ScalarField) -> String {
+    let mut message = field.prompt().to_string();
+    if let Some(Constraint::OneOf(choices)) = field.constraint() {
+        message.push_str(&format!(" ({})", choices.join(" / ")));
+    } else if field.kind() == ScalarKind::Bool {
+        message.push_str(" (yes/no)");
+    }
+    if let Some(default) = field.default() {
+        message.push_str(&format!(" [default: {default}]"));
+    }
+    message.push(' ');
+    message
+}

--- a/crates/standout-input/src/questionnaire/decode.rs
+++ b/crates/standout-input/src/questionnaire/decode.rs
@@ -1,0 +1,427 @@
+//! Shared decoding and validation of raw answers.
+//!
+//! Every collection path — interactive prompts, named files, and explicit
+//! stdin — normalizes to [`RawAnswers`] and runs through the functions here,
+//! so equivalent raw text always decodes to the same value with the same
+//! diagnostics. There are no adapter-specific conversions or messages.
+//!
+//! Decoding one field applies, in order: blank resolution (a blank answer
+//! resolves to the declared default first; an optional blank without a
+//! default is an omission; a required blank without a default is a
+//! missing-value error), kind conversion, constraint checking, and the
+//! application's [`FieldValidator`](super::FieldValidator). Whole-document
+//! decoding ([`Questionnaire::decode_answers`]) additionally evaluates
+//! conditional applicability and accumulates every independent diagnostic
+//! instead of stopping at the first; the application's whole-form rules
+//! join the same accumulated list via
+//! [`Questionnaire::decode_answers_with`].
+//!
+//! Diagnostics identify fields by stable ID and never echo submitted values;
+//! see the [module documentation](crate::questionnaire) for why.
+
+use std::collections::BTreeMap;
+
+use super::definition::{Constraint, Questionnaire, ScalarField, ScalarKind};
+use super::parse::RawAnswers;
+
+/// A decoded, field-validated answer value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnswerValue {
+    /// The value of a `String`, `Text`, or `Path` field.
+    Text(String),
+    /// The value of a `Bool` field.
+    Bool(bool),
+}
+
+impl AnswerValue {
+    /// The text content, for `String` / `Text` / `Path` fields.
+    pub fn as_text(&self) -> Option<&str> {
+        match self {
+            AnswerValue::Text(s) => Some(s),
+            AnswerValue::Bool(_) => None,
+        }
+    }
+
+    /// The boolean content, for `Bool` fields.
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            AnswerValue::Bool(b) => Some(*b),
+            AnswerValue::Text(_) => None,
+        }
+    }
+
+    /// Canonical string form, used to evaluate conditions: text verbatim,
+    /// bools as `true` / `false`.
+    pub(crate) fn canonical(&self) -> String {
+        match self {
+            AnswerValue::Text(s) => s.clone(),
+            AnswerValue::Bool(b) => if *b { "true" } else { "false" }.to_string(),
+        }
+    }
+}
+
+/// The decoded, validated answers for one questionnaire submission.
+///
+/// Contains one entry per *answered* field. Omitted optional fields and
+/// inactive conditional fields are absent. Conversion into application
+/// domain types starts from here.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Answers {
+    values: BTreeMap<String, AnswerValue>,
+}
+
+impl Answers {
+    /// The decoded value for a stable field ID, if the field was answered.
+    pub fn get(&self, field_id: &str) -> Option<&AnswerValue> {
+        self.values.get(field_id)
+    }
+
+    /// The text value for a `String` / `Text` / `Path` field, if answered.
+    pub fn get_text(&self, field_id: &str) -> Option<&str> {
+        self.get(field_id).and_then(AnswerValue::as_text)
+    }
+
+    /// The boolean value for a `Bool` field, if answered.
+    pub fn get_bool(&self, field_id: &str) -> Option<bool> {
+        self.get(field_id).and_then(AnswerValue::as_bool)
+    }
+
+    /// Iterate over `(field_id, value)` pairs, ordered by field ID.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &AnswerValue)> {
+        self.values.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    /// Number of answered fields.
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Whether no field was answered.
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
+
+/// One whole-form error returned by an application form validator.
+///
+/// Mapped into [`ValidationDiagnostic::Form`] so form-level findings
+/// accumulate in the same list as field-level ones. The message should
+/// describe the rule without echoing submitted values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FormError {
+    /// Stable IDs of the fields involved (may be empty for a global rule).
+    pub fields: Vec<String>,
+    /// User-facing description of the violated rule.
+    pub message: String,
+}
+
+impl FormError {
+    /// Create a form error over the given fields.
+    pub fn new(
+        fields: impl IntoIterator<Item = impl Into<String>>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            fields: fields.into_iter().map(Into::into).collect(),
+            message: message.into(),
+        }
+    }
+}
+
+/// One problem found while decoding and validating raw answers.
+///
+/// Diagnostics identify fields by stable ID and describe the violated rule;
+/// they never echo the submitted value, since answers may be sensitive.
+/// Independent diagnostics accumulate: a batch submission reports everything
+/// actionable in one pass.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum ValidationDiagnostic {
+    /// A required, active field has no answer (blank or absent, no default).
+    #[error("[{id}]: this question requires an answer.")]
+    MissingAnswer {
+        /// The unanswered field.
+        id: String,
+    },
+
+    /// An inactive conditional field was populated.
+    #[error("[{id}]: this question does not apply (it is asked only when {controller} is {expected}); remove its answer or change the controlling answer.")]
+    InactiveAnswered {
+        /// The populated inactive field.
+        id: String,
+        /// Its controlling field.
+        controller: String,
+        /// The canonical value that would activate it.
+        expected: String,
+    },
+
+    /// The answer text does not convert to the field's kind.
+    #[error("[{id}]: {reason}")]
+    InvalidValue {
+        /// The field whose answer failed conversion.
+        id: String,
+        /// What the kind expects (never the submitted value).
+        reason: String,
+    },
+
+    /// The converted answer is not one of the declared choices.
+    #[error("[{id}]: the answer must be one of: {}.", allowed.join(", "))]
+    ConstraintViolation {
+        /// The constrained field.
+        id: String,
+        /// The declared choices (definition data, safe to echo).
+        allowed: Vec<String>,
+    },
+
+    /// The application's field validator rejected the converted answer.
+    #[error("[{id}]: {message}")]
+    FieldValidation {
+        /// The rejected field.
+        id: String,
+        /// The validator's user-facing message.
+        message: String,
+    },
+
+    /// An application whole-form rule was violated.
+    #[error("{}", form_display(.fields, .message))]
+    Form {
+        /// Stable IDs of the fields involved (may be empty).
+        fields: Vec<String>,
+        /// The rule's user-facing message.
+        message: String,
+    },
+}
+
+/// Render a whole-form diagnostic: the rule's message, plus the involved
+/// stable field IDs when the rule names any.
+fn form_display(fields: &[String], message: &str) -> String {
+    if fields.is_empty() {
+        message.to_string()
+    } else {
+        format!("{message} (fields: {})", fields.join(", "))
+    }
+}
+
+/// Parse the shared boolean vocabulary: `true`/`false`/`yes`/`no`/`y`/`n`,
+/// case-insensitive. This is the single bool decoder for every collection
+/// path and for canonicalizing condition expected values.
+pub(crate) fn parse_bool(text: &str) -> Option<bool> {
+    match text.trim().to_ascii_lowercase().as_str() {
+        "true" | "yes" | "y" => Some(true),
+        "false" | "no" | "n" => Some(false),
+        _ => None,
+    }
+}
+
+/// Convert non-blank answer text through kind conversion, constraint
+/// checking, and the application validator.
+///
+/// Shared by every collection path and by definition-time default
+/// validation. Diagnostic reasons never include `text`.
+pub(crate) fn check_field_text(
+    field: &ScalarField,
+    text: &str,
+) -> Result<AnswerValue, ValidationDiagnostic> {
+    let value = match field.kind() {
+        ScalarKind::Text => AnswerValue::Text(text.to_string()),
+        ScalarKind::String | ScalarKind::Path => {
+            if text.contains('\n') {
+                return Err(ValidationDiagnostic::InvalidValue {
+                    id: field.id().to_string(),
+                    reason: format!("a {} answer must be a single line", field.kind().name()),
+                });
+            }
+            AnswerValue::Text(text.to_string())
+        }
+        ScalarKind::Bool => match parse_bool(text) {
+            Some(b) => AnswerValue::Bool(b),
+            None => {
+                return Err(ValidationDiagnostic::InvalidValue {
+                    id: field.id().to_string(),
+                    reason: "expected a yes/no answer (true, false, yes, no, y, or n)".to_string(),
+                })
+            }
+        },
+    };
+    if let Some(Constraint::OneOf(choices)) = field.constraint() {
+        let matches = value
+            .as_text()
+            .is_some_and(|t| choices.iter().any(|c| c == t));
+        if !matches {
+            return Err(ValidationDiagnostic::ConstraintViolation {
+                id: field.id().to_string(),
+                allowed: choices.clone(),
+            });
+        }
+    }
+    if let Some(validator) = field.validator() {
+        if let Err(message) = validator.check(&value) {
+            return Err(ValidationDiagnostic::FieldValidation {
+                id: field.id().to_string(),
+                message,
+            });
+        }
+    }
+    Ok(value)
+}
+
+/// Decode one active field's raw answer.
+///
+/// `raw` is the trimmed answer text, or `None` when the field is absent from
+/// the submission. Blank resolves through the declared default first; a
+/// blank without a default is an omission (`Ok(None)`) when optional and a
+/// [`ValidationDiagnostic::MissingAnswer`] when required.
+pub(crate) fn decode_field(
+    field: &ScalarField,
+    raw: Option<&str>,
+) -> Result<Option<AnswerValue>, ValidationDiagnostic> {
+    let submitted = raw.map(str::trim).filter(|t| !t.is_empty());
+    let effective = submitted.or(field.default());
+    match effective {
+        Some(text) => check_field_text(field, text).map(Some),
+        None if field.is_optional() => Ok(None),
+        None => Err(ValidationDiagnostic::MissingAnswer {
+            id: field.id().to_string(),
+        }),
+    }
+}
+
+/// What happened to one field during a whole-document decode pass.
+pub(crate) enum FieldOutcome {
+    /// Decoded and validated to a value.
+    Answered(AnswerValue),
+    /// Active and optional, left blank without a default.
+    Omitted,
+    /// Condition unsatisfied; the field was (correctly) not answered.
+    Inactive,
+    /// This field (or its controller chain) produced a diagnostic, so
+    /// dependents cannot be judged and are skipped without diagnostics.
+    Errored,
+}
+
+/// Evaluate a field's applicability from earlier outcomes.
+///
+/// `Some(true)` / `Some(false)` when applicability is known; `None` when the
+/// controller (or its chain) errored, so the field cannot be judged.
+pub(crate) fn is_active(
+    field: &ScalarField,
+    outcomes: &BTreeMap<String, FieldOutcome>,
+) -> Option<bool> {
+    let Some(condition) = field.condition() else {
+        return Some(true);
+    };
+    match outcomes.get(condition.controller()) {
+        Some(FieldOutcome::Answered(value)) => Some(value.canonical() == condition.expected()),
+        Some(FieldOutcome::Omitted) | Some(FieldOutcome::Inactive) => Some(false),
+        Some(FieldOutcome::Errored) | None => None,
+    }
+}
+
+impl Questionnaire {
+    /// Decode and validate a complete raw submission.
+    ///
+    /// Fields are processed in declaration order (controllers precede their
+    /// dependents by construction). For each field: applicability is
+    /// evaluated from earlier decoded values; an active field decodes via
+    /// [the shared field pipeline](Self::decode_answers) — default
+    /// resolution, kind conversion, constraints, application validator; an
+    /// inactive field must be blank or hold its untouched pre-filled
+    /// default, otherwise it is reported as populated-but-inapplicable.
+    ///
+    /// All independent diagnostics accumulate: one pass reports every
+    /// missing value, conversion failure, constraint violation, field-
+    /// validation failure, and populated inactive field together. A field
+    /// whose controller errored is skipped without piling on speculative
+    /// diagnostics.
+    ///
+    /// # Errors
+    ///
+    /// The accumulated [`ValidationDiagnostic`] list, identifying fields by
+    /// stable ID without echoing submitted values.
+    pub fn decode_answers(&self, raw: &RawAnswers) -> Result<Answers, Vec<ValidationDiagnostic>> {
+        let mut outcomes: BTreeMap<String, FieldOutcome> = BTreeMap::new();
+        let mut diagnostics = Vec::new();
+
+        for field in self.fields() {
+            let raw_value = raw.get(field.id());
+            let outcome = match is_active(field, &outcomes) {
+                None => FieldOutcome::Errored,
+                Some(false) => {
+                    let blank = raw_value.is_none_or(|t| t.trim().is_empty());
+                    let untouched_default =
+                        field.default().is_some() && raw_value == field.default();
+                    if blank || untouched_default {
+                        FieldOutcome::Inactive
+                    } else {
+                        let condition = field.condition().expect("inactive implies condition");
+                        diagnostics.push(ValidationDiagnostic::InactiveAnswered {
+                            id: field.id().to_string(),
+                            controller: condition.controller().to_string(),
+                            expected: condition.expected().to_string(),
+                        });
+                        FieldOutcome::Errored
+                    }
+                }
+                Some(true) => match decode_field(field, raw_value) {
+                    Ok(Some(value)) => FieldOutcome::Answered(value),
+                    Ok(None) => FieldOutcome::Omitted,
+                    Err(diagnostic) => {
+                        diagnostics.push(diagnostic);
+                        FieldOutcome::Errored
+                    }
+                },
+            };
+            outcomes.insert(field.id().to_string(), outcome);
+        }
+
+        if !diagnostics.is_empty() {
+            return Err(diagnostics);
+        }
+        let values = outcomes
+            .into_iter()
+            .filter_map(|(id, outcome)| match outcome {
+                FieldOutcome::Answered(value) => Some((id, value)),
+                _ => None,
+            })
+            .collect();
+        Ok(Answers { values })
+    }
+
+    /// Decode and validate a complete raw submission, then run the
+    /// application's whole-form rules over the successful result.
+    ///
+    /// Field-level diagnostics behave exactly as in
+    /// [`decode_answers`](Self::decode_answers). When the field stage
+    /// succeeds, `form` runs once over the decoded [`Answers`] and every
+    /// returned [`FormError`] accumulates as a
+    /// [`ValidationDiagnostic::Form`] — so a batch submission reports all of
+    /// its independent form-level findings together, in the same list and
+    /// format as field-level ones. Whole-form rules do not run over a
+    /// submission with field-level failures: they would be judging values
+    /// that do not exist.
+    ///
+    /// # Errors
+    ///
+    /// The accumulated [`ValidationDiagnostic`] list from whichever stages
+    /// could run.
+    pub fn decode_answers_with<F>(
+        &self,
+        raw: &RawAnswers,
+        form: F,
+    ) -> Result<Answers, Vec<ValidationDiagnostic>>
+    where
+        F: FnOnce(&Answers) -> Vec<FormError>,
+    {
+        let answers = self.decode_answers(raw)?;
+        let form_errors = form(&answers);
+        if form_errors.is_empty() {
+            return Ok(answers);
+        }
+        Err(form_errors
+            .into_iter()
+            .map(|e| ValidationDiagnostic::Form {
+                fields: e.fields,
+                message: e.message,
+            })
+            .collect())
+    }
+}

--- a/crates/standout-input/src/questionnaire/definition.rs
+++ b/crates/standout-input/src/questionnaire/definition.rs
@@ -5,34 +5,46 @@
 //! data and the split is the point:
 //!
 //! - **Semantic** (identity-bearing): the questionnaire ID, each field's
-//!   stable ID, its [`ScalarKind`], and its optionality. These feed the
-//!   [fingerprint](Questionnaire::fingerprint) and determine how a rendered
-//!   sheet is parsed.
+//!   stable ID, its [`ScalarKind`], its optionality, its declared default,
+//!   its [`Constraint`], its conditional-applicability [`Condition`], and the
+//!   revision of any attached [`FieldValidator`]. These feed the
+//!   [fingerprint](Questionnaire::fingerprint) and determine how answers are
+//!   decoded and validated.
 //! - **Cosmetic** (presentation-only): question wording and field order.
 //!   Changing them never changes answer identity or the fingerprint.
 //!
 //! Definitions are validated at construction: [`Questionnaire::new`] rejects
-//! empty or malformed IDs and duplicate field IDs, so every constructed
-//! questionnaire can render and parse without further checks.
+//! empty or malformed IDs, duplicate field IDs, invalid defaults and
+//! constraints, and conditions that reference unknown or later-declared
+//! fields, so every constructed questionnaire can render, parse, and decode
+//! without further checks.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
+use super::decode::{check_field_text, AnswerValue};
 use super::fingerprint::compute_fingerprint;
 
 /// The kind of value a scalar field collects.
 ///
 /// The kind is *semantic*: it participates in the questionnaire
-/// [fingerprint](Questionnaire::fingerprint) and drives the rendered type
-/// hint. It does not change how raw answer text is captured — both kinds
-/// round-trip text with outer whitespace trimmed and internal line breaks
-/// preserved. Decoding raw text into typed values is application/later-stage
-/// work, not part of the answer-sheet boundary.
+/// [fingerprint](Questionnaire::fingerprint), drives the rendered type hint,
+/// and selects the shared decoder every collection path uses. Interactive,
+/// file, and stdin answers for the same field always run through the same
+/// kind decoder, so equivalent raw text decodes identically everywhere.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScalarKind {
-    /// A short, single-line-oriented value (rendered hint: `string`).
+    /// A short, single-line value (rendered hint: `string`). A multi-line
+    /// answer is a decode error.
     String,
     /// Free-form prose that may span several lines (rendered hint: `text`).
     Text,
+    /// A yes/no value (rendered hint: `bool`). Decodes `true`/`false`/
+    /// `yes`/`no`/`y`/`n` case-insensitively.
+    Bool,
+    /// A filesystem path (rendered hint: `path`). Decoded as a single-line
+    /// string; no filesystem checks are performed at decode time.
+    Path,
 }
 
 impl ScalarKind {
@@ -41,43 +53,209 @@ impl ScalarKind {
         match self {
             ScalarKind::String => "string",
             ScalarKind::Text => "text",
+            ScalarKind::Bool => "bool",
+            ScalarKind::Path => "path",
         }
     }
 }
+
+/// A semantic constraint on the values a field accepts.
+///
+/// Constraints are checked by the shared decoder after kind conversion, so
+/// every collection path enforces them identically. They participate in the
+/// [fingerprint](Questionnaire::fingerprint).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Constraint {
+    /// The decoded answer must equal one of these values exactly.
+    ///
+    /// Choice order is presentation-only (the fingerprint sorts it); the set
+    /// of choices is semantic.
+    OneOf(Vec<String>),
+}
+
+/// A static conditional-applicability rule: this field is asked (and may be
+/// required) only when a previously declared *controller* field decoded to
+/// an expected value.
+///
+/// Conditions are semantic: they participate in the
+/// [fingerprint](Questionnaire::fingerprint). The expected value is stored
+/// canonically (for a bool controller, `true`/`false` — so declaring
+/// `"yes"` and `"true"` produce the same fingerprint).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Condition {
+    pub(crate) controller: String,
+    pub(crate) expected: String,
+}
+
+impl Condition {
+    /// The stable ID of the controlling field.
+    pub fn controller(&self) -> &str {
+        &self.controller
+    }
+
+    /// The canonical expected value that activates the dependent field.
+    pub fn expected(&self) -> &str {
+        &self.expected
+    }
+}
+
+/// The shared closure type behind a [`FieldValidator`]: judges a decoded
+/// value, returning a user-facing message on rejection.
+type ValidatorCheck = Arc<dyn Fn(&AnswerValue) -> Result<(), String> + Send + Sync>;
+
+/// An application-supplied field validator with an explicit semantic
+/// revision.
+///
+/// The closure runs in the shared decode stage, so interactive, file, and
+/// stdin answers are validated identically. Because closure semantics cannot
+/// be fingerprinted, the application declares an explicit `revision` string
+/// that *does* enter the [fingerprint](Questionnaire::fingerprint): bump the
+/// revision whenever the validator's accepted values change, and previously
+/// rendered sheets are invalidated exactly like any other semantic change.
+///
+/// Error messages returned by the closure are shown to users in diagnostics;
+/// they should describe the rule without echoing the submitted value.
+#[derive(Clone)]
+pub struct FieldValidator {
+    revision: String,
+    check: ValidatorCheck,
+}
+
+impl FieldValidator {
+    /// Create a validator with a semantic `revision` and a `check` that
+    /// returns a user-facing message on rejection.
+    pub fn new(
+        revision: impl Into<String>,
+        check: impl Fn(&AnswerValue) -> Result<(), String> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            revision: revision.into(),
+            check: Arc::new(check),
+        }
+    }
+
+    /// The semantic revision that participates in the fingerprint.
+    pub fn revision(&self) -> &str {
+        &self.revision
+    }
+
+    /// Run the validator against a decoded value.
+    pub(crate) fn check(&self, value: &AnswerValue) -> Result<(), String> {
+        (self.check)(value)
+    }
+}
+
+impl std::fmt::Debug for FieldValidator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FieldValidator")
+            .field("revision", &self.revision)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Equality compares the semantic revision only; the closure itself is not
+/// comparable, and the revision is the declared semantic identity.
+impl PartialEq for FieldValidator {
+    fn eq(&self, other: &Self) -> bool {
+        self.revision == other.revision
+    }
+}
+
+impl Eq for FieldValidator {}
 
 /// One scalar question in a questionnaire.
 ///
 /// The `id` is the stable machine identity rendered as the bracketed token
 /// (`[project.name]`); the `prompt` is human wording and may be edited freely
-/// without affecting compatibility.
+/// without affecting compatibility. Everything else — kind, optionality,
+/// default, constraint, condition, and validator revision — is semantic.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScalarField {
     pub(crate) id: String,
     pub(crate) prompt: String,
     pub(crate) kind: ScalarKind,
     pub(crate) optional: bool,
+    pub(crate) default: Option<String>,
+    pub(crate) constraint: Option<Constraint>,
+    pub(crate) condition: Option<Condition>,
+    pub(crate) validator: Option<FieldValidator>,
 }
 
 impl ScalarField {
     /// Create a required scalar field with a stable `id`, human `prompt`
     /// wording, and answer `kind`.
     ///
-    /// The `id` is validated when the field is passed to
-    /// [`Questionnaire::new`], not here.
+    /// The `id` and all declared properties are validated when the field is
+    /// passed to [`Questionnaire::new`], not here.
     pub fn new(id: impl Into<String>, prompt: impl Into<String>, kind: ScalarKind) -> Self {
         Self {
             id: id.into(),
             prompt: prompt.into(),
             kind,
             optional: false,
+            default: None,
+            constraint: None,
+            condition: None,
+            validator: None,
         }
     }
 
-    /// Mark this field as optional (a blank answer means omission).
+    /// Mark this field as optional (a blank answer without a default means
+    /// omission rather than a missing-value error).
     ///
     /// Optionality is semantic: it changes the fingerprint.
     pub fn optional(mut self) -> Self {
         self.optional = true;
+        self
+    }
+
+    /// Declare a default value.
+    ///
+    /// The renderer pre-fills the default on the answer marker line, and
+    /// during decoding any blank answer resolves to the default *before*
+    /// optionality is considered. Defaults must be a single line and must
+    /// themselves decode cleanly. Defaults are semantic: they change the
+    /// fingerprint.
+    pub fn with_default(mut self, default: impl Into<String>) -> Self {
+        self.default = Some(default.into());
+        self
+    }
+
+    /// Constrain the answer to one of the given values.
+    ///
+    /// Checked after kind conversion by the shared decoder. Not applicable
+    /// to [`ScalarKind::Bool`] fields. Semantic: changes the fingerprint.
+    pub fn one_of(mut self, choices: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.constraint = Some(Constraint::OneOf(
+            choices.into_iter().map(Into::into).collect(),
+        ));
+        self
+    }
+
+    /// Make this field applicable only when the earlier-declared `controller`
+    /// field decodes to `expected`.
+    ///
+    /// An inactive field may stay blank (or keep its untouched pre-filled
+    /// default) even when required; a *populated* inactive field is a
+    /// validation error. Conditions are semantic: they change the
+    /// fingerprint.
+    pub fn active_when(
+        mut self,
+        controller: impl Into<String>,
+        expected: impl Into<String>,
+    ) -> Self {
+        self.condition = Some(Condition {
+            controller: controller.into(),
+            expected: expected.into(),
+        });
+        self
+    }
+
+    /// Attach an application validator with an explicit semantic revision.
+    ///
+    /// See [`FieldValidator`] for the revision contract.
+    pub fn with_validator(mut self, validator: FieldValidator) -> Self {
+        self.validator = Some(validator);
         self
     }
 
@@ -96,18 +274,69 @@ impl ScalarField {
         self.kind
     }
 
-    /// Whether a blank answer means omission rather than a missing value.
+    /// Whether a blank answer without a default means omission rather than a
+    /// missing value.
     pub fn is_optional(&self) -> bool {
         self.optional
     }
 
+    /// The declared default, if any (semantic).
+    pub fn default(&self) -> Option<&str> {
+        self.default.as_deref()
+    }
+
+    /// The declared constraint, if any (semantic).
+    pub fn constraint(&self) -> Option<&Constraint> {
+        self.constraint.as_ref()
+    }
+
+    /// The conditional-applicability rule, if any (semantic).
+    pub fn condition(&self) -> Option<&Condition> {
+        self.condition.as_ref()
+    }
+
+    /// The attached application validator, if any (its revision is
+    /// semantic).
+    pub fn validator(&self) -> Option<&FieldValidator> {
+        self.validator.as_ref()
+    }
+
     /// The cosmetic type hint rendered after the bracketed ID.
+    ///
+    /// Presentation-only: choices render in "a, b, or c" style, optionality
+    /// and conditions are spelled out, and any square brackets in condition
+    /// values are stripped so a hint can never look like a field header to
+    /// the parser.
     pub(crate) fn type_hint(&self) -> String {
+        let mut hint = match &self.constraint {
+            Some(Constraint::OneOf(choices)) => join_or(choices),
+            None => self.kind.name().to_string(),
+        };
         if self.optional {
-            format!("{}, optional", self.kind.name())
-        } else {
-            self.kind.name().to_string()
+            hint.push_str(", optional");
         }
+        if let Some(condition) = &self.condition {
+            let expected: String = condition
+                .expected
+                .chars()
+                .filter(|c| !matches!(c, '[' | ']'))
+                .collect();
+            hint.push_str(&format!(
+                "; only when {} is {}",
+                condition.controller, expected
+            ));
+        }
+        hint
+    }
+}
+
+/// Join choices in prose style: `a`, `a or b`, `a, b, or c`.
+fn join_or(choices: &[String]) -> String {
+    match choices {
+        [] => String::new(),
+        [one] => one.clone(),
+        [a, b] => format!("{a} or {b}"),
+        [head @ .., last] => format!("{}, or {last}", head.join(", ")),
     }
 }
 
@@ -134,12 +363,67 @@ pub enum QuestionnaireError {
     /// The questionnaire declares no fields.
     #[error("A questionnaire must declare at least one field.")]
     NoFields,
+
+    /// A declared constraint is invalid for its field.
+    #[error("Invalid constraint on field '{id}': {reason}")]
+    InvalidConstraint {
+        /// The field carrying the constraint.
+        id: String,
+        /// Why the constraint is invalid.
+        reason: String,
+    },
+
+    /// A declared default is invalid for its field.
+    #[error("Invalid default on field '{id}': {reason}")]
+    InvalidDefault {
+        /// The field carrying the default.
+        id: String,
+        /// Why the default is invalid.
+        reason: String,
+    },
+
+    /// A condition references a field the questionnaire does not declare.
+    #[error("Field '{id}' is conditioned on unknown field '{controller}'.")]
+    UnknownConditionController {
+        /// The dependent field.
+        id: String,
+        /// The missing controller ID.
+        controller: String,
+    },
+
+    /// A condition references a field declared after the dependent field.
+    /// Controllers must be declared first so answers can be collected and
+    /// decoded in a single pass.
+    #[error("Field '{id}' is conditioned on '{controller}', which is declared after it. Declare the controlling field first.")]
+    ConditionOrder {
+        /// The dependent field.
+        id: String,
+        /// The later-declared controller ID.
+        controller: String,
+    },
+
+    /// A condition's expected value can never match its controller.
+    #[error("Invalid condition on field '{id}': {reason}")]
+    InvalidCondition {
+        /// The dependent field.
+        id: String,
+        /// Why the expected value can never match.
+        reason: String,
+    },
+
+    /// An attached validator declares an empty semantic revision.
+    #[error("Field '{id}' attaches a validator with an empty revision: the revision is the validator's semantic identity and must be non-empty.")]
+    EmptyValidatorRevision {
+        /// The field carrying the validator.
+        id: String,
+    },
 }
 
 /// An application-owned questionnaire definition.
 ///
 /// See the [module documentation](crate::questionnaire) for the ownership
-/// boundary and the rendered answer-sheet format.
+/// boundary, the rendered answer-sheet format, and the collection and
+/// decoding model.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Questionnaire {
     id: String,
@@ -159,17 +443,24 @@ impl Questionnaire {
     /// Create a validated questionnaire definition.
     ///
     /// `id` is the stable questionnaire identity written into every rendered
-    /// sheet's preamble. `fields` are rendered and parsed in the given order,
-    /// but order is cosmetic: reordering fields does not change the
-    /// [fingerprint](Self::fingerprint).
+    /// sheet's preamble. `fields` are rendered, collected, and decoded in the
+    /// given order, but order is cosmetic for identity: reordering fields
+    /// does not change the [fingerprint](Self::fingerprint). The one ordering
+    /// rule is structural: a conditional field's controller must be declared
+    /// before it.
+    ///
+    /// Condition expected values are canonicalized here (a bool controller's
+    /// `"yes"` becomes `"true"`), so equivalent declarations fingerprint
+    /// identically.
     ///
     /// # Errors
     ///
     /// Returns a [`QuestionnaireError`] for an invalid questionnaire or field
-    /// ID, a duplicate field ID, or an empty field list.
+    /// ID, a duplicate field ID, an empty field list, or an invalid default,
+    /// constraint, condition, or validator revision.
     pub fn new(
         id: impl Into<String>,
-        fields: Vec<ScalarField>,
+        mut fields: Vec<ScalarField>,
     ) -> Result<Self, QuestionnaireError> {
         let id = id.into();
         if !valid_id(&id) {
@@ -178,15 +469,34 @@ impl Questionnaire {
         if fields.is_empty() {
             return Err(QuestionnaireError::NoFields);
         }
-        let mut seen: HashSet<&str> = HashSet::with_capacity(fields.len());
-        for field in &fields {
+        let mut seen: HashSet<String> = HashSet::with_capacity(fields.len());
+        let all_ids: HashSet<String> = fields.iter().map(|f| f.id.clone()).collect();
+        // Kind and choices of already-validated (earlier) fields, for
+        // canonicalizing and checking conditions in one pass.
+        let mut earlier: HashMap<String, (ScalarKind, Option<Constraint>)> = HashMap::new();
+
+        for field in &mut fields {
             if !valid_id(&field.id) {
                 return Err(QuestionnaireError::InvalidFieldId(field.id.clone()));
             }
-            if !seen.insert(&field.id) {
+            if !seen.insert(field.id.clone()) {
                 return Err(QuestionnaireError::DuplicateFieldId(field.id.clone()));
             }
+            validate_constraint(field)?;
+            if let Some(condition) = &mut field.condition {
+                canonicalize_condition(&field.id, condition, &earlier, &all_ids)?;
+            }
+            if let Some(validator) = &field.validator {
+                if validator.revision().is_empty() {
+                    return Err(QuestionnaireError::EmptyValidatorRevision {
+                        id: field.id.clone(),
+                    });
+                }
+            }
+            validate_default(field)?;
+            earlier.insert(field.id.clone(), (field.kind, field.constraint.clone()));
         }
+
         let fingerprint = compute_fingerprint(&id, &fields);
         Ok(Self {
             id,
@@ -208,11 +518,12 @@ impl Questionnaire {
     /// The semantic fingerprint (`sha256:<hex>`).
     ///
     /// The fingerprint is a compatibility checksum over the *semantic*
-    /// definition — questionnaire ID, field IDs, kinds, and optionality. It
-    /// deliberately excludes wording, presentation order, and everything else
-    /// cosmetic, so copy-editing a questionnaire never invalidates existing
-    /// answer sheets. It is **not** an authenticity or tamper-proofing
-    /// mechanism.
+    /// definition — questionnaire ID and each field's stable ID, kind,
+    /// optionality, default, constraint, condition, and validator revision.
+    /// It deliberately excludes wording, presentation order, and everything
+    /// else cosmetic, so copy-editing a questionnaire never invalidates
+    /// existing answer sheets, while any change to accepted answers reliably
+    /// does. It is **not** an authenticity or tamper-proofing mechanism.
     pub fn fingerprint(&self) -> &str {
         &self.fingerprint
     }
@@ -221,4 +532,105 @@ impl Questionnaire {
     pub(crate) fn field(&self, id: &str) -> Option<&ScalarField> {
         self.fields.iter().find(|f| f.id == id)
     }
+}
+
+/// Reject constraints that can never apply to their field.
+fn validate_constraint(field: &ScalarField) -> Result<(), QuestionnaireError> {
+    let Some(Constraint::OneOf(choices)) = &field.constraint else {
+        return Ok(());
+    };
+    let invalid = |reason: &str| QuestionnaireError::InvalidConstraint {
+        id: field.id.clone(),
+        reason: reason.to_string(),
+    };
+    if field.kind == ScalarKind::Bool {
+        return Err(invalid("a bool field cannot declare choices"));
+    }
+    if choices.is_empty() {
+        return Err(invalid("the choice list is empty"));
+    }
+    let mut unique = HashSet::new();
+    for choice in choices {
+        if choice.trim().is_empty() || choice.contains('\n') {
+            return Err(invalid("choices must be non-blank single lines"));
+        }
+        if !unique.insert(choice.as_str()) {
+            return Err(invalid("choices must be unique"));
+        }
+    }
+    Ok(())
+}
+
+/// Check a condition against its (earlier-declared) controller and rewrite
+/// the expected value into canonical form.
+fn canonicalize_condition(
+    field_id: &str,
+    condition: &mut Condition,
+    earlier: &HashMap<String, (ScalarKind, Option<Constraint>)>,
+    all_ids: &HashSet<String>,
+) -> Result<(), QuestionnaireError> {
+    let Some((controller_kind, controller_constraint)) = earlier.get(&condition.controller) else {
+        if all_ids.contains(&condition.controller) {
+            return Err(QuestionnaireError::ConditionOrder {
+                id: field_id.to_string(),
+                controller: condition.controller.clone(),
+            });
+        }
+        return Err(QuestionnaireError::UnknownConditionController {
+            id: field_id.to_string(),
+            controller: condition.controller.clone(),
+        });
+    };
+    if *controller_kind == ScalarKind::Bool {
+        match super::decode::parse_bool(&condition.expected) {
+            Some(value) => condition.expected = if value { "true" } else { "false" }.to_string(),
+            None => {
+                return Err(QuestionnaireError::InvalidCondition {
+                    id: field_id.to_string(),
+                    reason: format!(
+                        "controller '{}' is a bool, but the expected value is not a yes/no value",
+                        condition.controller
+                    ),
+                })
+            }
+        }
+    } else if let Some(Constraint::OneOf(choices)) = controller_constraint {
+        if !choices.contains(&condition.expected) {
+            return Err(QuestionnaireError::InvalidCondition {
+                id: field_id.to_string(),
+                reason: format!(
+                    "controller '{}' never accepts the expected value (its choices are: {})",
+                    condition.controller,
+                    choices.join(", ")
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Reject defaults that could not survive the shared decoder or the
+/// single-line marker rendering.
+fn validate_default(field: &ScalarField) -> Result<(), QuestionnaireError> {
+    let Some(default) = &field.default else {
+        return Ok(());
+    };
+    let invalid = |reason: String| QuestionnaireError::InvalidDefault {
+        id: field.id.clone(),
+        reason,
+    };
+    if default.trim().is_empty() {
+        return Err(invalid("a default must be non-blank".to_string()));
+    }
+    if default.contains('\n') {
+        return Err(invalid(
+            "a default must be a single line (it renders on the answer marker line)".to_string(),
+        ));
+    }
+    if let Err(diagnostic) = check_field_text(field, default) {
+        return Err(invalid(format!(
+            "the default does not decode cleanly: {diagnostic}"
+        )));
+    }
+    Ok(())
 }

--- a/crates/standout-input/src/questionnaire/definition.rs
+++ b/crates/standout-input/src/questionnaire/definition.rs
@@ -68,8 +68,11 @@ impl ScalarKind {
 pub enum Constraint {
     /// The decoded answer must equal one of these values exactly.
     ///
-    /// Choice order is presentation-only (the fingerprint sorts it); the set
-    /// of choices is semantic.
+    /// Choices must be unique, non-blank single lines with no outer
+    /// whitespace (answers are trimmed before matching, so anything else is
+    /// unsatisfiable); [`Questionnaire::new`] rejects violations. Choice
+    /// order is presentation-only (the fingerprint sorts it); the set of
+    /// choices is semantic.
     OneOf(Vec<String>),
 }
 
@@ -213,9 +216,9 @@ impl ScalarField {
     ///
     /// The renderer pre-fills the default on the answer marker line, and
     /// during decoding any blank answer resolves to the default *before*
-    /// optionality is considered. Defaults must be a single line and must
-    /// themselves decode cleanly. Defaults are semantic: they change the
-    /// fingerprint.
+    /// optionality is considered. Defaults must be a single line with no
+    /// outer whitespace (parsed answers are trimmed) and must themselves
+    /// decode cleanly. Defaults are semantic: they change the fingerprint.
     pub fn with_default(mut self, default: impl Into<String>) -> Self {
         self.default = Some(default.into());
         self
@@ -554,6 +557,11 @@ fn validate_constraint(field: &ScalarField) -> Result<(), QuestionnaireError> {
         if choice.trim().is_empty() || choice.contains('\n') {
             return Err(invalid("choices must be non-blank single lines"));
         }
+        if choice != choice.trim() {
+            return Err(invalid(
+                "choices must carry no outer whitespace (answers are trimmed before matching, so such a choice is unsatisfiable)",
+            ));
+        }
         if !unique.insert(choice.as_str()) {
             return Err(invalid("choices must be unique"));
         }
@@ -605,12 +613,21 @@ fn canonicalize_condition(
                 ),
             });
         }
+    } else if condition.expected.is_empty() || condition.expected != condition.expected.trim() {
+        return Err(QuestionnaireError::InvalidCondition {
+            id: field_id.to_string(),
+            reason: format!(
+                "controller '{}' never decodes to the expected value (decoded answers are non-blank and carry no outer whitespace)",
+                condition.controller
+            ),
+        });
     }
     Ok(())
 }
 
-/// Reject defaults that could not survive the shared decoder or the
-/// single-line marker rendering.
+/// Reject defaults that could not survive the shared decoder, the
+/// single-line marker rendering, or the render/parse round trip (outer
+/// whitespace is trimmed away at parse time).
 fn validate_default(field: &ScalarField) -> Result<(), QuestionnaireError> {
     let Some(default) = &field.default else {
         return Ok(());
@@ -621,6 +638,12 @@ fn validate_default(field: &ScalarField) -> Result<(), QuestionnaireError> {
     };
     if default.trim().is_empty() {
         return Err(invalid("a default must be non-blank".to_string()));
+    }
+    if default != default.trim() {
+        return Err(invalid(
+            "a default must carry no outer whitespace (parsed answers are trimmed, so it could never survive a render/parse round trip)"
+                .to_string(),
+        ));
     }
     if default.contains('\n') {
         return Err(invalid(

--- a/crates/standout-input/src/questionnaire/fingerprint.rs
+++ b/crates/standout-input/src/questionnaire/fingerprint.rs
@@ -6,26 +6,40 @@
 //! guessing how old answers map onto new semantics.
 //!
 //! The canonical form hashed here includes exactly the semantic surface of a
-//! definition — questionnaire ID, and each field's stable ID, kind, and
-//! optionality — with fields sorted by stable ID so presentation order stays
-//! cosmetic. Wording, numbering, and styling never appear in the canonical
-//! form, so copy edits cannot invalidate existing sheets.
+//! definition — questionnaire ID, and each field's stable ID, kind,
+//! optionality, default, constraint choices, condition, and application-
+//! validator revision — everything that changes which answers are accepted.
+//! Fields are sorted by stable ID and constraint choices are sorted, so
+//! presentation order stays cosmetic. Wording, numbering, and styling never
+//! appear in the canonical form, so copy edits cannot invalidate existing
+//! sheets.
 
 use std::fmt::Write as _;
 
 use sha2::{Digest, Sha256};
 
-use super::definition::ScalarField;
+use super::definition::{Constraint, ScalarField};
 
 /// Version tag for the canonical form itself, distinct from the rendered
 /// answer-format version: changing how the fingerprint is computed must
 /// change every fingerprint.
-const CANONICAL_FORM_VERSION: &str = "1";
+const CANONICAL_FORM_VERSION: &str = "2";
+
+/// Escape free-form text for embedding in the canonical form, so values
+/// containing separators can never collide with the form's structure.
+fn esc(text: &str) -> String {
+    text.replace('\\', "\\\\")
+        .replace('|', "\\|")
+        .replace(',', "\\,")
+        .replace('\n', "\\n")
+}
 
 /// Compute the `sha256:<hex>` fingerprint of a definition's semantic surface.
 ///
 /// Deterministic for a given semantic definition and independent of field
-/// presentation order.
+/// presentation order and constraint-choice order. Optional semantic
+/// properties (default, constraint, condition, validator revision) appear
+/// only when declared, so absence and emptiness cannot collide.
 pub(crate) fn compute_fingerprint(questionnaire_id: &str, fields: &[ScalarField]) -> String {
     let mut canonical = format!(
         "standout-answers-canonical {CANONICAL_FORM_VERSION}\nquestionnaire={questionnaire_id}\n"
@@ -33,13 +47,34 @@ pub(crate) fn compute_fingerprint(questionnaire_id: &str, fields: &[ScalarField]
     let mut sorted: Vec<&ScalarField> = fields.iter().collect();
     sorted.sort_by(|a, b| a.id().cmp(b.id()));
     for field in sorted {
-        let _ = writeln!(
+        let _ = write!(
             canonical,
             "field={}|kind={}|optional={}",
             field.id(),
             field.kind().name(),
             field.is_optional()
         );
+        if let Some(default) = field.default() {
+            let _ = write!(canonical, "|default={}", esc(default));
+        }
+        if let Some(Constraint::OneOf(choices)) = field.constraint() {
+            let mut sorted_choices: Vec<&String> = choices.iter().collect();
+            sorted_choices.sort();
+            let joined: Vec<String> = sorted_choices.iter().map(|c| esc(c)).collect();
+            let _ = write!(canonical, "|one_of={}", joined.join(","));
+        }
+        if let Some(condition) = field.condition() {
+            let _ = write!(
+                canonical,
+                "|active_when={}={}",
+                condition.controller(),
+                esc(condition.expected())
+            );
+        }
+        if let Some(validator) = field.validator() {
+            let _ = write!(canonical, "|validator={}", esc(validator.revision()));
+        }
+        canonical.push('\n');
     }
     let digest = Sha256::digest(canonical.as_bytes());
     let mut out = String::with_capacity(7 + digest.len() * 2);

--- a/crates/standout-input/src/questionnaire/mod.rs
+++ b/crates/standout-input/src/questionnaire/mod.rs
@@ -1,20 +1,26 @@
-//! Questionnaire answer sheets: render a prose questionnaire, let a human
-//! edit it as text, and parse the answers back by stable identity.
+//! Questionnaire answer sheets: render a prose questionnaire, collect
+//! answers interactively or from a document, and decode them by stable
+//! identity through one shared validation pipeline.
 //!
 //! Long questionnaires are awkward as a sequence of terminal prompts. This
 //! module renders an application-defined questionnaire as a prose *answer
 //! sheet* — a document that reads as questions and answers, not as a
-//! configuration format — and parses an edited sheet back into raw answers.
+//! configuration format — and collects answers from any of three sources:
+//! interactive prompts, a named answer file, or explicitly requested stdin.
+//! Every source normalizes into the same [`RawAnswers`] representation and
+//! decodes through the same field decoders and validators, so equivalent
+//! answers behave identically no matter how they arrived. Sources never
+//! merge: one submission comes from exactly one source.
 //!
 //! # Ownership boundary
 //!
 //! `standout-input` owns the reusable machinery: definition validation,
-//! deterministic rendering, parsing, and diagnostics. The application owns
-//! everything else — its questionnaire definition, decoding raw answers into
-//! domain types, whole-form validation, interactive flow, review,
-//! confirmation, and side effects. Parsing stops at [`RawAnswers`]: trimmed
-//! answer text keyed by stable field ID, deliberately short of any
-//! application model.
+//! deterministic rendering, parsing, collection adapters, shared field
+//! decoding and validation, and diagnostics. The application owns everything
+//! else — its questionnaire definition, whole-form rules (supplied as a
+//! closure to [`Questionnaire::decode_answers_with`]), conversion of decoded
+//! [`Answers`] into domain types, interactive flow, review, confirmation,
+//! and side effects.
 //!
 //! # The rendered format
 //!
@@ -26,7 +32,10 @@
 //! 1. What is your project called? [project.name] (string)
 //! ->
 //!
-//! 2. Add any notes. [project.notes] (text, optional)
+//! 2. License. [project.license] (mit, bsd, or gpl)
+//! -> mit
+//!
+//! 3. Add any notes. [project.notes] (text, optional)
 //! ->
 //! ```
 //!
@@ -38,6 +47,25 @@
 //! schema-recognized bracketed ID whose next line begins with the `->`
 //! answer marker; ordinary bracketed prose inside an answer never opens a
 //! field. Answers keep internal line breaks and lose only outer whitespace.
+//! Declared defaults render pre-filled on the marker line.
+//!
+//! # Decoding: defaults, omission, conditions
+//!
+//! Decoding a submission ([`Questionnaire::decode_answers`]) applies one
+//! blank rule everywhere: a blank answer resolves to the declared default
+//! first; without a default, a blank optional field is an omission and a
+//! blank required field is a missing-value error. A conditional field
+//! ([`ScalarField::active_when`]) is asked and enforced only while its
+//! controller holds the expected value; an inactive field may stay blank
+//! (or keep its untouched pre-filled default), while a *populated* inactive
+//! field is an error — stale intent is never silently discarded.
+//!
+//! Interactive collection gives immediate feedback: a failed answer
+//! re-prompts that one question, keeping earlier answers. Batch collection
+//! (file / stdin) reads the whole document and accumulates every
+//! independent diagnostic — syntax, identity, missing values, conversion,
+//! field validation, and the application's whole-form rules — in one pass,
+//! so a sheet can be repaired in one edit.
 //!
 //! # Compatibility: exact match, no migration
 //!
@@ -45,9 +73,10 @@
 //! semantic *fingerprint* of the definition. Parsing accepts only exact
 //! matches of all three; a stale sheet gets a diagnostic asking for a
 //! freshly rendered one, never a guessed field mapping. The fingerprint
-//! covers the semantic definition (IDs, kinds, optionality) and ignores
-//! wording, numbering, and ordering — so copy edits keep old sheets valid,
-//! while semantic changes reliably invalidate them.
+//! covers every semantic property that changes accepted answers — IDs,
+//! kinds, optionality, defaults, constraints, conditions, and declared
+//! validator revisions — and ignores wording, numbering, and ordering. Copy
+//! edits keep old sheets valid; semantic changes reliably invalidate them.
 //!
 //! The fingerprint is a compatibility checksum only. It does not
 //! authenticate a document, detect tampering, or protect its content.
@@ -59,44 +88,55 @@
 //! the same care as the answers themselves: keep it out of version control
 //! and world-readable locations, and delete it when done. Diagnostics from
 //! this module identify fields by ID and line number without echoing answer
-//! values.
+//! values; application validator and form messages should do the same.
 //!
 //! # Round-trip example
 //!
 //! ```
-//! use standout_input::questionnaire::{Questionnaire, ScalarField, ScalarKind};
+//! use standout_input::questionnaire::{FormError, Questionnaire, ScalarField, ScalarKind};
 //!
 //! // The application owns this definition; IDs are the stable contract.
 //! let questionnaire = Questionnaire::new(
 //!     "demo.profile",
 //!     vec![
 //!         ScalarField::new("project.name", "What is your project called?", ScalarKind::String),
-//!         ScalarField::new("project.notes", "Add any notes.", ScalarKind::Text).optional(),
+//!         ScalarField::new("project.docker", "Use Docker?", ScalarKind::Bool)
+//!             .with_default("no"),
+//!         // Asked only when the controller above decodes to true.
+//!         ScalarField::new("project.docker_image", "Base image?", ScalarKind::String)
+//!             .active_when("project.docker", "yes"),
 //!     ],
 //! )
 //! .unwrap();
 //!
-//! // Render the blank sheet, then simulate a user editing answers in.
+//! // Render the blank sheet, then simulate a user editing an answer in.
+//! // The docker default is pre-filled; leaving it means "no", so the
+//! // conditional image question may stay blank.
 //! let sheet = questionnaire.render_answer_sheet();
-//! let edited = sheet
-//!     .replace(
-//!         "1. What is your project called? [project.name] (string)\n->",
-//!         "1. What is your project called? [project.name] (string)\n-> demo",
-//!     )
-//!     .replace(
-//!         "2. Add any notes. [project.notes] (text, optional)\n->",
-//!         "2. Add any notes. [project.notes] (text, optional)\n-> Spans two lines,\nlike [this] one.",
-//!     );
+//! let edited = sheet.replace(
+//!     "[project.name] (string)\n->",
+//!     "[project.name] (string)\n-> demo",
+//! );
 //!
-//! let answers = questionnaire.parse_answer_sheet(&edited).unwrap();
-//! assert_eq!(answers.get("project.name"), Some("demo"));
-//! assert_eq!(answers.get("project.notes"), Some("Spans two lines,\nlike [this] one."));
+//! let raw = questionnaire.parse_answer_sheet(&edited).unwrap();
+//! let answers = questionnaire
+//!     .decode_answers_with(&raw, |_answers| Vec::<FormError>::new())
+//!     .unwrap();
+//! assert_eq!(answers.get_text("project.name"), Some("demo"));
+//! assert_eq!(answers.get_bool("project.docker"), Some(false));
+//! assert_eq!(answers.get("project.docker_image"), None); // inactive
 //! ```
 
+mod collect;
+mod decode;
 mod definition;
 mod fingerprint;
 mod parse;
 mod render;
 
-pub use definition::{Questionnaire, QuestionnaireError, ScalarField, ScalarKind};
+pub use decode::{AnswerValue, Answers, FormError, ValidationDiagnostic};
+pub use definition::{
+    Condition, Constraint, FieldValidator, Questionnaire, QuestionnaireError, ScalarField,
+    ScalarKind,
+};
 pub use parse::{AnswerSheetDiagnostic, RawAnswers};

--- a/crates/standout-input/src/questionnaire/parse.rs
+++ b/crates/standout-input/src/questionnaire/parse.rs
@@ -29,6 +29,14 @@ pub struct RawAnswers {
 }
 
 impl RawAnswers {
+    /// Build raw answers directly, for collection paths (interactive
+    /// prompting) that never see a document. Keys are stable field IDs;
+    /// values are trimmed answer text.
+    #[cfg(feature = "simple-prompts")]
+    pub(crate) fn from_values(values: BTreeMap<String, String>) -> Self {
+        Self { values }
+    }
+
     /// The raw answer text for a stable field ID, if the field appeared.
     pub fn get(&self, field_id: &str) -> Option<&str> {
         self.values.get(field_id).map(String::as_str)
@@ -109,6 +117,14 @@ pub enum AnswerSheetDiagnostic {
         id: String,
         /// 1-based line number of the second occurrence.
         line: usize,
+    },
+
+    /// The answer-sheet document could not be read at all (unreadable file,
+    /// terminal stdin, or an I/O failure), so no content was parsed.
+    #[error("Could not read the answer sheet: {detail}")]
+    UnreadableDocument {
+        /// What prevented reading, without any document content.
+        detail: String,
     },
 }
 

--- a/crates/standout-input/src/questionnaire/render.rs
+++ b/crates/standout-input/src/questionnaire/render.rs
@@ -2,8 +2,9 @@
 //!
 //! Rendering writes the prose document described in the
 //! [module documentation](crate::questionnaire): a three-line `#!` metadata
-//! preamble followed by one numbered question block per field. The same
-//! definition always renders byte-identical output.
+//! preamble followed by one numbered question block per field, with declared
+//! defaults pre-filled on their answer marker lines. The same definition
+//! always renders byte-identical output.
 
 use std::fmt::Write as _;
 
@@ -25,7 +26,9 @@ impl Questionnaire {
     /// produces the same document, including the fingerprint in the preamble.
     /// Each field renders as a header line — cosmetic display number and
     /// wording, the bracketed stable ID, and a parenthesized type hint —
-    /// followed by a bare `->` answer marker awaiting the answer.
+    /// followed by the `->` answer marker. A field with a declared default
+    /// renders the default pre-filled on the marker line; every other field
+    /// renders a bare marker awaiting the answer.
     pub fn render_answer_sheet(&self) -> String {
         let mut out = String::new();
         out.push_str(FORMAT_LINE);
@@ -42,8 +45,15 @@ impl Questionnaire {
                 field.id(),
                 field.type_hint()
             );
-            out.push_str(ANSWER_MARKER);
-            out.push('\n');
+            match field.default() {
+                Some(default) => {
+                    let _ = writeln!(out, "{ANSWER_MARKER} {default}");
+                }
+                None => {
+                    out.push_str(ANSWER_MARKER);
+                    out.push('\n');
+                }
+            }
         }
         out
     }

--- a/crates/standout-input/src/sources/mod.rs
+++ b/crates/standout-input/src/sources/mod.rs
@@ -35,7 +35,7 @@ pub use stdin::{read_if_piped, StdinSource};
 pub use editor::{EditorRunner, EditorSource, MockEditorResult, MockEditorRunner};
 
 #[cfg(feature = "simple-prompts")]
-pub use prompt::{ConfirmPromptSource, MockTerminal, TerminalIO, TextPromptSource};
+pub use prompt::{ConfirmPromptSource, MockTerminal, RealTerminal, TerminalIO, TextPromptSource};
 
 #[cfg(feature = "inquire")]
 pub use inquire_adapters::{

--- a/crates/standout-input/src/sources/prompt.rs
+++ b/crates/standout-input/src/sources/prompt.rs
@@ -23,6 +23,24 @@ pub trait TerminalIO: Send + Sync {
     fn read_line(&self) -> io::Result<String>;
 }
 
+/// Sharing one terminal across several prompt sources: an `Arc<T>` delegates
+/// to the wrapped terminal, so a single (possibly stateful mock) terminal can
+/// back a sequence of [`TextPromptSource`] / [`ConfirmPromptSource`] values —
+/// e.g. one prompt per questionnaire field.
+impl<T: TerminalIO + ?Sized> TerminalIO for Arc<T> {
+    fn is_terminal(&self) -> bool {
+        (**self).is_terminal()
+    }
+
+    fn write_prompt(&self, prompt: &str) -> io::Result<()> {
+        (**self).write_prompt(prompt)
+    }
+
+    fn read_line(&self) -> io::Result<String> {
+        (**self).read_line()
+    }
+}
+
 /// Real terminal I/O.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct RealTerminal;

--- a/crates/standout-input/tests/questionnaire_collection.rs
+++ b/crates/standout-input/tests/questionnaire_collection.rs
@@ -1,0 +1,338 @@
+//! Collection-adapter tests through the real abstractions: named files,
+//! explicit stdin (via the injectable stdin reader), and interactive
+//! prompting (via the prompt-responder seam and the mock terminal) — no real
+//! terminal required. Covers EOF, cancellation, malformed documents,
+//! defaults, conditions, retry-without-loss, and cross-source equivalence.
+
+use std::sync::Arc;
+
+use serial_test::serial;
+use standout_input::env::{reset_default_stdin_reader, set_default_stdin_reader, MockStdin};
+use standout_input::questionnaire::{
+    AnswerSheetDiagnostic, Questionnaire, ScalarField, ScalarKind,
+};
+use standout_input::{
+    reset_default_prompt_responder, set_default_prompt_responder, InputError, MockTerminal,
+    PromptResponse, ScriptedResponder,
+};
+
+fn questionnaire() -> Questionnaire {
+    Questionnaire::new(
+        "demo.collect",
+        vec![
+            ScalarField::new("project.name", "Project name?", ScalarKind::String),
+            ScalarField::new("project.docker", "Use Docker?", ScalarKind::Bool).with_default("no"),
+            ScalarField::new("project.docker_image", "Base image?", ScalarKind::String)
+                .active_when("project.docker", "yes"),
+            ScalarField::new("project.notes", "Notes?", ScalarKind::Text).optional(),
+        ],
+    )
+    .unwrap()
+}
+
+/// Replace a field's rendered marker (bare or pre-filled) with `answer`.
+fn answer(sheet: &str, id: &str, answer: &str) -> String {
+    let needle = format!("[{id}]");
+    let mut out = String::new();
+    let mut lines = sheet.lines().peekable();
+    while let Some(line) = lines.next() {
+        out.push_str(line);
+        out.push('\n');
+        if line.contains(&needle) {
+            let marker = lines.next().expect("marker follows header");
+            assert!(marker.starts_with("->"), "expected a marker line");
+            out.push_str("-> ");
+            out.push_str(answer);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// An edited sheet: name answered, docker default kept, notes blank.
+fn edited_sheet(q: &Questionnaire) -> String {
+    answer(&q.render_answer_sheet(), "project.name", "demo")
+}
+
+struct ResponderGuard;
+impl ResponderGuard {
+    fn install(responses: impl IntoIterator<Item = PromptResponse>) -> Self {
+        set_default_prompt_responder(Arc::new(ScriptedResponder::new(responses)));
+        Self
+    }
+}
+impl Drop for ResponderGuard {
+    fn drop(&mut self) {
+        reset_default_prompt_responder();
+    }
+}
+
+struct StdinGuard;
+impl StdinGuard {
+    fn install(mock: MockStdin) -> Self {
+        set_default_stdin_reader(Arc::new(mock));
+        Self
+    }
+}
+impl Drop for StdinGuard {
+    fn drop(&mut self) {
+        reset_default_stdin_reader();
+    }
+}
+
+// ============================================================================
+// Named-file adapter
+// ============================================================================
+
+#[test]
+fn file_adapter_reads_one_complete_sheet() {
+    let q = questionnaire();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("answers.txt");
+    std::fs::write(&path, edited_sheet(&q)).unwrap();
+
+    let raw = q.read_answer_sheet_file(&path).unwrap();
+    let answers = q.decode_answers(&raw).unwrap();
+    assert_eq!(answers.get_text("project.name"), Some("demo"));
+    assert_eq!(answers.get_bool("project.docker"), Some(false));
+}
+
+#[test]
+fn unreadable_file_is_a_diagnostic_not_a_panic() {
+    let q = questionnaire();
+    let diagnostics = q
+        .read_answer_sheet_file("/nonexistent/answers.txt")
+        .unwrap_err();
+    assert!(matches!(
+        &diagnostics[..],
+        [AnswerSheetDiagnostic::UnreadableDocument { .. }]
+    ));
+}
+
+#[test]
+fn malformed_file_reports_parse_diagnostics() {
+    let q = questionnaire();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("answers.txt");
+    std::fs::write(&path, "not an answer sheet").unwrap();
+
+    let diagnostics = q.read_answer_sheet_file(&path).unwrap_err();
+    assert!(matches!(
+        &diagnostics[..],
+        [AnswerSheetDiagnostic::MalformedPreamble { .. }, ..]
+    ));
+}
+
+// ============================================================================
+// Explicit-stdin adapter
+// ============================================================================
+
+#[test]
+fn stdin_adapter_reads_one_complete_sheet() {
+    let q = questionnaire();
+    let raw = q
+        .read_answer_sheet_stdin_with(&MockStdin::piped(edited_sheet(&q)))
+        .unwrap();
+    let answers = q.decode_answers(&raw).unwrap();
+    assert_eq!(answers.get_text("project.name"), Some("demo"));
+}
+
+#[test]
+fn stdin_adapter_rejects_an_interactive_terminal() {
+    let q = questionnaire();
+    let diagnostics = q
+        .read_answer_sheet_stdin_with(&MockStdin::terminal())
+        .unwrap_err();
+    assert!(matches!(
+        &diagnostics[..],
+        [AnswerSheetDiagnostic::UnreadableDocument { .. }]
+    ));
+}
+
+#[test]
+#[serial(default_stdin)]
+fn stdin_adapter_honors_the_process_default_reader() {
+    let q = questionnaire();
+    let _guard = StdinGuard::install(MockStdin::piped(edited_sheet(&q)));
+    let raw = q.read_answer_sheet_stdin().unwrap();
+    assert_eq!(raw.get("project.name"), Some("demo"));
+}
+
+#[test]
+fn stale_fingerprint_reaches_the_adapter_caller() {
+    let q = questionnaire();
+    let sheet = edited_sheet(&q).replace("sha256:", "sha256:0000");
+    let diagnostics = q
+        .read_answer_sheet_stdin_with(&MockStdin::piped(sheet))
+        .unwrap_err();
+    assert!(matches!(
+        &diagnostics[..],
+        [AnswerSheetDiagnostic::FingerprintMismatch { .. }]
+    ));
+}
+
+// ============================================================================
+// Interactive adapter (prompt-responder seam)
+// ============================================================================
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_collection_walks_active_fields_in_order() {
+    let q = questionnaire();
+    // name, docker=yes, image, notes — all four prompts fire.
+    let _guard = ResponderGuard::install([
+        PromptResponse::text("demo"),
+        PromptResponse::text("yes"),
+        PromptResponse::text("debian:stable"),
+        PromptResponse::text("multi word notes"),
+    ]);
+    let raw = q.collect_interactive().unwrap();
+    let answers = q.decode_answers(&raw).unwrap();
+    assert_eq!(answers.get_text("project.name"), Some("demo"));
+    assert_eq!(answers.get_bool("project.docker"), Some(true));
+    assert_eq!(
+        answers.get_text("project.docker_image"),
+        Some("debian:stable")
+    );
+    assert_eq!(answers.get_text("project.notes"), Some("multi word notes"));
+}
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_collection_skips_inactive_fields_without_prompting() {
+    let q = questionnaire();
+    // Three prompts only: name, docker=no, notes. No image prompt — the
+    // ScriptedResponder would panic on a fourth request.
+    let _guard = ResponderGuard::install([
+        PromptResponse::text("demo"),
+        PromptResponse::text("no"),
+        PromptResponse::Skip,
+    ]);
+    let raw = q.collect_interactive().unwrap();
+    assert_eq!(raw.get("project.docker_image"), None);
+    let answers = q.decode_answers(&raw).unwrap();
+    assert_eq!(answers.get("project.docker_image"), None);
+    assert_eq!(answers.get("project.notes"), None);
+}
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_blank_resolves_defaults_and_omission() {
+    let q = questionnaire();
+    // Skip = blank entry: docker resolves its default, notes is omitted.
+    let _guard = ResponderGuard::install([
+        PromptResponse::text("demo"),
+        PromptResponse::Skip,
+        PromptResponse::Skip,
+    ]);
+    let raw = q.collect_interactive().unwrap();
+    let answers = q.decode_answers(&raw).unwrap();
+    assert_eq!(answers.get_bool("project.docker"), Some(false));
+    assert_eq!(answers.get("project.notes"), None);
+}
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_failures_retry_locally_without_losing_earlier_answers() {
+    let q = questionnaire();
+    // The docker question fails twice (bad bool, then a required blank has a
+    // default so blank *succeeds* — use the name question instead for the
+    // required-blank retry) before the loop accepts an answer.
+    let _guard = ResponderGuard::install([
+        PromptResponse::Skip,          // name: blank, required, no default -> retry
+        PromptResponse::text("demo"),  // name: accepted
+        PromptResponse::text("maybe"), // docker: not a bool -> retry
+        PromptResponse::text("yes"),   // docker: accepted
+        PromptResponse::text("debian:stable"), // image
+        PromptResponse::Skip,          // notes
+    ]);
+    let raw = q.collect_interactive().unwrap();
+    let answers = q.decode_answers(&raw).unwrap();
+    // The earlier accepted answer survived the later retries.
+    assert_eq!(answers.get_text("project.name"), Some("demo"));
+    assert_eq!(answers.get_bool("project.docker"), Some(true));
+}
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_cancellation_aborts_collection() {
+    let q = questionnaire();
+    let _guard = ResponderGuard::install([PromptResponse::text("demo"), PromptResponse::Cancel]);
+    let err = q.collect_interactive().unwrap_err();
+    assert!(matches!(err, InputError::PromptCancelled));
+}
+
+// ============================================================================
+// Interactive adapter (mock terminal)
+// ============================================================================
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_collection_runs_over_an_injected_terminal() {
+    let q = questionnaire();
+    let terminal = Arc::new(MockTerminal::with_responses([
+        "demo",
+        "yes",
+        "debian:stable",
+        "some notes",
+    ]));
+    let raw = q.collect_interactive_with_terminal(terminal).unwrap();
+    let answers = q.decode_answers(&raw).unwrap();
+    assert_eq!(answers.get_text("project.name"), Some("demo"));
+    assert_eq!(
+        answers.get_text("project.docker_image"),
+        Some("debian:stable")
+    );
+}
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_eof_is_cancellation() {
+    let q = questionnaire();
+    let err = q
+        .collect_interactive_with_terminal(Arc::new(MockTerminal::eof()))
+        .unwrap_err();
+    assert!(matches!(err, InputError::PromptCancelled));
+}
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_collection_refuses_a_non_terminal_without_a_responder() {
+    let q = questionnaire();
+    let err = q
+        .collect_interactive_with_terminal(Arc::new(MockTerminal::non_terminal()))
+        .unwrap_err();
+    assert!(matches!(err, InputError::NoInput));
+}
+
+// ============================================================================
+// Cross-source equivalence
+// ============================================================================
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_and_sheet_submissions_decode_identically() {
+    let q = questionnaire();
+
+    let _guard = ResponderGuard::install([
+        PromptResponse::text("demo"),
+        PromptResponse::text("yes"),
+        PromptResponse::text("debian:stable"),
+        PromptResponse::Skip,
+    ]);
+    let interactive = q.decode_answers(&q.collect_interactive().unwrap()).unwrap();
+
+    let sheet = answer(
+        &answer(&edited_sheet(&q), "project.docker", "yes"),
+        "project.docker_image",
+        "debian:stable",
+    );
+    let batch = q
+        .decode_answers(
+            &q.read_answer_sheet_stdin_with(&MockStdin::piped(sheet))
+                .unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(interactive, batch);
+}

--- a/crates/standout-input/tests/questionnaire_decode.rs
+++ b/crates/standout-input/tests/questionnaire_decode.rs
@@ -80,7 +80,9 @@ fn choices_on_bool_field_are_rejected() {
 
 #[test]
 fn empty_and_duplicate_choices_are_rejected() {
-    for choices in [vec![], vec!["x", "x"]] {
+    // Answers are trimmed before matching, so a choice with outer whitespace
+    // is unsatisfiable (and would shadow its trimmed twin in dup detection).
+    for choices in [vec![], vec!["x", "x"], vec![" x", "y"], vec!["x", "x "]] {
         let err = Questionnaire::new(
             "demo.q",
             vec![ScalarField::new("a", "A?", ScalarKind::String).one_of(choices)],
@@ -114,6 +116,15 @@ fn default_must_decode_cleanly() {
     let err = Questionnaire::new(
         "demo.q",
         vec![ScalarField::new("a", "A?", ScalarKind::Text).with_default("one\ntwo")],
+    )
+    .unwrap_err();
+    assert!(matches!(err, QuestionnaireError::InvalidDefault { .. }));
+
+    // A default with outer whitespace could never survive the render/parse
+    // round trip (parsed answers are trimmed).
+    let err = Questionnaire::new(
+        "demo.q",
+        vec![ScalarField::new("a", "A?", ScalarKind::String).with_default(" x ")],
     )
     .unwrap_err();
     assert!(matches!(err, QuestionnaireError::InvalidDefault { .. }));
@@ -166,6 +177,20 @@ fn condition_expected_value_must_be_reachable() {
     )
     .unwrap_err();
     assert!(matches!(err, QuestionnaireError::InvalidCondition { .. }));
+
+    // An unconstrained controller never decodes to a blank value or one with
+    // outer whitespace (answers are trimmed, blanks resolve to omission).
+    for expected in ["", " x "] {
+        let err = Questionnaire::new(
+            "demo.q",
+            vec![
+                ScalarField::new("a", "A?", ScalarKind::String),
+                ScalarField::new("b", "B?", ScalarKind::String).active_when("a", expected),
+            ],
+        )
+        .unwrap_err();
+        assert!(matches!(err, QuestionnaireError::InvalidCondition { .. }));
+    }
 }
 
 #[test]

--- a/crates/standout-input/tests/questionnaire_decode.rs
+++ b/crates/standout-input/tests/questionnaire_decode.rs
@@ -1,0 +1,548 @@
+//! Shared decode/validation engine tests: extended scalar definitions
+//! (kinds, defaults, constraints, conditions, validator revisions),
+//! fingerprint coverage of every semantic property, default pre-filling,
+//! blank resolution, conditional applicability, and accumulated batch
+//! diagnostics.
+
+use standout_input::questionnaire::{
+    AnswerValue, FieldValidator, FormError, Questionnaire, QuestionnaireError, ScalarField,
+    ScalarKind, ValidationDiagnostic,
+};
+
+/// A questionnaire exercising every scalar property: kinds, optionality,
+/// defaults, choices, a condition, and an application validator.
+fn full() -> Questionnaire {
+    Questionnaire::new(
+        "demo.full",
+        vec![
+            ScalarField::new("project.name", "Project name?", ScalarKind::String).with_validator(
+                FieldValidator::new("name-rules-1", |value| {
+                    let name = value.as_text().unwrap_or_default();
+                    if name.contains(' ') {
+                        Err("the name must not contain spaces".to_string())
+                    } else {
+                        Ok(())
+                    }
+                }),
+            ),
+            ScalarField::new("project.license", "License?", ScalarKind::String)
+                .one_of(["mit", "bsd", "gpl"])
+                .with_default("mit"),
+            ScalarField::new("project.docker", "Use Docker?", ScalarKind::Bool).with_default("no"),
+            ScalarField::new("project.docker_image", "Base image?", ScalarKind::Path)
+                .active_when("project.docker", "yes"),
+            ScalarField::new("project.notes", "Notes?", ScalarKind::Text).optional(),
+        ],
+    )
+    .unwrap()
+}
+
+/// Replace a field's rendered marker (bare or pre-filled) with `answer`.
+fn answer(sheet: &str, id: &str, answer: &str) -> String {
+    let needle = format!("[{id}]");
+    let mut out = String::new();
+    let mut lines = sheet.lines().peekable();
+    while let Some(line) = lines.next() {
+        out.push_str(line);
+        out.push('\n');
+        if line.contains(&needle) {
+            let marker = lines.next().expect("marker follows header");
+            assert!(marker.starts_with("->"), "expected a marker line");
+            out.push_str("-> ");
+            out.push_str(answer);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+fn decode(
+    q: &Questionnaire,
+    sheet: &str,
+) -> Result<standout_input::questionnaire::Answers, Vec<ValidationDiagnostic>> {
+    let raw = q.parse_answer_sheet(sheet).expect("sheet parses");
+    q.decode_answers(&raw)
+}
+
+// ============================================================================
+// Definition validation for the extended properties
+// ============================================================================
+
+#[test]
+fn choices_on_bool_field_are_rejected() {
+    let err = Questionnaire::new(
+        "demo.q",
+        vec![ScalarField::new("a", "A?", ScalarKind::Bool).one_of(["x", "y"])],
+    )
+    .unwrap_err();
+    assert!(matches!(err, QuestionnaireError::InvalidConstraint { id, .. } if id == "a"));
+}
+
+#[test]
+fn empty_and_duplicate_choices_are_rejected() {
+    for choices in [vec![], vec!["x", "x"]] {
+        let err = Questionnaire::new(
+            "demo.q",
+            vec![ScalarField::new("a", "A?", ScalarKind::String).one_of(choices)],
+        )
+        .unwrap_err();
+        assert!(matches!(err, QuestionnaireError::InvalidConstraint { .. }));
+    }
+}
+
+#[test]
+fn default_must_decode_cleanly() {
+    // A bool default outside the yes/no vocabulary.
+    let err = Questionnaire::new(
+        "demo.q",
+        vec![ScalarField::new("a", "A?", ScalarKind::Bool).with_default("maybe")],
+    )
+    .unwrap_err();
+    assert!(matches!(err, QuestionnaireError::InvalidDefault { id, .. } if id == "a"));
+
+    // A default outside the declared choices.
+    let err = Questionnaire::new(
+        "demo.q",
+        vec![ScalarField::new("a", "A?", ScalarKind::String)
+            .one_of(["x", "y"])
+            .with_default("z")],
+    )
+    .unwrap_err();
+    assert!(matches!(err, QuestionnaireError::InvalidDefault { .. }));
+
+    // A multiline default cannot render on the marker line.
+    let err = Questionnaire::new(
+        "demo.q",
+        vec![ScalarField::new("a", "A?", ScalarKind::Text).with_default("one\ntwo")],
+    )
+    .unwrap_err();
+    assert!(matches!(err, QuestionnaireError::InvalidDefault { .. }));
+}
+
+#[test]
+fn condition_must_reference_an_earlier_known_field() {
+    let err = Questionnaire::new(
+        "demo.q",
+        vec![ScalarField::new("a", "A?", ScalarKind::String).active_when("ghost", "x")],
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, QuestionnaireError::UnknownConditionController { controller, .. } if controller == "ghost")
+    );
+
+    let err = Questionnaire::new(
+        "demo.q",
+        vec![
+            ScalarField::new("a", "A?", ScalarKind::String).active_when("b", "x"),
+            ScalarField::new("b", "B?", ScalarKind::String),
+        ],
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, QuestionnaireError::ConditionOrder { controller, .. } if controller == "b")
+    );
+}
+
+#[test]
+fn condition_expected_value_must_be_reachable() {
+    // A bool controller with a non-boolean expected value.
+    let err = Questionnaire::new(
+        "demo.q",
+        vec![
+            ScalarField::new("a", "A?", ScalarKind::Bool),
+            ScalarField::new("b", "B?", ScalarKind::String).active_when("a", "sometimes"),
+        ],
+    )
+    .unwrap_err();
+    assert!(matches!(err, QuestionnaireError::InvalidCondition { .. }));
+
+    // A constrained controller whose choices never include the expected value.
+    let err = Questionnaire::new(
+        "demo.q",
+        vec![
+            ScalarField::new("a", "A?", ScalarKind::String).one_of(["x", "y"]),
+            ScalarField::new("b", "B?", ScalarKind::String).active_when("a", "z"),
+        ],
+    )
+    .unwrap_err();
+    assert!(matches!(err, QuestionnaireError::InvalidCondition { .. }));
+}
+
+#[test]
+fn validator_revision_must_be_non_empty() {
+    let err = Questionnaire::new(
+        "demo.q",
+        vec![ScalarField::new("a", "A?", ScalarKind::String)
+            .with_validator(FieldValidator::new("", |_| Ok(())))],
+    )
+    .unwrap_err();
+    assert!(matches!(err, QuestionnaireError::EmptyValidatorRevision { id } if id == "a"));
+}
+
+// ============================================================================
+// Fingerprint: every semantic property participates; presentation does not
+// ============================================================================
+
+fn fp(fields: Vec<ScalarField>) -> String {
+    Questionnaire::new("demo.q", fields)
+        .unwrap()
+        .fingerprint()
+        .to_string()
+}
+
+#[test]
+fn default_constraint_condition_and_revision_all_enter_the_fingerprint() {
+    let base = || ScalarField::new("a", "A?", ScalarKind::String);
+    let plain = fp(vec![base()]);
+
+    assert_ne!(plain, fp(vec![base().with_default("x")]));
+    assert_ne!(
+        fp(vec![base().with_default("x")]),
+        fp(vec![base().with_default("y")])
+    );
+    assert_ne!(plain, fp(vec![base().one_of(["x", "y"])]));
+    assert_ne!(
+        plain,
+        fp(vec![
+            base().with_validator(FieldValidator::new("v1", |_| Ok(())))
+        ])
+    );
+    assert_ne!(
+        fp(vec![
+            base().with_validator(FieldValidator::new("v1", |_| Ok(())))
+        ]),
+        fp(vec![
+            base().with_validator(FieldValidator::new("v2", |_| Ok(())))
+        ])
+    );
+
+    let with_condition = |expected: &str| {
+        fp(vec![
+            ScalarField::new("c", "C?", ScalarKind::String),
+            ScalarField::new("a", "A?", ScalarKind::String).active_when("c", expected),
+        ])
+    };
+    let without_condition = fp(vec![
+        ScalarField::new("c", "C?", ScalarKind::String),
+        ScalarField::new("a", "A?", ScalarKind::String),
+    ]);
+    assert_ne!(without_condition, with_condition("x"));
+    assert_ne!(with_condition("x"), with_condition("y"));
+}
+
+#[test]
+fn presentation_only_properties_stay_out_of_the_fingerprint() {
+    // Choice order is presentation; the choice set is semantic.
+    assert_eq!(
+        fp(vec![
+            ScalarField::new("a", "A?", ScalarKind::String).one_of(["x", "y"])
+        ]),
+        fp(vec![
+            ScalarField::new("a", "Reworded?", ScalarKind::String).one_of(["y", "x"])
+        ])
+    );
+    // A validator closure's behavior is invisible; only the revision counts.
+    assert_eq!(
+        fp(vec![ScalarField::new("a", "A?", ScalarKind::String)
+            .with_validator(FieldValidator::new("v1", |_| Ok(())))]),
+        fp(vec![ScalarField::new("a", "A?", ScalarKind::String)
+            .with_validator(FieldValidator::new("v1", |_| Err(
+                "no".to_string()
+            )))])
+    );
+}
+
+#[test]
+fn bool_condition_values_are_canonicalized_for_identity() {
+    let declare = |expected: &str| {
+        fp(vec![
+            ScalarField::new("c", "C?", ScalarKind::Bool),
+            ScalarField::new("a", "A?", ScalarKind::String).active_when("c", expected),
+        ])
+    };
+    assert_eq!(declare("yes"), declare("true"));
+    assert_eq!(declare("yes"), declare("Y"));
+    assert_ne!(declare("yes"), declare("no"));
+}
+
+// ============================================================================
+// Rendering: defaults pre-filled, hints stay cosmetic
+// ============================================================================
+
+#[test]
+fn defaults_render_pre_filled_and_round_trip() {
+    let q = full();
+    let sheet = q.render_answer_sheet();
+    assert!(sheet.contains("[project.license] (mit, bsd, or gpl)\n-> mit\n"));
+    assert!(sheet.contains("-> no\n"));
+
+    // An untouched sheet decodes: name is missing (required, no default),
+    // everything else resolves through defaults and omission.
+    let filled = answer(&sheet, "project.name", "demo");
+    let answers = decode(&q, &filled).unwrap();
+    assert_eq!(answers.get_text("project.name"), Some("demo"));
+    assert_eq!(answers.get_text("project.license"), Some("mit"));
+    assert_eq!(answers.get_bool("project.docker"), Some(false));
+    assert_eq!(answers.get("project.docker_image"), None);
+    assert_eq!(answers.get("project.notes"), None);
+}
+
+// ============================================================================
+// Blank resolution: default first, then optionality
+// ============================================================================
+
+#[test]
+fn blank_resolves_default_before_optionality() {
+    let q = full();
+    let sheet = q.render_answer_sheet();
+    // Blank out the pre-filled license default entirely.
+    let blanked = answer(&sheet, "project.license", "");
+    let filled = answer(&blanked, "project.name", "demo");
+    let answers = decode(&q, &filled).unwrap();
+    assert_eq!(answers.get_text("project.license"), Some("mit"));
+}
+
+#[test]
+fn required_blank_without_default_is_missing() {
+    let q = full();
+    let sheet = q.render_answer_sheet();
+    let diagnostics = decode(&q, &sheet).unwrap_err();
+    assert_eq!(
+        diagnostics,
+        vec![ValidationDiagnostic::MissingAnswer {
+            id: "project.name".to_string()
+        }]
+    );
+}
+
+// ============================================================================
+// Kind conversion and constraints
+// ============================================================================
+
+#[test]
+fn bool_vocabulary_is_shared_and_case_insensitive() {
+    let q = full();
+    let sheet = answer(&q.render_answer_sheet(), "project.name", "demo");
+    for (text, expected) in [("TRUE", true), ("Yes", true), ("y", true), ("n", false)] {
+        let answers = decode(&q, &answer(&sheet, "project.docker", text));
+        // Answering docker=true activates the image question, which is then
+        // missing — so only check the docker decode for the true cases.
+        match answers {
+            Ok(a) => assert_eq!(a.get_bool("project.docker"), Some(expected)),
+            Err(d) => {
+                assert!(expected, "false must not activate the image question");
+                assert_eq!(
+                    d,
+                    vec![ValidationDiagnostic::MissingAnswer {
+                        id: "project.docker_image".to_string()
+                    }]
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn invalid_bool_and_multiline_string_are_conversion_errors() {
+    let q = full();
+    let sheet = answer(&q.render_answer_sheet(), "project.name", "demo");
+    let diagnostics = decode(&q, &answer(&sheet, "project.docker", "maybe")).unwrap_err();
+    assert!(matches!(
+        &diagnostics[..],
+        [ValidationDiagnostic::InvalidValue { id, .. }] if id == "project.docker"
+    ));
+
+    let diagnostics = decode(&q, &answer(&sheet, "project.name", "two\nlines")).unwrap_err();
+    assert!(matches!(
+        &diagnostics[..],
+        [ValidationDiagnostic::InvalidValue { id, .. }] if id == "project.name"
+    ));
+}
+
+#[test]
+fn constraint_violations_report_the_choices_not_the_value() {
+    let q = full();
+    let sheet = answer(&q.render_answer_sheet(), "project.name", "demo");
+    let diagnostics = decode(&q, &answer(&sheet, "project.license", "wtfpl")).unwrap_err();
+    assert_eq!(
+        diagnostics,
+        vec![ValidationDiagnostic::ConstraintViolation {
+            id: "project.license".to_string(),
+            allowed: vec!["mit".to_string(), "bsd".to_string(), "gpl".to_string()],
+        }]
+    );
+    assert!(!diagnostics[0].to_string().contains("wtfpl"));
+}
+
+#[test]
+fn application_validator_runs_in_the_shared_pipeline() {
+    let q = full();
+    let sheet = answer(&q.render_answer_sheet(), "project.name", "has spaces");
+    let diagnostics = decode(&q, &sheet).unwrap_err();
+    assert_eq!(
+        diagnostics,
+        vec![ValidationDiagnostic::FieldValidation {
+            id: "project.name".to_string(),
+            message: "the name must not contain spaces".to_string(),
+        }]
+    );
+}
+
+// ============================================================================
+// Conditional applicability
+// ============================================================================
+
+#[test]
+fn active_required_conditional_field_must_be_answered() {
+    let q = full();
+    let sheet = answer(&q.render_answer_sheet(), "project.name", "demo");
+    let diagnostics = decode(&q, &answer(&sheet, "project.docker", "yes")).unwrap_err();
+    assert_eq!(
+        diagnostics,
+        vec![ValidationDiagnostic::MissingAnswer {
+            id: "project.docker_image".to_string()
+        }]
+    );
+
+    let filled = answer(
+        &answer(&sheet, "project.docker", "yes"),
+        "project.docker_image",
+        "debian:stable",
+    );
+    let answers = decode(&q, &filled).unwrap();
+    assert_eq!(
+        answers.get_text("project.docker_image"),
+        Some("debian:stable")
+    );
+}
+
+#[test]
+fn populated_inactive_field_is_an_error() {
+    let q = full();
+    let sheet = answer(&q.render_answer_sheet(), "project.name", "demo");
+    // docker stays "no" (default): the image question is inactive.
+    let stale = answer(&sheet, "project.docker_image", "debian:stable");
+    let diagnostics = decode(&q, &stale).unwrap_err();
+    assert_eq!(
+        diagnostics,
+        vec![ValidationDiagnostic::InactiveAnswered {
+            id: "project.docker_image".to_string(),
+            controller: "project.docker".to_string(),
+            expected: "true".to_string(),
+        }]
+    );
+}
+
+#[test]
+fn inactive_field_keeps_untouched_pre_filled_default() {
+    let q = Questionnaire::new(
+        "demo.q",
+        vec![
+            ScalarField::new("a", "A?", ScalarKind::Bool).with_default("no"),
+            ScalarField::new("b", "B?", ScalarKind::String)
+                .with_default("fallback")
+                .active_when("a", "yes"),
+        ],
+    )
+    .unwrap();
+    // Untouched sheet: b's pre-filled default remains while b is inactive.
+    let answers = decode(&q, &q.render_answer_sheet()).unwrap();
+    assert_eq!(answers.get("b"), None);
+}
+
+#[test]
+fn errored_controller_skips_dependents_without_piling_on() {
+    let q = full();
+    let sheet = answer(&q.render_answer_sheet(), "project.name", "demo");
+    // The controller fails to decode; its dependent must not add noise.
+    let diagnostics = decode(&q, &answer(&sheet, "project.docker", "maybe")).unwrap_err();
+    assert_eq!(diagnostics.len(), 1);
+}
+
+// ============================================================================
+// Accumulation and whole-form validation
+// ============================================================================
+
+#[test]
+fn independent_diagnostics_accumulate_in_one_pass() {
+    let q = full();
+    let sheet = q.render_answer_sheet(); // name left blank: missing
+    let bad = answer(&sheet, "project.license", "wtfpl"); // constraint violation
+    let diagnostics = decode(&q, &bad).unwrap_err();
+    assert_eq!(diagnostics.len(), 2);
+    assert!(diagnostics
+        .iter()
+        .any(|d| matches!(d, ValidationDiagnostic::MissingAnswer { id } if id == "project.name")));
+    assert!(diagnostics.iter().any(
+        |d| matches!(d, ValidationDiagnostic::ConstraintViolation { id, .. } if id == "project.license")
+    ));
+}
+
+#[test]
+fn form_errors_accumulate_after_a_clean_field_stage() {
+    let q = full();
+    let sheet = answer(&q.render_answer_sheet(), "project.name", "demo");
+    let raw = q.parse_answer_sheet(&sheet).unwrap();
+
+    let diagnostics = q
+        .decode_answers_with(&raw, |_| {
+            vec![
+                FormError::new(["project.name"], "the name is already taken"),
+                FormError::new(Vec::<String>::new(), "the project limit is reached"),
+            ]
+        })
+        .unwrap_err();
+    assert_eq!(
+        diagnostics,
+        vec![
+            ValidationDiagnostic::Form {
+                fields: vec!["project.name".to_string()],
+                message: "the name is already taken".to_string(),
+            },
+            ValidationDiagnostic::Form {
+                fields: vec![],
+                message: "the project limit is reached".to_string(),
+            },
+        ]
+    );
+    assert_eq!(
+        diagnostics[0].to_string(),
+        "the name is already taken (fields: project.name)"
+    );
+}
+
+#[test]
+fn form_validation_does_not_run_over_broken_fields() {
+    let q = full();
+    let raw = q.parse_answer_sheet(&q.render_answer_sheet()).unwrap();
+    let diagnostics = q
+        .decode_answers_with(&raw, |_| panic!("form must not run on field failures"))
+        .unwrap_err();
+    assert!(matches!(
+        &diagnostics[..],
+        [ValidationDiagnostic::MissingAnswer { .. }]
+    ));
+}
+
+#[test]
+fn form_success_passes_the_answers_through() {
+    let q = full();
+    let sheet = answer(&q.render_answer_sheet(), "project.name", "demo");
+    let raw = q.parse_answer_sheet(&sheet).unwrap();
+    let answers = q.decode_answers_with(&raw, |_| Vec::new()).unwrap();
+    assert_eq!(answers.get_text("project.name"), Some("demo"));
+}
+
+// ============================================================================
+// Decoded value surface
+// ============================================================================
+
+#[test]
+fn answer_values_expose_typed_accessors() {
+    let text = AnswerValue::Text("x".to_string());
+    let boolean = AnswerValue::Bool(true);
+    assert_eq!(text.as_text(), Some("x"));
+    assert_eq!(text.as_bool(), None);
+    assert_eq!(boolean.as_bool(), Some(true));
+    assert_eq!(boolean.as_text(), None);
+}


### PR DESCRIPTION
for #254

## What

Extends the WS01 scalar answer-sheet engine (`crates/standout-input/src/questionnaire/`) into complete collection and validation behavior:

- **Definitions**: `ScalarKind` gains `Bool` and `Path`; fields gain `.with_default()`, `.one_of()` (choice constraint), `.active_when()` (static conditional applicability against an earlier-declared controller), and `.with_validator(FieldValidator::new(revision, check))` — an application validator whose explicit revision string is its semantic identity. All properties are validated at construction (defaults must decode cleanly, conditions must reference reachable controller values, etc.).
- **Fingerprint**: canonical form v2 covers every semantic property that changes accepted answers — defaults, sorted constraint choices, canonicalized condition values (a bool controller's `"yes"` fingerprints as `"true"`), validator revisions — with free-text values escaped. Wording, field order, and choice order stay cosmetic.
- **Rendering**: declared defaults render pre-filled on the answer marker line; hints (choices in "a, b, or c" style, condition notes) stay cosmetic and bracket-free so they can never look like headers to the parser.
- **Shared decoding** (`decode.rs`): one pipeline for every source — blank resolves to the default first, then optional-blank omits and required-blank errors; kind conversion; constraint check; application validator. `decode_answers` evaluates conditional applicability (active required must be answered; inactive blank/untouched-default accepted; populated inactive is an error) and accumulates all independent diagnostics by stable ID without echoing submitted values. `decode_answers_with` folds application whole-form errors into the same diagnostic list.
- **Collection adapters** (`collect.rs`): `read_answer_sheet_file` and `read_answer_sheet_stdin[_with]` read one complete document (terminal stdin is an `UnreadableDocument` diagnostic, not a hang); `collect_interactive[_with_terminal]` walks applicable fields through `TextPromptSource`/`PromptResponder`, with locally retryable decode failures that keep earlier answers, blank entries following the shared blank rule, inactive fields skipped, and EOF/cancel aborting. All three normalize to the same `RawAnswers`; sources never merge.

## Context

- **Why this approach**: the acceptance criteria demand adapter-shared decoding — so *all* kinds (including bool) prompt through the plain text prompt and decode via the one shared decoder, rather than using `ConfirmPromptSource`'s own y/n handling, which would have been an adapter-specific conversion. Conditions must name an earlier-declared controller (a construction error otherwise): that keeps interactive collection and batch decoding single-pass and cycle-free while field *order* stays cosmetic for identity. An inactive field keeping its untouched pre-filled default is accepted (only user-supplied values on inactive fields error), otherwise every rendered sheet with a defaulted conditional field would fail when inactive.
- **Self-check against governing docs**: diff checked against `docs/spec/questionnaire-answer-sheets.md` (blank→default-first rule identical interactive/batch §"Prose answer-sheet format"; shared decoders/validators and accumulated batch diagnostics §"Collection and validation"; populated-inactive-is-an-error; fingerprint semantic inclusion/exclusion list incl. explicit validator revisions §fingerprint; no answer-source merging; stdin adapter stops at the reusable collection layer) and `docs/adr/0014` (prose-first format, stable bracketed identity, exact version/ID/fingerprint match, no migration — all preserved). Mandatory test seams 1 and 2 are covered here (`tests/questionnaire_decode.rs`, `tests/questionnaire_collection.rs`) via `ScriptedResponder`, `MockTerminal` (incl. EOF), `MockStdin`, and tempfiles — no real terminal; library-level cross-source equivalence is asserted; app-boundary equivalence and real CLI flows (seams 3–4) belong to the wizard-adoption workstreams.
- **Out of scope — do not "fix"**: nested/repeatable groups (#255), bootstrap-wizard adoption (#256), confirmation policy and `--yes` (#257), application domain types in `standout-input`, answer-source merging, fuzzy migration. `Constraint`/`ValidationDiagnostic` enums are deliberately minimal (one constraint kind, spec-derived diagnostics) — richer variants wait for real consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)