### PR TITLE
STANDOUT-WIZ02-WS03: Epic: Questionnaire Answer Sheets - Workstream: Round-trip nested and repeatable questionnaire groups

### DIFF
--- a/crates/standout-input/src/lib.rs
+++ b/crates/standout-input/src/lib.rs
@@ -40,11 +40,13 @@
 //! # Questionnaire answer sheets
 //!
 //! The [`questionnaire`] module renders an application-defined questionnaire
-//! as an editable prose answer sheet, collects answers interactively or from
-//! a named file or explicit stdin, and decodes every submission through one
-//! shared validation pipeline keyed by stable field identity. See the module
-//! documentation for the format, the application/library ownership boundary,
-//! and the exact-match compatibility contract.
+//! — scalar fields plus nested and repeatable groups — as an editable prose
+//! answer sheet, collects answers interactively or from a named file or
+//! explicit stdin, and decodes every submission through one shared
+//! validation pipeline keyed by stable identity (with indexed occurrence
+//! paths for repeated items). See the module documentation for the format,
+//! the application/library ownership boundary, and the exact-match
+//! compatibility contract.
 //!
 //! # Testing
 //!

--- a/crates/standout-input/src/questionnaire/collect.rs
+++ b/crates/standout-input/src/questionnaire/collect.rs
@@ -30,7 +30,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 #[cfg(feature = "simple-prompts")]
-use super::definition::{Constraint, ScalarKind};
+use super::definition::{Constraint, Group, Item, ScalarField, ScalarKind};
 
 #[cfg(feature = "simple-prompts")]
 use crate::sources::{RealTerminal, TerminalIO, TextPromptSource};
@@ -38,7 +38,7 @@ use crate::sources::{RealTerminal, TerminalIO, TextPromptSource};
 use crate::InputError;
 
 #[cfg(feature = "simple-prompts")]
-use super::decode::{decode_field, is_active, FieldOutcome};
+use super::decode::{decode_field, is_active, parse_bool, FieldOutcome, ScopeCtx};
 
 impl Questionnaire {
     /// Read one complete answer sheet from a named file.
@@ -103,7 +103,8 @@ impl Questionnaire {
         self.parse_answer_sheet(&text)
     }
 
-    /// Collect answers interactively, one prompt per applicable field.
+    /// Collect answers interactively, one prompt per applicable field
+    /// occurrence.
     ///
     /// Prompts through [`TextPromptSource`] on the real terminal — and
     /// therefore through any installed
@@ -116,9 +117,16 @@ impl Questionnaire {
     /// a required-answer retry), and inactive conditional fields are skipped
     /// without prompting.
     ///
+    /// Groups walk their children in place. A repeatable group collects its
+    /// declared minimum number of occurrences, then asks a yes/no
+    /// "add another?" question (blank means no) before each further
+    /// occurrence, stopping unprompted at the declared maximum — so an
+    /// interactive submission always satisfies the declared bounds, exactly
+    /// like a well-formed answer sheet.
+    ///
     /// The result is the same [`RawAnswers`] representation the document
-    /// adapters produce (each entry already field-valid); run
-    /// [`decode_answers`](Self::decode_answers) or
+    /// adapters produce (each entry already field-valid, keyed by occurrence
+    /// path); run [`decode_answers`](Self::decode_answers) or
     /// [`decode_answers_with`](Self::decode_answers_with) on it for typed
     /// values and whole-form rules.
     ///
@@ -146,55 +154,165 @@ impl Questionnaire {
             return Err(InputError::NoInput);
         }
 
-        let mut raw: BTreeMap<String, String> = BTreeMap::new();
-        let mut outcomes: BTreeMap<String, FieldOutcome> = BTreeMap::new();
+        let mut collector = Collector {
+            questionnaire: self,
+            terminal,
+            raw: BTreeMap::new(),
+            occurrences: BTreeMap::new(),
+            outcomes: BTreeMap::new(),
+        };
+        collector.collect_items(self.items(), &mut vec![ScopeCtx::root()])?;
+        Ok(RawAnswers::from_parts(collector.raw, collector.occurrences))
+    }
+}
 
-        for field in self.fields() {
-            // Interactive fields either decode or retry, so controllers are
-            // never in an errored state and applicability is always known.
-            if is_active(field, &outcomes) != Some(true) {
-                outcomes.insert(field.id().to_string(), FieldOutcome::Inactive);
-                continue;
+/// One interactive collection pass: the walk state threaded through the
+/// definition tree.
+#[cfg(feature = "simple-prompts")]
+struct Collector<'a, T: TerminalIO + 'static> {
+    questionnaire: &'a Questionnaire,
+    terminal: Arc<T>,
+    /// Accepted raw answer text per occurrence path.
+    raw: BTreeMap<String, String>,
+    /// Collected occurrences per repeatable-group path base.
+    occurrences: BTreeMap<String, usize>,
+    /// Decode outcomes per occurrence path, for condition evaluation.
+    outcomes: BTreeMap<String, FieldOutcome>,
+}
+
+#[cfg(feature = "simple-prompts")]
+impl<T: TerminalIO + 'static> Collector<'_, T> {
+    /// Walk one scope's items; `chain` is the open scope chain, innermost
+    /// last (used to build occurrence paths and resolve controllers).
+    fn collect_items(
+        &mut self,
+        items: &[Item],
+        chain: &mut Vec<ScopeCtx>,
+    ) -> Result<(), InputError> {
+        for item in items {
+            match item {
+                Item::Field(field) => self.collect_field(field, chain)?,
+                Item::Group(group) => match group.repeat() {
+                    None => {
+                        let base = chain
+                            .last()
+                            .expect("chain starts rooted")
+                            .child_path(group.id());
+                        chain.push(scope_for(group, base));
+                        self.collect_items(group.children(), chain)?;
+                        chain.pop();
+                    }
+                    Some(repeat) => {
+                        let base = chain
+                            .last()
+                            .expect("chain starts rooted")
+                            .child_path(group.id());
+                        let mut count = 0;
+                        loop {
+                            if count >= repeat.min()
+                                && (repeat.max() == Some(count) || !self.ask_add_another(group)?)
+                            {
+                                break;
+                            }
+                            chain.push(scope_for(group, format!("{base}[{count}]")));
+                            self.collect_items(group.children(), chain)?;
+                            chain.pop();
+                            count += 1;
+                        }
+                        self.occurrences.insert(base, count);
+                    }
+                },
             }
+        }
+        Ok(())
+    }
 
-            let base = interactive_message(field);
-            let mut message = base.clone();
-            loop {
-                let source = TextPromptSource::with_terminal(message.clone(), terminal.clone());
-                let entered = match source.prompt() {
-                    Ok(text) => text,
-                    // Blank entry (or a responder `Skip`): the shared blank
-                    // rule decides between default, omission, and retry.
-                    Err(InputError::NoInput) => String::new(),
-                    Err(error) => return Err(error),
-                };
-                match decode_field(field, Some(&entered)) {
-                    Ok(outcome) => {
-                        raw.insert(field.id().to_string(), entered.trim().to_string());
-                        outcomes.insert(
-                            field.id().to_string(),
-                            match outcome {
-                                Some(value) => FieldOutcome::Answered(value),
-                                None => FieldOutcome::Omitted,
-                            },
-                        );
-                        break;
-                    }
-                    Err(diagnostic) => {
-                        message = format!("{diagnostic} Try again: {base}");
-                    }
+    /// Prompt for one field occurrence, retrying locally until an answer
+    /// decodes (inactive occurrences are skipped without prompting).
+    fn collect_field(&mut self, field: &ScalarField, chain: &[ScopeCtx]) -> Result<(), InputError> {
+        let path = chain
+            .last()
+            .expect("chain starts rooted")
+            .child_path(field.id());
+        // Interactive fields either decode or retry, so controllers are
+        // never in an errored state and applicability is always known.
+        if is_active(self.questionnaire, field, chain, &self.outcomes) != Some(true) {
+            self.outcomes.insert(path, FieldOutcome::Inactive);
+            return Ok(());
+        }
+
+        let base = interactive_message(field);
+        let mut message = base.clone();
+        loop {
+            // A blank entry (or a responder `Skip`) resolves to an empty
+            // string: the shared blank rule then decides between default,
+            // omission, and retry.
+            let entered: String = self.prompt(message.clone())?.unwrap_or_default();
+            match decode_field(field, &path, Some(&entered)) {
+                Ok(outcome) => {
+                    self.raw.insert(path.clone(), entered.trim().to_string());
+                    self.outcomes.insert(
+                        path,
+                        match outcome {
+                            Some(value) => FieldOutcome::Answered(value),
+                            None => FieldOutcome::Omitted,
+                        },
+                    );
+                    return Ok(());
+                }
+                Err(diagnostic) => {
+                    message = format!("{diagnostic} Try again: {base}");
                 }
             }
         }
+    }
 
-        Ok(RawAnswers::from_values(raw))
+    /// Ask whether to collect one more occurrence of a repeatable group.
+    /// Blank means no; a non-yes/no entry re-asks with the diagnostic.
+    fn ask_add_another(&mut self, group: &Group) -> Result<bool, InputError> {
+        let base = format!("Add another? {} (yes/no) ", group.prompt());
+        let mut message = base.clone();
+        loop {
+            match self.prompt(message.clone())? {
+                None => return Ok(false),
+                Some(entered) => match parse_bool(&entered) {
+                    Some(answer) => return Ok(answer),
+                    None => {
+                        message = format!(
+                            "Expected a yes/no answer (true, false, yes, no, y, or n). Try again: {base}"
+                        );
+                    }
+                },
+            }
+        }
+    }
+
+    /// One prompt round trip: `Ok(None)` is a blank entry, cancellation and
+    /// I/O failures propagate.
+    fn prompt(&self, message: String) -> Result<Option<String>, InputError> {
+        let source = TextPromptSource::with_terminal(message, self.terminal.clone());
+        match source.prompt() {
+            Ok(text) => Ok(Some(text)),
+            Err(InputError::NoInput) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+/// The scope-chain entry for one group occurrence.
+#[cfg(feature = "simple-prompts")]
+fn scope_for(group: &Group, path_prefix: String) -> ScopeCtx {
+    ScopeCtx {
+        group_id: Some(group.id().to_string()),
+        def_prefix: group.def_prefix(),
+        path_prefix,
     }
 }
 
 /// The cosmetic prompt message for one field: its wording plus entry hints
 /// (choices, the yes/no vocabulary, the pre-filled default).
 #[cfg(feature = "simple-prompts")]
-fn interactive_message(field: &super::definition::ScalarField) -> String {
+fn interactive_message(field: &ScalarField) -> String {
     let mut message = field.prompt().to_string();
     if let Some(Constraint::OneOf(choices)) = field.constraint() {
         message.push_str(&format!(" ({})", choices.join(" / ")));

--- a/crates/standout-input/src/questionnaire/decode.rs
+++ b/crates/standout-input/src/questionnaire/decode.rs
@@ -16,12 +16,24 @@
 //! join the same accumulated list via
 //! [`Questionnaire::decode_answers_with`].
 //!
-//! Diagnostics identify fields by stable ID and never echo submitted values;
-//! see the [module documentation](crate::questionnaire) for why.
+//! Nested and repeated values run through the exact same pipeline as
+//! scalars: decoding walks the definition tree, visits every submitted
+//! occurrence of each repeatable group, and addresses each value by its
+//! *occurrence path* (`command.inputs[1].name`) — the stable definition ID
+//! with a zero-based index per enclosing repeatable-group occurrence.
+//! Occurrence counts outside a group's declared [`Repeat`](super::Repeat)
+//! bounds are reported here as structural diagnostics, alongside the value
+//! diagnostics of the occurrences that do exist.
+//!
+//! Diagnostics identify fields by stable occurrence path and never echo
+//! submitted values; see the [module documentation](crate::questionnaire)
+//! for why.
 
 use std::collections::BTreeMap;
 
-use super::definition::{Constraint, Questionnaire, ScalarField, ScalarKind};
+use super::definition::{
+    child_segment, path_join, Constraint, Item, Questionnaire, ScalarField, ScalarKind,
+};
 use super::parse::RawAnswers;
 
 /// A decoded, field-validated answer value.
@@ -62,31 +74,44 @@ impl AnswerValue {
 
 /// The decoded, validated answers for one questionnaire submission.
 ///
-/// Contains one entry per *answered* field. Omitted optional fields and
-/// inactive conditional fields are absent. Conversion into application
-/// domain types starts from here.
+/// Contains one entry per *answered* occurrence path — the stable field ID,
+/// with a zero-based index per enclosing repeatable-group occurrence
+/// (`command.inputs[1].name`). Omitted optional fields and inactive
+/// conditional fields are absent. Repeatable-group occurrence counts are
+/// carried alongside ([`occurrence_count`](Self::occurrence_count)), so an
+/// application can iterate submitted items without guessing from key shapes.
+/// Conversion into application domain types starts from here.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Answers {
     values: BTreeMap<String, AnswerValue>,
+    occurrences: BTreeMap<String, usize>,
 }
 
 impl Answers {
-    /// The decoded value for a stable field ID, if the field was answered.
-    pub fn get(&self, field_id: &str) -> Option<&AnswerValue> {
-        self.values.get(field_id)
+    /// The decoded value at an occurrence path (for fields outside
+    /// repeatable groups: the stable field ID), if it was answered.
+    pub fn get(&self, path: &str) -> Option<&AnswerValue> {
+        self.values.get(path)
     }
 
     /// The text value for a `String` / `Text` / `Path` field, if answered.
-    pub fn get_text(&self, field_id: &str) -> Option<&str> {
-        self.get(field_id).and_then(AnswerValue::as_text)
+    pub fn get_text(&self, path: &str) -> Option<&str> {
+        self.get(path).and_then(AnswerValue::as_text)
     }
 
     /// The boolean value for a `Bool` field, if answered.
-    pub fn get_bool(&self, field_id: &str) -> Option<bool> {
-        self.get(field_id).and_then(AnswerValue::as_bool)
+    pub fn get_bool(&self, path: &str) -> Option<bool> {
+        self.get(path).and_then(AnswerValue::as_bool)
     }
 
-    /// Iterate over `(field_id, value)` pairs, ordered by field ID.
+    /// How many occurrences of a repeatable group were submitted, addressed
+    /// by the group's occurrence path base — `command.inputs` at the root,
+    /// `command.inputs[0].flags` for a group nested in another occurrence.
+    pub fn occurrence_count(&self, group_path: &str) -> usize {
+        self.occurrences.get(group_path).copied().unwrap_or(0)
+    }
+
+    /// Iterate over `(occurrence_path, value)` pairs, ordered by path.
     pub fn iter(&self) -> impl Iterator<Item = (&str, &AnswerValue)> {
         self.values.iter().map(|(k, v)| (k.as_str(), v))
     }
@@ -130,7 +155,8 @@ impl FormError {
 
 /// One problem found while decoding and validating raw answers.
 ///
-/// Diagnostics identify fields by stable ID and describe the violated rule;
+/// Diagnostics identify fields by stable occurrence path (for fields outside
+/// repeatable groups: the stable field ID) and describe the violated rule;
 /// they never echo the submitted value, since answers may be sensitive.
 /// Independent diagnostics accumulate: a batch submission reports everything
 /// actionable in one pass.
@@ -139,14 +165,14 @@ pub enum ValidationDiagnostic {
     /// A required, active field has no answer (blank or absent, no default).
     #[error("[{id}]: this question requires an answer.")]
     MissingAnswer {
-        /// The unanswered field.
+        /// The unanswered field's occurrence path.
         id: String,
     },
 
     /// An inactive conditional field was populated.
     #[error("[{id}]: this question does not apply (it is asked only when {controller} is {expected}); remove its answer or change the controlling answer.")]
     InactiveAnswered {
-        /// The populated inactive field.
+        /// The populated inactive field's occurrence path.
         id: String,
         /// Its controlling field.
         controller: String,
@@ -157,7 +183,7 @@ pub enum ValidationDiagnostic {
     /// The answer text does not convert to the field's kind.
     #[error("[{id}]: {reason}")]
     InvalidValue {
-        /// The field whose answer failed conversion.
+        /// The occurrence path of the field whose answer failed conversion.
         id: String,
         /// What the kind expects (never the submitted value).
         reason: String,
@@ -166,7 +192,7 @@ pub enum ValidationDiagnostic {
     /// The converted answer is not one of the declared choices.
     #[error("[{id}]: the answer must be one of: {}.", allowed.join(", "))]
     ConstraintViolation {
-        /// The constrained field.
+        /// The constrained field's occurrence path.
         id: String,
         /// The declared choices (definition data, safe to echo).
         allowed: Vec<String>,
@@ -175,10 +201,34 @@ pub enum ValidationDiagnostic {
     /// The application's field validator rejected the converted answer.
     #[error("[{id}]: {message}")]
     FieldValidation {
-        /// The rejected field.
+        /// The rejected field's occurrence path.
         id: String,
         /// The validator's user-facing message.
         message: String,
+    },
+
+    /// A repeatable group has fewer submitted occurrences than its declared
+    /// minimum.
+    #[error("[{path}]: {found} of at least {minimum} required item(s) submitted. Copy a complete group block - its heading line and its questions - for each missing item.")]
+    TooFewOccurrences {
+        /// The group's occurrence path base.
+        path: String,
+        /// The declared minimum.
+        minimum: usize,
+        /// The submitted occurrence count.
+        found: usize,
+    },
+
+    /// A repeatable group has more submitted occurrences than its declared
+    /// maximum.
+    #[error("[{path}]: {found} items submitted, but at most {maximum} are accepted. Remove the extra group block(s).")]
+    TooManyOccurrences {
+        /// The group's occurrence path base.
+        path: String,
+        /// The declared maximum.
+        maximum: usize,
+        /// The submitted occurrence count.
+        found: usize,
     },
 
     /// An application whole-form rule was violated.
@@ -213,12 +263,14 @@ pub(crate) fn parse_bool(text: &str) -> Option<bool> {
 }
 
 /// Convert non-blank answer text through kind conversion, constraint
-/// checking, and the application validator.
+/// checking, and the application validator. `path` is the occurrence path
+/// used in diagnostics (the field's own ID outside repeated groups).
 ///
 /// Shared by every collection path and by definition-time default
 /// validation. Diagnostic reasons never include `text`.
 pub(crate) fn check_field_text(
     field: &ScalarField,
+    path: &str,
     text: &str,
 ) -> Result<AnswerValue, ValidationDiagnostic> {
     let value = match field.kind() {
@@ -226,7 +278,7 @@ pub(crate) fn check_field_text(
         ScalarKind::String | ScalarKind::Path => {
             if text.contains('\n') {
                 return Err(ValidationDiagnostic::InvalidValue {
-                    id: field.id().to_string(),
+                    id: path.to_string(),
                     reason: format!("a {} answer must be a single line", field.kind().name()),
                 });
             }
@@ -236,7 +288,7 @@ pub(crate) fn check_field_text(
             Some(b) => AnswerValue::Bool(b),
             None => {
                 return Err(ValidationDiagnostic::InvalidValue {
-                    id: field.id().to_string(),
+                    id: path.to_string(),
                     reason: "expected a yes/no answer (true, false, yes, no, y, or n)".to_string(),
                 })
             }
@@ -248,7 +300,7 @@ pub(crate) fn check_field_text(
             .is_some_and(|t| choices.iter().any(|c| c == t));
         if !matches {
             return Err(ValidationDiagnostic::ConstraintViolation {
-                id: field.id().to_string(),
+                id: path.to_string(),
                 allowed: choices.clone(),
             });
         }
@@ -256,7 +308,7 @@ pub(crate) fn check_field_text(
     if let Some(validator) = field.validator() {
         if let Err(message) = validator.check(&value) {
             return Err(ValidationDiagnostic::FieldValidation {
-                id: field.id().to_string(),
+                id: path.to_string(),
                 message,
             });
         }
@@ -264,7 +316,8 @@ pub(crate) fn check_field_text(
     Ok(value)
 }
 
-/// Decode one active field's raw answer.
+/// Decode one active field's raw answer, identified in diagnostics by its
+/// occurrence `path`.
 ///
 /// `raw` is the trimmed answer text, or `None` when the field is absent from
 /// the submission. Blank resolves through the declared default first; a
@@ -272,20 +325,22 @@ pub(crate) fn check_field_text(
 /// [`ValidationDiagnostic::MissingAnswer`] when required.
 pub(crate) fn decode_field(
     field: &ScalarField,
+    path: &str,
     raw: Option<&str>,
 ) -> Result<Option<AnswerValue>, ValidationDiagnostic> {
     let submitted = raw.map(str::trim).filter(|t| !t.is_empty());
     let effective = submitted.or(field.default());
     match effective {
-        Some(text) => check_field_text(field, text).map(Some),
+        Some(text) => check_field_text(field, path, text).map(Some),
         None if field.is_optional() => Ok(None),
         None => Err(ValidationDiagnostic::MissingAnswer {
-            id: field.id().to_string(),
+            id: path.to_string(),
         }),
     }
 }
 
-/// What happened to one field during a whole-document decode pass.
+/// What happened to one field occurrence during a whole-document decode
+/// pass. Keyed by occurrence path.
 pub(crate) enum FieldOutcome {
     /// Decoded and validated to a value.
     Answered(AnswerValue),
@@ -298,18 +353,74 @@ pub(crate) enum FieldOutcome {
     Errored,
 }
 
-/// Evaluate a field's applicability from earlier outcomes.
+/// One open definition scope during a decode or collection walk: the root,
+/// or a group occurrence.
+#[derive(Debug, Clone)]
+pub(crate) struct ScopeCtx {
+    /// The scope's group ID (`None` at the questionnaire root).
+    pub(crate) group_id: Option<String>,
+    /// The definition-ID prefix children of this scope extend (`""` at the
+    /// root, `<group_id>.` inside a group).
+    pub(crate) def_prefix: String,
+    /// The occurrence path prefix of this scope (`""`, `command`, or
+    /// `command.inputs[1]`).
+    pub(crate) path_prefix: String,
+}
+
+impl ScopeCtx {
+    /// The root scope every walk starts from.
+    pub(crate) fn root() -> Self {
+        Self {
+            group_id: None,
+            def_prefix: String::new(),
+            path_prefix: String::new(),
+        }
+    }
+
+    /// The occurrence path of a direct child of this scope.
+    pub(crate) fn child_path(&self, id: &str) -> String {
+        path_join(&self.path_prefix, child_segment(&self.def_prefix, id))
+    }
+}
+
+/// Resolve a condition controller's occurrence path against the current
+/// scope chain: the controller lives in whichever open scope declares it as
+/// a direct child (construction guarantees that scope is on the chain).
+pub(crate) fn controller_path(
+    questionnaire: &Questionnaire,
+    chain: &[ScopeCtx],
+    controller: &str,
+) -> String {
+    let parent = questionnaire
+        .node_meta(controller)
+        .expect("conditions are validated at construction")
+        .parent
+        .as_deref();
+    let scope = chain
+        .iter()
+        .rev()
+        .find(|scope| scope.group_id.as_deref() == parent)
+        .expect("the controller's scope encloses the dependent's");
+    scope.child_path(controller)
+}
+
+/// Evaluate a field's applicability from earlier outcomes, resolving its
+/// controller within the current scope chain (a controller inside a
+/// repeatable group controls per occurrence).
 ///
 /// `Some(true)` / `Some(false)` when applicability is known; `None` when the
 /// controller (or its chain) errored, so the field cannot be judged.
 pub(crate) fn is_active(
+    questionnaire: &Questionnaire,
     field: &ScalarField,
+    chain: &[ScopeCtx],
     outcomes: &BTreeMap<String, FieldOutcome>,
 ) -> Option<bool> {
     let Some(condition) = field.condition() else {
         return Some(true);
     };
-    match outcomes.get(condition.controller()) {
+    let path = controller_path(questionnaire, chain, condition.controller());
+    match outcomes.get(&path) {
         Some(FieldOutcome::Answered(value)) => Some(value.canonical() == condition.expected()),
         Some(FieldOutcome::Omitted) | Some(FieldOutcome::Inactive) => Some(false),
         Some(FieldOutcome::Errored) | None => None,
@@ -319,71 +430,171 @@ pub(crate) fn is_active(
 impl Questionnaire {
     /// Decode and validate a complete raw submission.
     ///
-    /// Fields are processed in declaration order (controllers precede their
-    /// dependents by construction). For each field: applicability is
-    /// evaluated from earlier decoded values; an active field decodes via
-    /// [the shared field pipeline](Self::decode_answers) — default
-    /// resolution, kind conversion, constraints, application validator; an
-    /// inactive field must be blank or hold its untouched pre-filled
-    /// default, otherwise it is reported as populated-but-inapplicable.
+    /// The definition tree is walked in declaration order (controllers
+    /// precede their dependents by construction), visiting every submitted
+    /// occurrence of each repeatable group. For each field occurrence:
+    /// applicability is evaluated from earlier decoded values in the same
+    /// scope chain; an active field decodes via the shared field pipeline —
+    /// default resolution, kind conversion, constraints, application
+    /// validator; an inactive field must be blank or hold its untouched
+    /// pre-filled default, otherwise it is reported as
+    /// populated-but-inapplicable. Repeatable-group occurrence counts
+    /// outside the declared bounds are reported as structural diagnostics
+    /// while the occurrences that do exist still decode.
     ///
     /// All independent diagnostics accumulate: one pass reports every
     /// missing value, conversion failure, constraint violation, field-
-    /// validation failure, and populated inactive field together. A field
-    /// whose controller errored is skipped without piling on speculative
-    /// diagnostics.
+    /// validation failure, populated inactive field, and occurrence-bound
+    /// violation together. A field whose controller errored is skipped
+    /// without piling on speculative diagnostics.
     ///
     /// # Errors
     ///
     /// The accumulated [`ValidationDiagnostic`] list, identifying fields by
-    /// stable ID without echoing submitted values.
+    /// stable occurrence path without echoing submitted values.
     pub fn decode_answers(&self, raw: &RawAnswers) -> Result<Answers, Vec<ValidationDiagnostic>> {
         let mut outcomes: BTreeMap<String, FieldOutcome> = BTreeMap::new();
+        let mut occurrences: BTreeMap<String, usize> = BTreeMap::new();
         let mut diagnostics = Vec::new();
 
-        for field in self.fields() {
-            let raw_value = raw.get(field.id());
-            let outcome = match is_active(field, &outcomes) {
-                None => FieldOutcome::Errored,
-                Some(false) => {
-                    let blank = raw_value.is_none_or(|t| t.trim().is_empty());
-                    let untouched_default =
-                        field.default().is_some() && raw_value == field.default();
-                    if blank || untouched_default {
-                        FieldOutcome::Inactive
-                    } else {
-                        let condition = field.condition().expect("inactive implies condition");
-                        diagnostics.push(ValidationDiagnostic::InactiveAnswered {
-                            id: field.id().to_string(),
-                            controller: condition.controller().to_string(),
-                            expected: condition.expected().to_string(),
-                        });
-                        FieldOutcome::Errored
-                    }
-                }
-                Some(true) => match decode_field(field, raw_value) {
-                    Ok(Some(value)) => FieldOutcome::Answered(value),
-                    Ok(None) => FieldOutcome::Omitted,
-                    Err(diagnostic) => {
-                        diagnostics.push(diagnostic);
-                        FieldOutcome::Errored
-                    }
-                },
-            };
-            outcomes.insert(field.id().to_string(), outcome);
-        }
+        self.decode_items(
+            self.items(),
+            &mut vec![ScopeCtx::root()],
+            raw,
+            &mut outcomes,
+            &mut occurrences,
+            &mut diagnostics,
+        );
 
         if !diagnostics.is_empty() {
             return Err(diagnostics);
         }
         let values = outcomes
             .into_iter()
-            .filter_map(|(id, outcome)| match outcome {
-                FieldOutcome::Answered(value) => Some((id, value)),
+            .filter_map(|(path, outcome)| match outcome {
+                FieldOutcome::Answered(value) => Some((path, value)),
                 _ => None,
             })
             .collect();
-        Ok(Answers { values })
+        Ok(Answers {
+            values,
+            occurrences,
+        })
+    }
+
+    /// Decode one scope's items; `chain` is the open scope chain, innermost
+    /// last (used to build occurrence paths and resolve controllers).
+    fn decode_items(
+        &self,
+        items: &[Item],
+        chain: &mut Vec<ScopeCtx>,
+        raw: &RawAnswers,
+        outcomes: &mut BTreeMap<String, FieldOutcome>,
+        occurrences: &mut BTreeMap<String, usize>,
+        diagnostics: &mut Vec<ValidationDiagnostic>,
+    ) {
+        for item in items {
+            match item {
+                Item::Field(field) => {
+                    let path = chain
+                        .last()
+                        .expect("chain starts rooted")
+                        .child_path(field.id());
+                    let raw_value = raw.get(&path);
+                    let outcome = match is_active(self, field, chain, outcomes) {
+                        None => FieldOutcome::Errored,
+                        Some(false) => {
+                            let blank = raw_value.is_none_or(|t| t.trim().is_empty());
+                            let untouched_default =
+                                field.default().is_some() && raw_value == field.default();
+                            if blank || untouched_default {
+                                FieldOutcome::Inactive
+                            } else {
+                                let condition =
+                                    field.condition().expect("inactive implies condition");
+                                diagnostics.push(ValidationDiagnostic::InactiveAnswered {
+                                    id: path.clone(),
+                                    controller: condition.controller().to_string(),
+                                    expected: condition.expected().to_string(),
+                                });
+                                FieldOutcome::Errored
+                            }
+                        }
+                        Some(true) => match decode_field(field, &path, raw_value) {
+                            Ok(Some(value)) => FieldOutcome::Answered(value),
+                            Ok(None) => FieldOutcome::Omitted,
+                            Err(diagnostic) => {
+                                diagnostics.push(diagnostic);
+                                FieldOutcome::Errored
+                            }
+                        },
+                    };
+                    outcomes.insert(path, outcome);
+                }
+                Item::Group(group) => {
+                    let base = chain
+                        .last()
+                        .expect("chain starts rooted")
+                        .child_path(group.id());
+                    match group.repeat() {
+                        None => {
+                            chain.push(ScopeCtx {
+                                group_id: Some(group.id().to_string()),
+                                def_prefix: group.def_prefix(),
+                                path_prefix: base,
+                            });
+                            self.decode_items(
+                                group.children(),
+                                chain,
+                                raw,
+                                outcomes,
+                                occurrences,
+                                diagnostics,
+                            );
+                            chain.pop();
+                        }
+                        Some(repeat) => {
+                            let count = raw.occurrence_count(&base);
+                            if count < repeat.min() {
+                                diagnostics.push(ValidationDiagnostic::TooFewOccurrences {
+                                    path: base.clone(),
+                                    minimum: repeat.min(),
+                                    found: count,
+                                });
+                            }
+                            if let Some(max) = repeat.max() {
+                                if count > max {
+                                    diagnostics.push(ValidationDiagnostic::TooManyOccurrences {
+                                        path: base.clone(),
+                                        maximum: max,
+                                        found: count,
+                                    });
+                                }
+                            }
+                            if count > 0 {
+                                occurrences.insert(base.clone(), count);
+                            }
+                            for index in 0..count {
+                                chain.push(ScopeCtx {
+                                    group_id: Some(group.id().to_string()),
+                                    def_prefix: group.def_prefix(),
+                                    path_prefix: format!("{base}[{index}]"),
+                                });
+                                self.decode_items(
+                                    group.children(),
+                                    chain,
+                                    raw,
+                                    outcomes,
+                                    occurrences,
+                                    diagnostics,
+                                );
+                                chain.pop();
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Decode and validate a complete raw submission, then run the

--- a/crates/standout-input/src/questionnaire/definition.rs
+++ b/crates/standout-input/src/questionnaire/definition.rs
@@ -570,7 +570,7 @@ pub enum QuestionnaireError {
     DuplicateId(String),
 
     /// The questionnaire declares no items.
-    #[error("A questionnaire must declare at least one field.")]
+    #[error("A questionnaire must declare at least one item (field or group).")]
     NoFields,
 
     /// A group declares no children.

--- a/crates/standout-input/src/questionnaire/definition.rs
+++ b/crates/standout-input/src/questionnaire/definition.rs
@@ -1,23 +1,39 @@
 //! Questionnaire definitions: stable identities plus cosmetic wording.
 //!
 //! A [`Questionnaire`] is an application-owned, static description of the
-//! information to collect. The definition carries two very different kinds of
-//! data and the split is the point:
+//! information to collect: a tree of [`Item`]s, where each item is either a
+//! [`ScalarField`] or a [`Group`] of nested items (optionally repeatable
+//! within declared bounds). The definition carries two very different kinds
+//! of data and the split is the point:
 //!
-//! - **Semantic** (identity-bearing): the questionnaire ID, each field's
-//!   stable ID, its [`ScalarKind`], its optionality, its declared default,
-//!   its [`Constraint`], its conditional-applicability [`Condition`], and the
+//! - **Semantic** (identity-bearing): the questionnaire ID, each field's and
+//!   group's stable ID, group structure and [`Repeat`] bounds, each field's
+//!   [`ScalarKind`], its optionality, its declared default, its
+//!   [`Constraint`], its conditional-applicability [`Condition`], and the
 //!   revision of any attached [`FieldValidator`]. These feed the
 //!   [fingerprint](Questionnaire::fingerprint) and determine how answers are
 //!   decoded and validated.
-//! - **Cosmetic** (presentation-only): question wording and field order.
+//! - **Cosmetic** (presentation-only): question wording and item order.
 //!   Changing them never changes answer identity or the fingerprint.
 //!
 //! Definitions are validated at construction: [`Questionnaire::new`] rejects
-//! empty or malformed IDs, duplicate field IDs, invalid defaults and
-//! constraints, and conditions that reference unknown or later-declared
-//! fields, so every constructed questionnaire can render, parse, and decode
-//! without further checks.
+//! empty or malformed IDs, duplicate IDs, empty groups, invalid repeat
+//! bounds, child IDs that do not extend their group's ID, invalid defaults
+//! and constraints, and conditions that reference unknown, later-declared,
+//! or out-of-scope fields, so every constructed questionnaire can render,
+//! parse, and decode without further checks.
+//!
+//! # Definition IDs vs occurrence paths
+//!
+//! Every field and group declares one *stable definition ID* such as
+//! `command.inputs.name`. A submitted answer instead lives at an *occurrence
+//! path*: for scalar fields and fields inside non-repeatable groups the path
+//! equals the definition ID, while each occurrence of a repeatable group
+//! inserts a zero-based index — the second submitted input's name is
+//! `command.inputs[1].name`. Definition IDs never carry indexes; indexes
+//! belong to an answer instance, which is why every child of a group must
+//! extend its group's ID (`command.inputs` → `command.inputs.name`): the
+//! occurrence path is then always derivable from the definition.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -238,10 +254,13 @@ impl ScalarField {
     /// Make this field applicable only when the earlier-declared `controller`
     /// field decodes to `expected`.
     ///
-    /// An inactive field may stay blank (or keep its untouched pre-filled
-    /// default) even when required; a *populated* inactive field is a
-    /// validation error. Conditions are semantic: they change the
-    /// fingerprint.
+    /// The controller must live in the same group as this field or in one of
+    /// its enclosing groups (so every submitted occurrence resolves it
+    /// unambiguously); a controller inside a repeatable group gates its
+    /// dependents *per occurrence*. An inactive field may stay blank (or
+    /// keep its untouched pre-filled default) even when required; a
+    /// *populated* inactive field is a validation error. Conditions are
+    /// semantic: they change the fingerprint.
     pub fn active_when(
         mut self,
         controller: impl Into<String>,
@@ -343,6 +362,193 @@ fn join_or(choices: &[String]) -> String {
     }
 }
 
+/// Repeat bounds for a repeatable [`Group`]: at least `min` occurrences
+/// (rendering emits exactly `min` blank blocks) and, when declared, at most
+/// `max`.
+///
+/// Bounds are semantic: they participate in the
+/// [fingerprint](Questionnaire::fingerprint). The minimum must be at least 1
+/// so a rendered sheet always contains one complete block to copy; an
+/// entirely optional list of items should live behind a conditional field or
+/// an optional child instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Repeat {
+    pub(crate) min: usize,
+    pub(crate) max: Option<usize>,
+}
+
+impl Repeat {
+    /// The minimum number of occurrences (also the rendered count).
+    pub fn min(&self) -> usize {
+        self.min
+    }
+
+    /// The maximum number of occurrences, if bounded.
+    pub fn max(&self) -> Option<usize> {
+        self.max
+    }
+}
+
+/// A named group of nested questionnaire items.
+///
+/// The `id` is the stable machine identity rendered as the bracketed token
+/// (`[command.inputs]`); the `prompt` is human wording and may be edited
+/// freely. Every child's ID must extend the group's ID with a `.` segment
+/// (`command.inputs` → `command.inputs.name`), which keeps submitted
+/// occurrence paths derivable from definition IDs.
+///
+/// A plain group ([`Group::new`]) renders and is answered exactly once — it
+/// structures related questions under one heading. A *repeatable* group
+/// ([`Group::repeatable`]) is answered once per submitted occurrence:
+/// rendering emits exactly the declared minimum number of blank blocks, and
+/// a person adds items by copying a complete block (its heading line and its
+/// questions). The number of submitted items is inferred from occurrences of
+/// the stable group header, never from display numbers or wording.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Group {
+    pub(crate) id: String,
+    pub(crate) prompt: String,
+    pub(crate) children: Vec<Item>,
+    pub(crate) repeat: Option<Repeat>,
+}
+
+impl Group {
+    /// Create a non-repeatable group with a stable `id`, human `prompt`
+    /// wording, and nested `children`.
+    ///
+    /// The `id`, the child-ID prefix rule, and all nested declarations are
+    /// validated when the group is passed to [`Questionnaire::new`], not
+    /// here.
+    pub fn new(
+        id: impl Into<String>,
+        prompt: impl Into<String>,
+        children: impl IntoIterator<Item = impl Into<Item>>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            prompt: prompt.into(),
+            children: children.into_iter().map(Into::into).collect(),
+            repeat: None,
+        }
+    }
+
+    /// Make this group repeatable with at least `min` occurrences
+    /// (`min >= 1`; rendering emits exactly `min` blank blocks).
+    ///
+    /// Repeat bounds are semantic: they change the fingerprint.
+    pub fn repeatable(mut self, min: usize) -> Self {
+        self.repeat = Some(Repeat { min, max: None });
+        self
+    }
+
+    /// Bound a repeatable group to at most `max` occurrences.
+    ///
+    /// Only meaningful after [`repeatable`](Self::repeatable);
+    /// [`Questionnaire::new`] rejects a maximum on a non-repeatable group or
+    /// a maximum below the minimum. Semantic: changes the fingerprint.
+    pub fn max_occurrences(mut self, max: usize) -> Self {
+        match &mut self.repeat {
+            Some(repeat) => repeat.max = Some(max),
+            // Recorded as an impossible bound so `Questionnaire::new` can
+            // reject it with a precise error instead of silently ignoring it.
+            None => {
+                self.repeat = Some(Repeat {
+                    min: 0,
+                    max: Some(max),
+                })
+            }
+        }
+        self
+    }
+
+    /// The stable group ID.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// The human wording (cosmetic).
+    pub fn prompt(&self) -> &str {
+        &self.prompt
+    }
+
+    /// The nested items, in presentation order.
+    pub fn children(&self) -> &[Item] {
+        &self.children
+    }
+
+    /// The repeat bounds, or `None` for a group answered exactly once.
+    pub fn repeat(&self) -> Option<Repeat> {
+        self.repeat
+    }
+
+    /// The definition-ID prefix every child extends (`<id>.`).
+    pub(crate) fn def_prefix(&self) -> String {
+        format!("{}.", self.id)
+    }
+
+    /// The cosmetic type hint rendered after the bracketed ID.
+    pub(crate) fn type_hint(&self) -> String {
+        match self.repeat {
+            None => "section".to_string(),
+            Some(Repeat { min, max: None }) => {
+                format!("repeatable section, minimum {min}")
+            }
+            Some(Repeat {
+                min,
+                max: Some(max),
+            }) => format!("repeatable section, minimum {min}, maximum {max}"),
+        }
+    }
+}
+
+/// One node of a questionnaire definition: a scalar question or a group of
+/// nested items.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Item {
+    /// A single scalar question.
+    Field(ScalarField),
+    /// A (possibly repeatable) group of nested items.
+    Group(Group),
+}
+
+impl From<ScalarField> for Item {
+    fn from(field: ScalarField) -> Self {
+        Item::Field(field)
+    }
+}
+
+impl From<Group> for Item {
+    fn from(group: Group) -> Self {
+        Item::Group(group)
+    }
+}
+
+impl Item {
+    /// The stable ID of this item, field or group alike.
+    pub fn id(&self) -> &str {
+        match self {
+            Item::Field(field) => field.id(),
+            Item::Group(group) => group.id(),
+        }
+    }
+}
+
+/// Join an occurrence-path prefix and a child segment (`""` prefixes join to
+/// the bare segment, so root items keep their definition IDs as paths).
+pub(crate) fn path_join(prefix: &str, segment: &str) -> String {
+    if prefix.is_empty() {
+        segment.to_string()
+    } else {
+        format!("{prefix}.{segment}")
+    }
+}
+
+/// The path segment a child contributes under its group's definition-ID
+/// prefix (`command.inputs.` + `command.inputs.name` → `name`).
+pub(crate) fn child_segment<'a>(def_prefix: &str, id: &'a str) -> &'a str {
+    id.strip_prefix(def_prefix).unwrap_or(id)
+}
+
 /// A definition-time validation error.
 ///
 /// Produced by [`Questionnaire::new`]; a constructed questionnaire is always
@@ -354,18 +560,52 @@ pub enum QuestionnaireError {
     #[error("Invalid questionnaire ID '{0}': IDs must be non-empty and use only a-z, 0-9, '.', '_', '-'.")]
     InvalidQuestionnaireId(String),
 
-    /// A field ID is empty or contains characters outside
+    /// A field or group ID is empty or contains characters outside
     /// `a-z`, `0-9`, `.`, `_`, `-`.
-    #[error("Invalid field ID '{0}': IDs must be non-empty and use only a-z, 0-9, '.', '_', '-'.")]
-    InvalidFieldId(String),
+    #[error("Invalid ID '{0}': IDs must be non-empty and use only a-z, 0-9, '.', '_', '-'.")]
+    InvalidId(String),
 
-    /// Two fields declare the same stable ID.
-    #[error("Duplicate field ID '{0}': stable IDs must be unique within a questionnaire.")]
-    DuplicateFieldId(String),
+    /// Two items (fields or groups) declare the same stable ID.
+    #[error("Duplicate ID '{0}': stable IDs must be unique within a questionnaire.")]
+    DuplicateId(String),
 
-    /// The questionnaire declares no fields.
+    /// The questionnaire declares no items.
     #[error("A questionnaire must declare at least one field.")]
     NoFields,
+
+    /// A group declares no children.
+    #[error("Group '{0}' declares no children: a group must contain at least one field or group.")]
+    EmptyGroup(String),
+
+    /// A group child's ID does not extend the group's ID.
+    #[error("Item '{child}' inside group '{group}' must extend the group's ID ('{group}.<segment>') so submitted occurrence paths stay derivable from definition IDs.")]
+    GroupChildId {
+        /// The enclosing group.
+        group: String,
+        /// The offending child ID.
+        child: String,
+    },
+
+    /// A group declares impossible repeat bounds.
+    #[error("Invalid repeat bounds on group '{id}': {reason}")]
+    InvalidRepeat {
+        /// The group carrying the bounds.
+        id: String,
+        /// Why the bounds are invalid.
+        reason: String,
+    },
+
+    /// A condition references a field outside the dependent field's own
+    /// scope chain. A controller must live in the same group occurrence or
+    /// an enclosing one, so that every submitted occurrence can resolve it
+    /// unambiguously.
+    #[error("Field '{id}' is conditioned on '{controller}', which is not in an enclosing scope. A controller must be declared in the same group as the dependent field or in one of its enclosing groups.")]
+    ConditionScope {
+        /// The dependent field.
+        id: String,
+        /// The out-of-scope controller ID.
+        controller: String,
+    },
 
     /// A declared constraint is invalid for its field.
     #[error("Invalid constraint on field '{id}': {reason}")]
@@ -430,8 +670,31 @@ pub enum QuestionnaireError {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Questionnaire {
     id: String,
-    fields: Vec<ScalarField>,
+    items: Vec<Item>,
+    /// Every declared ID mapped to its structural position, for scope
+    /// resolution during parsing and decoding.
+    meta: HashMap<String, NodeMeta>,
     fingerprint: String,
+}
+
+/// Structural position of one declared ID within the definition tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NodeMeta {
+    /// The enclosing group's ID, or `None` at the questionnaire root.
+    pub(crate) parent: Option<String>,
+    /// Whether the ID names a group (vs a scalar field).
+    pub(crate) group: bool,
+}
+
+/// Per-field facts gathered during the structural pass, consumed by the
+/// semantic pass to validate and canonicalize conditions.
+struct FieldInfo {
+    /// Depth-first declaration index (controllers must come first).
+    dfs: usize,
+    /// The chain of enclosing group IDs, outermost first.
+    chain: Vec<String>,
+    kind: ScalarKind,
+    constraint: Option<Constraint>,
 }
 
 /// Returns `true` when `id` is a valid stable identifier.
@@ -446,11 +709,13 @@ impl Questionnaire {
     /// Create a validated questionnaire definition.
     ///
     /// `id` is the stable questionnaire identity written into every rendered
-    /// sheet's preamble. `fields` are rendered, collected, and decoded in the
-    /// given order, but order is cosmetic for identity: reordering fields
-    /// does not change the [fingerprint](Self::fingerprint). The one ordering
-    /// rule is structural: a conditional field's controller must be declared
-    /// before it.
+    /// sheet's preamble. `items` — scalar fields and (possibly repeatable)
+    /// groups; a `Vec<ScalarField>` works directly for a flat questionnaire
+    /// — are rendered, collected, and decoded in the given order, but order
+    /// is cosmetic for identity: reordering items does not change the
+    /// [fingerprint](Self::fingerprint). The one ordering rule is
+    /// structural: a conditional field's controller must be declared before
+    /// it, in the same group or an enclosing one.
     ///
     /// Condition expected values are canonicalized here (a bool controller's
     /// `"yes"` becomes `"true"`), so equivalent declarations fingerprint
@@ -458,52 +723,43 @@ impl Questionnaire {
     ///
     /// # Errors
     ///
-    /// Returns a [`QuestionnaireError`] for an invalid questionnaire or field
-    /// ID, a duplicate field ID, an empty field list, or an invalid default,
-    /// constraint, condition, or validator revision.
+    /// Returns a [`QuestionnaireError`] for an invalid questionnaire or item
+    /// ID, a duplicate ID, an empty item list, an empty group, invalid
+    /// repeat bounds, a child ID that does not extend its group's ID, or an
+    /// invalid default, constraint, condition, or validator revision.
     pub fn new(
         id: impl Into<String>,
-        mut fields: Vec<ScalarField>,
+        items: Vec<impl Into<Item>>,
     ) -> Result<Self, QuestionnaireError> {
         let id = id.into();
         if !valid_id(&id) {
             return Err(QuestionnaireError::InvalidQuestionnaireId(id));
         }
-        if fields.is_empty() {
+        let mut items: Vec<Item> = items.into_iter().map(Into::into).collect();
+        if items.is_empty() {
             return Err(QuestionnaireError::NoFields);
         }
-        let mut seen: HashSet<String> = HashSet::with_capacity(fields.len());
-        let all_ids: HashSet<String> = fields.iter().map(|f| f.id.clone()).collect();
-        // Kind and choices of already-validated (earlier) fields, for
-        // canonicalizing and checking conditions in one pass.
-        let mut earlier: HashMap<String, (ScalarKind, Option<Constraint>)> = HashMap::new();
 
-        for field in &mut fields {
-            if !valid_id(&field.id) {
-                return Err(QuestionnaireError::InvalidFieldId(field.id.clone()));
-            }
-            if !seen.insert(field.id.clone()) {
-                return Err(QuestionnaireError::DuplicateFieldId(field.id.clone()));
-            }
-            validate_constraint(field)?;
-            if let Some(condition) = &mut field.condition {
-                canonicalize_condition(&field.id, condition, &earlier, &all_ids)?;
-            }
-            if let Some(validator) = &field.validator {
-                if validator.revision().is_empty() {
-                    return Err(QuestionnaireError::EmptyValidatorRevision {
-                        id: field.id.clone(),
-                    });
-                }
-            }
-            validate_default(field)?;
-            earlier.insert(field.id.clone(), (field.kind, field.constraint.clone()));
-        }
+        // Structural pass: IDs, duplicates, group shape, repeat bounds.
+        let mut meta = HashMap::new();
+        let mut field_info = HashMap::new();
+        collect_structure(
+            &items,
+            None,
+            &mut Vec::new(),
+            &mut meta,
+            &mut field_info,
+            &mut 0,
+        )?;
 
-        let fingerprint = compute_fingerprint(&id, &fields);
+        // Semantic pass: constraints, defaults, validators, conditions.
+        validate_fields(&mut items, &meta, &field_info)?;
+
+        let fingerprint = compute_fingerprint(&id, &items);
         Ok(Self {
             id,
-            fields,
+            items,
+            meta,
             fingerprint,
         })
     }
@@ -513,9 +769,9 @@ impl Questionnaire {
         &self.id
     }
 
-    /// The declared fields, in presentation order.
-    pub fn fields(&self) -> &[ScalarField] {
-        &self.fields
+    /// The declared items, in presentation order.
+    pub fn items(&self) -> &[Item] {
+        &self.items
     }
 
     /// The semantic fingerprint (`sha256:<hex>`).
@@ -531,10 +787,145 @@ impl Questionnaire {
         &self.fingerprint
     }
 
-    /// Look up a field by stable ID.
-    pub(crate) fn field(&self, id: &str) -> Option<&ScalarField> {
-        self.fields.iter().find(|f| f.id == id)
+    /// Look up a group anywhere in the tree by stable ID.
+    pub(crate) fn group_def(&self, id: &str) -> Option<&Group> {
+        find_group(&self.items, id)
     }
+
+    /// Structural position of a declared ID, or `None` for unknown IDs.
+    pub(crate) fn node_meta(&self, id: &str) -> Option<&NodeMeta> {
+        self.meta.get(id)
+    }
+}
+
+/// Depth-first group lookup by stable ID.
+fn find_group<'a>(items: &'a [Item], id: &str) -> Option<&'a Group> {
+    items.iter().find_map(|item| match item {
+        Item::Field(_) => None,
+        Item::Group(group) if group.id == id => Some(group),
+        Item::Group(group) => find_group(&group.children, id),
+    })
+}
+
+/// Structural validation walk: ID shape and uniqueness, the child-ID prefix
+/// rule, group non-emptiness, and repeat bounds. Fills `meta` (structural
+/// position per ID) and `field_info` (per-field facts for the semantic
+/// pass).
+fn collect_structure(
+    items: &[Item],
+    parent: Option<&str>,
+    chain: &mut Vec<String>,
+    meta: &mut HashMap<String, NodeMeta>,
+    field_info: &mut HashMap<String, FieldInfo>,
+    dfs: &mut usize,
+) -> Result<(), QuestionnaireError> {
+    for item in items {
+        let item_id = item.id();
+        if !valid_id(item_id) {
+            return Err(QuestionnaireError::InvalidId(item_id.to_string()));
+        }
+        if meta.contains_key(item_id) {
+            return Err(QuestionnaireError::DuplicateId(item_id.to_string()));
+        }
+        if let Some(parent) = parent {
+            let prefix = format!("{parent}.");
+            if !item_id.starts_with(&prefix) || item_id.len() == prefix.len() {
+                return Err(QuestionnaireError::GroupChildId {
+                    group: parent.to_string(),
+                    child: item_id.to_string(),
+                });
+            }
+        }
+        meta.insert(
+            item_id.to_string(),
+            NodeMeta {
+                parent: parent.map(str::to_string),
+                group: matches!(item, Item::Group(_)),
+            },
+        );
+        *dfs += 1;
+        match item {
+            Item::Field(field) => {
+                field_info.insert(
+                    field.id.clone(),
+                    FieldInfo {
+                        dfs: *dfs,
+                        chain: chain.clone(),
+                        kind: field.kind,
+                        constraint: field.constraint.clone(),
+                    },
+                );
+            }
+            Item::Group(group) => {
+                if group.children.is_empty() {
+                    return Err(QuestionnaireError::EmptyGroup(group.id.clone()));
+                }
+                if let Some(repeat) = group.repeat {
+                    if repeat.min == 0 {
+                        return Err(QuestionnaireError::InvalidRepeat {
+                            id: group.id.clone(),
+                            reason: "the minimum must be at least 1 — rendering emits exactly the minimum number of blocks, and a sheet needs one complete block to copy (declare repeatable(min) before max_occurrences)".to_string(),
+                        });
+                    }
+                    if let Some(max) = repeat.max {
+                        if max < repeat.min {
+                            return Err(QuestionnaireError::InvalidRepeat {
+                                id: group.id.clone(),
+                                reason: format!(
+                                    "the maximum ({max}) is below the minimum ({})",
+                                    repeat.min
+                                ),
+                            });
+                        }
+                    }
+                }
+                chain.push(group.id.clone());
+                collect_structure(
+                    &group.children,
+                    Some(&group.id),
+                    chain,
+                    meta,
+                    field_info,
+                    dfs,
+                )?;
+                chain.pop();
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Semantic validation walk: per-field constraints, defaults, validator
+/// revisions, and conditions (classified and canonicalized against the
+/// structural pass's facts).
+fn validate_fields(
+    items: &mut [Item],
+    meta: &HashMap<String, NodeMeta>,
+    field_info: &HashMap<String, FieldInfo>,
+) -> Result<(), QuestionnaireError> {
+    for item in items {
+        match item {
+            Item::Field(field) => {
+                validate_constraint(field)?;
+                let field_id = field.id.clone();
+                if let Some(condition) = &mut field.condition {
+                    validate_condition(&field_id, condition, meta, field_info)?;
+                }
+                if let Some(validator) = &field.validator {
+                    if validator.revision().is_empty() {
+                        return Err(QuestionnaireError::EmptyValidatorRevision {
+                            id: field.id.clone(),
+                        });
+                    }
+                }
+                validate_default(field)?;
+            }
+            Item::Group(group) => {
+                validate_fields(&mut group.children, meta, field_info)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Reject constraints that can never apply to their field.
@@ -569,19 +960,24 @@ fn validate_constraint(field: &ScalarField) -> Result<(), QuestionnaireError> {
     Ok(())
 }
 
-/// Check a condition against its (earlier-declared) controller and rewrite
-/// the expected value into canonical form.
-fn canonicalize_condition(
+/// Check a condition's controller — it must be an earlier-declared field in
+/// the dependent's own scope chain — and rewrite the expected value into
+/// canonical form.
+fn validate_condition(
     field_id: &str,
     condition: &mut Condition,
-    earlier: &HashMap<String, (ScalarKind, Option<Constraint>)>,
-    all_ids: &HashSet<String>,
+    meta: &HashMap<String, NodeMeta>,
+    field_info: &HashMap<String, FieldInfo>,
 ) -> Result<(), QuestionnaireError> {
-    let Some((controller_kind, controller_constraint)) = earlier.get(&condition.controller) else {
-        if all_ids.contains(&condition.controller) {
-            return Err(QuestionnaireError::ConditionOrder {
+    let dependent = &field_info[field_id];
+    let Some(controller) = field_info.get(&condition.controller) else {
+        if meta.contains_key(&condition.controller) {
+            return Err(QuestionnaireError::InvalidCondition {
                 id: field_id.to_string(),
-                controller: condition.controller.clone(),
+                reason: format!(
+                    "controller '{}' is a group; a controller must be a scalar field",
+                    condition.controller
+                ),
             });
         }
         return Err(QuestionnaireError::UnknownConditionController {
@@ -589,6 +985,24 @@ fn canonicalize_condition(
             controller: condition.controller.clone(),
         });
     };
+    // The controller's scope chain must enclose (or equal) the dependent's,
+    // so every submitted occurrence resolves the controller unambiguously.
+    let enclosing = controller.chain.len() <= dependent.chain.len()
+        && dependent.chain[..controller.chain.len()] == controller.chain[..];
+    if !enclosing {
+        return Err(QuestionnaireError::ConditionScope {
+            id: field_id.to_string(),
+            controller: condition.controller.clone(),
+        });
+    }
+    if controller.dfs > dependent.dfs {
+        return Err(QuestionnaireError::ConditionOrder {
+            id: field_id.to_string(),
+            controller: condition.controller.clone(),
+        });
+    }
+    let controller_kind = &controller.kind;
+    let controller_constraint = &controller.constraint;
     if *controller_kind == ScalarKind::Bool {
         match super::decode::parse_bool(&condition.expected) {
             Some(value) => condition.expected = if value { "true" } else { "false" }.to_string(),
@@ -650,7 +1064,7 @@ fn validate_default(field: &ScalarField) -> Result<(), QuestionnaireError> {
             "a default must be a single line (it renders on the answer marker line)".to_string(),
         ));
     }
-    if let Err(diagnostic) = check_field_text(field, default) {
+    if let Err(diagnostic) = check_field_text(field, field.id(), default) {
         return Err(invalid(format!(
             "the default does not decode cleanly: {diagnostic}"
         )));

--- a/crates/standout-input/src/questionnaire/fingerprint.rs
+++ b/crates/standout-input/src/questionnaire/fingerprint.rs
@@ -6,10 +6,11 @@
 //! guessing how old answers map onto new semantics.
 //!
 //! The canonical form hashed here includes exactly the semantic surface of a
-//! definition — questionnaire ID, and each field's stable ID, kind,
-//! optionality, default, constraint choices, condition, and application-
-//! validator revision — everything that changes which answers are accepted.
-//! Fields are sorted by stable ID and constraint choices are sorted, so
+//! definition — questionnaire ID; group structure (each item's enclosing
+//! group) and repeat bounds; and each field's stable ID, kind, optionality,
+//! default, constraint choices, condition, and application-validator
+//! revision — everything that changes which answers are accepted. Entries
+//! are sorted by stable ID and constraint choices are sorted, so
 //! presentation order stays cosmetic. Wording, numbering, and styling never
 //! appear in the canonical form, so copy edits cannot invalidate existing
 //! sheets.
@@ -18,12 +19,12 @@ use std::fmt::Write as _;
 
 use sha2::{Digest, Sha256};
 
-use super::definition::{Constraint, ScalarField};
+use super::definition::{Constraint, Item, ScalarField};
 
 /// Version tag for the canonical form itself, distinct from the rendered
 /// answer-format version: changing how the fingerprint is computed must
 /// change every fingerprint.
-const CANONICAL_FORM_VERSION: &str = "2";
+const CANONICAL_FORM_VERSION: &str = "3";
 
 /// Escape free-form text for embedding in the canonical form, so values
 /// containing separators can never collide with the form's structure.
@@ -36,44 +37,21 @@ fn esc(text: &str) -> String {
 
 /// Compute the `sha256:<hex>` fingerprint of a definition's semantic surface.
 ///
-/// Deterministic for a given semantic definition and independent of field
+/// Deterministic for a given semantic definition and independent of item
 /// presentation order and constraint-choice order. Optional semantic
-/// properties (default, constraint, condition, validator revision) appear
-/// only when declared, so absence and emptiness cannot collide.
-pub(crate) fn compute_fingerprint(questionnaire_id: &str, fields: &[ScalarField]) -> String {
+/// properties (parent group, repeat bounds, default, constraint, condition,
+/// validator revision) appear only when declared, so absence and emptiness
+/// cannot collide.
+pub(crate) fn compute_fingerprint(questionnaire_id: &str, items: &[Item]) -> String {
+    let mut entries: Vec<(String, String)> = Vec::new();
+    collect_entries(items, None, &mut entries);
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
     let mut canonical = format!(
         "standout-answers-canonical {CANONICAL_FORM_VERSION}\nquestionnaire={questionnaire_id}\n"
     );
-    let mut sorted: Vec<&ScalarField> = fields.iter().collect();
-    sorted.sort_by(|a, b| a.id().cmp(b.id()));
-    for field in sorted {
-        let _ = write!(
-            canonical,
-            "field={}|kind={}|optional={}",
-            field.id(),
-            field.kind().name(),
-            field.is_optional()
-        );
-        if let Some(default) = field.default() {
-            let _ = write!(canonical, "|default={}", esc(default));
-        }
-        if let Some(Constraint::OneOf(choices)) = field.constraint() {
-            let mut sorted_choices: Vec<&String> = choices.iter().collect();
-            sorted_choices.sort();
-            let joined: Vec<String> = sorted_choices.iter().map(|c| esc(c)).collect();
-            let _ = write!(canonical, "|one_of={}", joined.join(","));
-        }
-        if let Some(condition) = field.condition() {
-            let _ = write!(
-                canonical,
-                "|active_when={}={}",
-                condition.controller(),
-                esc(condition.expected())
-            );
-        }
-        if let Some(validator) = field.validator() {
-            let _ = write!(canonical, "|validator={}", esc(validator.revision()));
-        }
+    for (_, entry) in entries {
+        canonical.push_str(&entry);
         canonical.push('\n');
     }
     let digest = Sha256::digest(canonical.as_bytes());
@@ -83,4 +61,65 @@ pub(crate) fn compute_fingerprint(questionnaire_id: &str, fields: &[ScalarField]
         let _ = write!(out, "{byte:02x}");
     }
     out
+}
+
+/// Collect one canonical `(id, entry)` line per item, depth first. The
+/// parent group appears in every nested entry, so group structure — not just
+/// the flat set of IDs — is part of the hash.
+fn collect_entries(items: &[Item], parent: Option<&str>, entries: &mut Vec<(String, String)>) {
+    for item in items {
+        match item {
+            Item::Field(field) => {
+                entries.push((field.id().to_string(), field_entry(field, parent)));
+            }
+            Item::Group(group) => {
+                let mut entry = format!("group={}", group.id());
+                if let Some(parent) = parent {
+                    let _ = write!(entry, "|parent={parent}");
+                }
+                if let Some(repeat) = group.repeat() {
+                    let _ = write!(entry, "|repeat_min={}", repeat.min());
+                    if let Some(max) = repeat.max() {
+                        let _ = write!(entry, "|repeat_max={max}");
+                    }
+                }
+                entries.push((group.id().to_string(), entry));
+                collect_entries(group.children(), Some(group.id()), entries);
+            }
+        }
+    }
+}
+
+/// The canonical entry for one scalar field.
+fn field_entry(field: &ScalarField, parent: Option<&str>) -> String {
+    let mut entry = format!(
+        "field={}|kind={}|optional={}",
+        field.id(),
+        field.kind().name(),
+        field.is_optional()
+    );
+    if let Some(parent) = parent {
+        let _ = write!(entry, "|parent={parent}");
+    }
+    if let Some(default) = field.default() {
+        let _ = write!(entry, "|default={}", esc(default));
+    }
+    if let Some(Constraint::OneOf(choices)) = field.constraint() {
+        let mut sorted_choices: Vec<&String> = choices.iter().collect();
+        sorted_choices.sort();
+        let joined: Vec<String> = sorted_choices.iter().map(|c| esc(c)).collect();
+        let _ = write!(entry, "|one_of={}", joined.join(","));
+    }
+    if let Some(condition) = field.condition() {
+        let _ = write!(
+            entry,
+            "|active_when={}={}",
+            condition.controller(),
+            esc(condition.expected())
+        );
+    }
+    if let Some(validator) = field.validator() {
+        let _ = write!(entry, "|validator={}", esc(validator.revision()));
+    }
+    entry
 }

--- a/crates/standout-input/src/questionnaire/mod.rs
+++ b/crates/standout-input/src/questionnaire/mod.rs
@@ -63,11 +63,11 @@
 //! 2.1 What is the command name? [command.name] (string)
 //! ->
 //!
-//! 3. Describe a command input. [command.inputs] (repeatable section, minimum 1)
+//! 2.2 Describe a command input. [command.inputs] (repeatable section, minimum 1)
 //! (Add an item by copying one complete block - its heading line and its
 //! questions - below the last block, then answering the copy.)
 //!
-//! 3.1 What is its name? [command.inputs.name] (string)
+//! 2.2.1 What is its name? [command.inputs.name] (string)
 //! ->
 //! ```
 //!
@@ -75,7 +75,7 @@
 //! repeatable group. Adding an item is *copy-the-block* editing: copy one
 //! complete block — the group heading line and its questions — paste it
 //! below the last block, and answer the copy. Display numbers stay purely
-//! decorative: every copy may keep saying `3.1`, because the parser counts
+//! decorative: every copy may keep saying `2.2.1`, because the parser counts
 //! *occurrences of the stable group header* and nothing else — never
 //! numbering, wording, or any count written in prose.
 //!

--- a/crates/standout-input/src/questionnaire/mod.rs
+++ b/crates/standout-input/src/questionnaire/mod.rs
@@ -49,6 +49,56 @@
 //! field. Answers keep internal line breaks and lose only outer whitespace.
 //! Declared defaults render pre-filled on the marker line.
 //!
+//! # Nested and repeatable groups
+//!
+//! A questionnaire is a tree: alongside scalar fields it may declare
+//! [`Group`]s — nested sections answered once, or *repeatable* sections
+//! answered once per submitted item within declared [`Repeat`] bounds. A
+//! questionnaire with a repeatable `command.inputs` group (minimum 1)
+//! renders as:
+//!
+//! ```text
+//! 2. Describe the initial command. [command] (section)
+//!
+//! 2.1 What is the command name? [command.name] (string)
+//! ->
+//!
+//! 3. Describe a command input. [command.inputs] (repeatable section, minimum 1)
+//! (Add an item by copying one complete block - its heading line and its
+//! questions - below the last block, then answering the copy.)
+//!
+//! 3.1 What is its name? [command.inputs.name] (string)
+//! ->
+//! ```
+//!
+//! Rendering emits exactly the declared minimum number of blocks per
+//! repeatable group. Adding an item is *copy-the-block* editing: copy one
+//! complete block — the group heading line and its questions — paste it
+//! below the last block, and answer the copy. Display numbers stay purely
+//! decorative: every copy may keep saying `3.1`, because the parser counts
+//! *occurrences of the stable group header* and nothing else — never
+//! numbering, wording, or any count written in prose.
+//!
+//! A group header is recognized only when its bracketed ID names a group
+//! valid at that point of the document *and* it is followed by a child its
+//! definition permits (a child field with its `->` marker, or a child
+//! group); a field header is recognized only where its definition places
+//! it. Bracketed prose inside answers that satisfies neither contract stays
+//! answer content.
+//!
+//! ## Definition IDs vs occurrence indexes
+//!
+//! Definition IDs never change: the name field of *every* submitted input
+//! is defined as `command.inputs.name`. A submitted *instance* of that
+//! field is addressed by its **occurrence path**, which inserts a
+//! zero-based index per enclosing repeatable-group occurrence: the second
+//! input's name is `command.inputs[1].name`. Diagnostics use occurrence
+//! paths, so an error points at the exact copied block to fix; [`Answers`]
+//! and [`RawAnswers`] are keyed by them and expose
+//! [`occurrence_count`](Answers::occurrence_count) for iterating submitted
+//! items. Indexes belong to an answer instance, never to the definition —
+//! which is why they participate in paths but not in the fingerprint.
+//!
 //! # Decoding: defaults, omission, conditions
 //!
 //! Decoding a submission ([`Questionnaire::decode_answers`]) applies one
@@ -126,6 +176,57 @@
 //! assert_eq!(answers.get_bool("project.docker"), Some(false));
 //! assert_eq!(answers.get("project.docker_image"), None); // inactive
 //! ```
+//!
+//! # Nested and repeatable round trip
+//!
+//! ```
+//! use standout_input::questionnaire::{Group, Item, Questionnaire, ScalarField, ScalarKind};
+//!
+//! let questionnaire = Questionnaire::new(
+//!     "demo.commands",
+//!     vec![
+//!         Item::from(ScalarField::new(
+//!             "command.name",
+//!             "What is the command name?",
+//!             ScalarKind::String,
+//!         )),
+//!         // A repeatable group: at least one input, each with two fields.
+//!         Item::from(
+//!             Group::new(
+//!                 "command.inputs",
+//!                 "Describe a command input.",
+//!                 vec![
+//!                     ScalarField::new("command.inputs.name", "Its name?", ScalarKind::String),
+//!                     ScalarField::new("command.inputs.value_type", "Its type?", ScalarKind::String)
+//!                         .with_default("string"),
+//!                 ],
+//!             )
+//!             .repeatable(1),
+//!         ),
+//!     ],
+//! )
+//! .unwrap();
+//!
+//! // Answer the sheet, then simulate copy-the-block editing: duplicate the
+//! // one rendered `command.inputs` block to submit a second item.
+//! let sheet = questionnaire
+//!     .render_answer_sheet()
+//!     .replace("[command.name] (string)\n->", "[command.name] (string)\n-> generate")
+//!     .replace("[command.inputs.name] (string)\n->", "[command.inputs.name] (string)\n-> definition");
+//! let block_start = sheet.find("Describe a command input.").unwrap();
+//! let block = sheet[block_start..].to_string();
+//! let copied = format!("{sheet}\n{}", block.replace("-> definition", "-> output"));
+//!
+//! let raw = questionnaire.parse_answer_sheet(&copied).unwrap();
+//! let answers = questionnaire.decode_answers(&raw).unwrap();
+//!
+//! // Occurrences are counted from the stable group header; each submitted
+//! // instance is addressed by its indexed occurrence path.
+//! assert_eq!(answers.occurrence_count("command.inputs"), 2);
+//! assert_eq!(answers.get_text("command.inputs[0].name"), Some("definition"));
+//! assert_eq!(answers.get_text("command.inputs[1].name"), Some("output"));
+//! assert_eq!(answers.get_text("command.inputs[1].value_type"), Some("string")); // default
+//! ```
 
 mod collect;
 mod decode;
@@ -136,7 +237,7 @@ mod render;
 
 pub use decode::{AnswerValue, Answers, FormError, ValidationDiagnostic};
 pub use definition::{
-    Condition, Constraint, FieldValidator, Questionnaire, QuestionnaireError, ScalarField,
-    ScalarKind,
+    Condition, Constraint, FieldValidator, Group, Item, Questionnaire, QuestionnaireError, Repeat,
+    ScalarField, ScalarKind,
 };
 pub use parse::{AnswerSheetDiagnostic, RawAnswers};

--- a/crates/standout-input/src/questionnaire/parse.rs
+++ b/crates/standout-input/src/questionnaire/parse.rs
@@ -1,53 +1,87 @@
 //! Parsing edited answer sheets back into raw answers.
 //!
 //! Parsing recognizes structure only from stable identities: a field opens
-//! when a header-shaped line carries a schema-recognized bracketed ID and the
-//! following line begins with the `->` answer marker. Everything cosmetic —
-//! display numbers, wording, indentation, type hints — is ignored, so a user
-//! may freely reword or renumber a sheet without changing what it means.
+//! when a header-shaped line carries a schema-recognized bracketed ID, valid
+//! in the current scope, and the following line begins with the `->` answer
+//! marker. A group occurrence opens when a header-shaped line (never a
+//! marker line) carries a group ID valid in the current scope *and* the next
+//! header-shaped line is a child that group's definition permits — so
+//! bracketed prose inside an answer stays answer content unless it satisfies
+//! the full header contract. Everything cosmetic — display numbers, wording,
+//! indentation, type hints — is ignored, so a user may freely reword or
+//! renumber a sheet without changing what it means.
+//!
+//! Repeated items are counted from occurrences of the stable group header,
+//! never from display numbers or wording. Each occurrence of a repeatable
+//! group gives its answers an indexed *occurrence path* (`command.inputs`
+//! occurrence 1 holds `command.inputs[1].name`); fields outside repeatable
+//! groups keep their definition IDs as paths.
 //!
 //! Compatibility is exact-version: the preamble's answer-format version,
 //! questionnaire ID, and fingerprint must all match the parsing definition,
 //! or parsing stops with diagnostics that ask for a freshly rendered sheet.
 //! No migration or fuzzy matching is attempted.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
-use super::definition::Questionnaire;
+use super::definition::{child_segment, path_join, Questionnaire};
 use super::render::{ANSWER_MARKER, FINGERPRINT_PREFIX, FORMAT_LINE, QUESTIONNAIRE_PREFIX};
 
 /// The raw answers parsed from one answer sheet.
 ///
-/// Values are the verbatim answer text with outer whitespace trimmed and
-/// internal line breaks preserved. A field absent from the document is absent
-/// here; a field whose marker was left blank is present with an empty string.
+/// Values are keyed by *occurrence path* — the stable field ID, with a
+/// zero-based index inserted for every enclosing repeatable-group occurrence
+/// (`command.inputs[1].name`) — and hold the verbatim answer text with outer
+/// whitespace trimmed and internal line breaks preserved. A field absent
+/// from the document is absent here; a field whose marker was left blank is
+/// present with an empty string. Occurrence counts of repeatable groups are
+/// carried alongside ([`occurrence_count`](Self::occurrence_count)).
 /// Decoding raw text into typed values (defaults, omission, validation) is a
 /// later stage, shared with interactive collection.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RawAnswers {
     values: BTreeMap<String, String>,
+    /// Occurrences per repeatable group, keyed by the group's own occurrence
+    /// path base (`command.inputs`, or `command.inputs[0].flags` when
+    /// nested). Groups with no submitted occurrence are absent.
+    occurrences: BTreeMap<String, usize>,
 }
 
 impl RawAnswers {
     /// Build raw answers directly, for collection paths (interactive
-    /// prompting) that never see a document. Keys are stable field IDs;
-    /// values are trimmed answer text.
+    /// prompting) that never see a document. Keys are occurrence paths;
+    /// values are trimmed answer text; `occurrences` counts each repeatable
+    /// group's collected occurrences by path base.
     #[cfg(feature = "simple-prompts")]
-    pub(crate) fn from_values(values: BTreeMap<String, String>) -> Self {
-        Self { values }
+    pub(crate) fn from_parts(
+        values: BTreeMap<String, String>,
+        occurrences: BTreeMap<String, usize>,
+    ) -> Self {
+        Self {
+            values,
+            occurrences,
+        }
     }
 
-    /// The raw answer text for a stable field ID, if the field appeared.
-    pub fn get(&self, field_id: &str) -> Option<&str> {
-        self.values.get(field_id).map(String::as_str)
+    /// The raw answer text at an occurrence path (for fields outside
+    /// repeatable groups: the stable field ID), if it appeared.
+    pub fn get(&self, path: &str) -> Option<&str> {
+        self.values.get(path).map(String::as_str)
     }
 
-    /// Iterate over `(field_id, raw_answer)` pairs, ordered by field ID.
+    /// How many occurrences of a repeatable group appeared, addressed by the
+    /// group's occurrence path base — `command.inputs` at the root,
+    /// `command.inputs[0].flags` for a group nested in another occurrence.
+    pub fn occurrence_count(&self, group_path: &str) -> usize {
+        self.occurrences.get(group_path).copied().unwrap_or(0)
+    }
+
+    /// Iterate over `(occurrence_path, raw_answer)` pairs, ordered by path.
     pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
         self.values.iter().map(|(k, v)| (k.as_str(), v.as_str()))
     }
 
-    /// Number of fields that appeared in the document.
+    /// Number of answered occurrence paths in the document.
     pub fn len(&self) -> usize {
         self.values.len()
     }
@@ -60,11 +94,11 @@ impl RawAnswers {
 
 /// One problem found while parsing an answer sheet.
 ///
-/// Diagnostics identify locations by 1-based line number and fields by stable
-/// ID; they never echo full answer values, since answer sheets may contain
-/// sensitive content. Compatibility diagnostics deliberately point at
-/// re-rendering: version 1 rejects incompatible sheets instead of migrating
-/// them.
+/// Diagnostics identify locations by 1-based line number and fields by
+/// stable ID or occurrence path; they never echo full answer values, since
+/// answer sheets may contain sensitive content. Compatibility diagnostics
+/// deliberately point at re-rendering: version 1 rejects incompatible sheets
+/// instead of migrating them.
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 pub enum AnswerSheetDiagnostic {
     /// The `#!` metadata preamble is missing or malformed.
@@ -110,12 +144,41 @@ pub enum AnswerSheetDiagnostic {
         line: usize,
     },
 
-    /// A field header appears more than once.
-    #[error("Line {line}: duplicate field '[{id}]'. Each field may be answered once; remove the extra occurrence.")]
+    /// A field header appears more than once at the same occurrence path.
+    #[error("Line {line}: duplicate field '[{path}]'. Each field may be answered once per occurrence; remove the extra occurrence or copy the complete group block instead.")]
     DuplicateField {
-        /// The duplicated stable field ID.
-        id: String,
+        /// The duplicated occurrence path.
+        path: String,
         /// 1-based line number of the second occurrence.
+        line: usize,
+    },
+
+    /// A non-repeatable group's header appears more than once.
+    #[error("Line {line}: duplicate group '[{id}]'. This group is answered once; remove the extra block (only repeatable sections take copied blocks).")]
+    DuplicateGroup {
+        /// The duplicated stable group ID.
+        id: String,
+        /// 1-based line number of the second header.
+        line: usize,
+    },
+
+    /// A known field or group header appeared outside the scope its
+    /// definition allows (e.g. a group's child without its group header, or
+    /// another group's child inside this group's block).
+    #[error("Line {line}: misplaced '[{id}]'. That ID is not valid at this point of the sheet; keep each field inside its own group block, or render a fresh answer sheet to restore the structure.")]
+    MisplacedId {
+        /// The known-but-misplaced stable ID.
+        id: String,
+        /// 1-based line number of the header-shaped line.
+        line: usize,
+    },
+
+    /// A group header was written with a field-style `->` answer marker.
+    #[error("Line {line}: group '[{id}]' does not take a '->' answer; groups introduce their nested questions. Remove the marker line.")]
+    GroupAnswerMarker {
+        /// The group ID carrying the marker.
+        id: String,
+        /// 1-based line number of the header-shaped line.
         line: usize,
     },
 
@@ -130,18 +193,33 @@ pub enum AnswerSheetDiagnostic {
 
 /// The field (or discard sink) currently accumulating answer lines.
 struct OpenAnswer {
-    /// `Some(id)` for a recognized field; `None` discards the answer text of
-    /// an unknown or duplicate header so it cannot leak into a neighbor.
-    id: Option<String>,
+    /// `Some(path)` for a recognized field; `None` discards the answer text
+    /// of an unknown, duplicate, or misplaced header so it cannot leak into
+    /// a neighbor.
+    path: Option<String>,
     lines: Vec<String>,
 }
 
 impl OpenAnswer {
     fn flush_into(self, values: &mut BTreeMap<String, String>) {
-        if let Some(id) = self.id {
-            values.insert(id, self.lines.join("\n").trim().to_string());
+        if let Some(path) = self.path {
+            values.insert(path, self.lines.join("\n").trim().to_string());
         }
     }
+}
+
+/// One open group occurrence on the parser's scope stack.
+struct Scope {
+    /// The group's stable ID.
+    group_id: String,
+    /// The definition-ID prefix its children extend (`<group_id>.`).
+    def_prefix: String,
+    /// The occurrence path of this occurrence (`command.inputs[1]`).
+    path_prefix: String,
+    /// A scope opened after a structural diagnostic: its content parses for
+    /// boundary tracking but is discarded rather than piling on speculative
+    /// diagnostics.
+    discard: bool,
 }
 
 /// Returns the last bracketed token on `line` when it is shaped like a stable
@@ -160,6 +238,12 @@ fn header_candidate(line: &str) -> Option<&str> {
     valid.then_some(token)
 }
 
+/// Whether a line is an answer-marker line (`->` after optional indent).
+/// Marker lines carry answer text; they can never be group headers.
+fn is_marker_line(line: &str) -> bool {
+    line.trim_start().starts_with(ANSWER_MARKER)
+}
+
 impl Questionnaire {
     /// Parse an edited answer sheet back into [`RawAnswers`].
     ///
@@ -169,73 +253,263 @@ impl Questionnaire {
     /// and fingerprint are checked exactly, and any mismatch returns
     /// diagnostics asking for a fresh sheet without reading the body.
     ///
-    /// Within the body, a field is recognized only by a schema-recognized
-    /// bracketed ID whose *next* line begins with the `->` answer marker.
-    /// The answer is everything after the marker up to the next recognized
-    /// header or end of file, outer whitespace trimmed, internal line breaks
-    /// preserved. Bracketed prose inside an answer is answer text unless it
-    /// satisfies that full header contract.
+    /// Within the body, a field is recognized only by a bracketed ID that is
+    /// schema-valid where it appears and whose *next* line begins with the
+    /// `->` answer marker; a group occurrence is recognized by a bracketed
+    /// group ID (on a non-marker line) that is schema-valid where it appears
+    /// and is followed by a child its definition permits. An answer is
+    /// everything after its marker up to the next recognized header or end
+    /// of file, outer whitespace trimmed, internal line breaks preserved.
+    /// Bracketed prose inside an answer is answer text unless it satisfies
+    /// one of those full header contracts. Repeated items come from repeated
+    /// occurrences of the stable group header: copying a complete rendered
+    /// group block submits one more occurrence, whatever its display
+    /// numbers say.
     ///
     /// # Errors
     ///
     /// Returns every accumulated [`AnswerSheetDiagnostic`]: compatibility
-    /// mismatches, malformed preambles, and unknown or duplicate IDs on
-    /// header-shaped lines.
+    /// mismatches, malformed preambles, and unknown, duplicate, or misplaced
+    /// IDs on header-shaped lines. Occurrence counts *below* a repeatable
+    /// group's minimum (or above its maximum) are not parse errors — they
+    /// are structural validation, reported with the other value diagnostics
+    /// by [`decode_answers`](Self::decode_answers).
     pub fn parse_answer_sheet(&self, text: &str) -> Result<RawAnswers, Vec<AnswerSheetDiagnostic>> {
         let lines: Vec<&str> = text.lines().collect();
         let body_start = self.check_preamble(&lines)?;
 
-        let mut diagnostics = Vec::new();
-        let mut values = BTreeMap::new();
+        let mut diagnostics: Vec<AnswerSheetDiagnostic> = Vec::new();
+        let mut values: BTreeMap<String, String> = BTreeMap::new();
+        let mut occurrences: BTreeMap<String, usize> = BTreeMap::new();
+        let mut seen_sections: HashSet<String> = HashSet::new();
+        let mut stack: Vec<Scope> = Vec::new();
         let mut open: Option<OpenAnswer> = None;
+
         let mut i = body_start;
         while i < lines.len() {
             let line = lines[i];
-            let marker_follows = lines
-                .get(i + 1)
-                .is_some_and(|next| next.trim_start().starts_with(ANSWER_MARKER));
-            if let (true, Some(candidate)) = (marker_follows, header_candidate(line)) {
+            let candidate = header_candidate(line);
+            let marker_follows = lines.get(i + 1).is_some_and(|next| is_marker_line(next));
+
+            // A field-header shape: bracketed ID followed by a marker line.
+            if let (true, Some(candidate)) = (marker_follows, candidate) {
                 if let Some(previous) = open.take() {
                     previous.flush_into(&mut values);
                 }
-                let id = if self.field(candidate).is_none() {
-                    diagnostics.push(AnswerSheetDiagnostic::UnknownFieldId {
-                        id: candidate.to_string(),
-                        line: i + 1,
-                    });
-                    None
-                } else if values.contains_key(candidate) {
-                    diagnostics.push(AnswerSheetDiagnostic::DuplicateField {
-                        id: candidate.to_string(),
-                        line: i + 1,
-                    });
-                    None
-                } else {
-                    Some(candidate.to_string())
-                };
+                let path = self.open_field(candidate, i, &mut stack, &values, &mut diagnostics);
                 let marker_line = lines[i + 1].trim_start();
                 let first = marker_line[ANSWER_MARKER.len()..].to_string();
                 open = Some(OpenAnswer {
-                    id,
+                    path,
                     lines: vec![first],
                 });
                 i += 2;
-            } else {
-                if let Some(current) = open.as_mut() {
-                    current.lines.push(line.to_string());
-                }
-                i += 1;
+                continue;
             }
+
+            // A group-header shape: bracketed group ID on a non-marker line,
+            // followed by a permitted child header.
+            if let Some(candidate) = candidate {
+                let is_group = self.node_meta(candidate).is_some_and(|meta| meta.group);
+                if is_group
+                    && !is_marker_line(line)
+                    && self.group_contract_holds(candidate, &lines, i)
+                {
+                    if let Some(previous) = open.take() {
+                        previous.flush_into(&mut values);
+                    }
+                    self.open_group(
+                        candidate,
+                        i,
+                        &mut stack,
+                        &mut occurrences,
+                        &mut seen_sections,
+                        &mut diagnostics,
+                    );
+                    i += 1;
+                    continue;
+                }
+            }
+
+            // Ordinary content: part of the open answer, or ignored prose.
+            if let Some(current) = open.as_mut() {
+                current.lines.push(line.to_string());
+            }
+            i += 1;
         }
         if let Some(last) = open {
             last.flush_into(&mut values);
         }
 
         if diagnostics.is_empty() {
-            Ok(RawAnswers { values })
+            Ok(RawAnswers {
+                values,
+                occurrences,
+            })
         } else {
             Err(diagnostics)
         }
+    }
+
+    /// Recognize one field header: resolve its scope (popping closed
+    /// groups), then return the occurrence path to accumulate its answer
+    /// under — or `None` (a discard sink) with the appropriate diagnostic.
+    fn open_field(
+        &self,
+        candidate: &str,
+        line_index: usize,
+        stack: &mut Vec<Scope>,
+        values: &BTreeMap<String, String>,
+        diagnostics: &mut Vec<AnswerSheetDiagnostic>,
+    ) -> Option<String> {
+        let line = line_index + 1;
+        let Some(meta) = self.node_meta(candidate) else {
+            diagnostics.push(AnswerSheetDiagnostic::UnknownFieldId {
+                id: candidate.to_string(),
+                line,
+            });
+            return None;
+        };
+        if meta.group {
+            diagnostics.push(AnswerSheetDiagnostic::GroupAnswerMarker {
+                id: candidate.to_string(),
+                line,
+            });
+            return None;
+        }
+        let Some(keep) = resolve_scope(stack, meta.parent.as_deref()) else {
+            diagnostics.push(AnswerSheetDiagnostic::MisplacedId {
+                id: candidate.to_string(),
+                line,
+            });
+            return None;
+        };
+        stack.truncate(keep);
+        let (def_prefix, path_prefix, discard) = match stack.last() {
+            Some(scope) => (
+                scope.def_prefix.as_str(),
+                scope.path_prefix.as_str(),
+                scope.discard,
+            ),
+            None => ("", "", false),
+        };
+        if discard {
+            return None;
+        }
+        let path = path_join(path_prefix, child_segment(def_prefix, candidate));
+        if values.contains_key(&path) {
+            diagnostics.push(AnswerSheetDiagnostic::DuplicateField { path, line });
+            return None;
+        }
+        Some(path)
+    }
+
+    /// Recognize one group header whose contract already held: resolve its
+    /// scope, count the occurrence, and push the occurrence scope (a discard
+    /// scope after a misplacement or duplicate, so nested content does not
+    /// cascade diagnostics).
+    fn open_group(
+        &self,
+        candidate: &str,
+        line_index: usize,
+        stack: &mut Vec<Scope>,
+        occurrences: &mut BTreeMap<String, usize>,
+        seen_sections: &mut HashSet<String>,
+        diagnostics: &mut Vec<AnswerSheetDiagnostic>,
+    ) {
+        let line = line_index + 1;
+        let group = self
+            .group_def(candidate)
+            .expect("caller verified the ID names a group");
+        let parent = self
+            .node_meta(candidate)
+            .expect("known group has meta")
+            .parent
+            .clone();
+
+        let discard_scope = |discard: bool| Scope {
+            group_id: group.id().to_string(),
+            def_prefix: group.def_prefix(),
+            path_prefix: String::new(),
+            discard,
+        };
+
+        let Some(keep) = resolve_scope(stack, parent.as_deref()) else {
+            diagnostics.push(AnswerSheetDiagnostic::MisplacedId {
+                id: candidate.to_string(),
+                line,
+            });
+            stack.push(discard_scope(true));
+            return;
+        };
+        stack.truncate(keep);
+        let (parent_def, parent_path, parent_discard) = match stack.last() {
+            Some(scope) => (
+                scope.def_prefix.as_str(),
+                scope.path_prefix.as_str(),
+                scope.discard,
+            ),
+            None => ("", "", false),
+        };
+        if parent_discard {
+            stack.push(discard_scope(true));
+            return;
+        }
+        let base = path_join(parent_path, child_segment(parent_def, candidate));
+        let path_prefix = match group.repeat() {
+            Some(_) => {
+                let count = occurrences.entry(base.clone()).or_insert(0);
+                let index = *count;
+                *count += 1;
+                format!("{base}[{index}]")
+            }
+            None => {
+                if !seen_sections.insert(base.clone()) {
+                    diagnostics.push(AnswerSheetDiagnostic::DuplicateGroup {
+                        id: candidate.to_string(),
+                        line,
+                    });
+                    stack.push(discard_scope(true));
+                    return;
+                }
+                base
+            }
+        };
+        stack.push(Scope {
+            group_id: group.id().to_string(),
+            def_prefix: group.def_prefix(),
+            path_prefix,
+            discard: false,
+        });
+    }
+
+    /// The group-header contract beyond the ID itself: the next
+    /// header-shaped, non-marker line must carry a *direct child* of this
+    /// group — a child field followed by its own `->` marker, or a child
+    /// group. Anything else leaves the line as ordinary prose.
+    fn group_contract_holds(&self, group_id: &str, lines: &[&str], at: usize) -> bool {
+        for (offset, line) in lines[at + 1..].iter().enumerate() {
+            if is_marker_line(line) {
+                continue;
+            }
+            let Some(next) = header_candidate(line) else {
+                continue;
+            };
+            let Some(meta) = self.node_meta(next) else {
+                continue;
+            };
+            if meta.parent.as_deref() != Some(group_id) {
+                return false;
+            }
+            if meta.group {
+                return true;
+            }
+            let index = at + 1 + offset;
+            return lines
+                .get(index + 1)
+                .is_some_and(|next| is_marker_line(next));
+        }
+        false
     }
 
     /// Validate the three-line `#!` preamble against this definition.
@@ -328,5 +602,19 @@ impl Questionnaire {
         } else {
             Err(diagnostics)
         }
+    }
+}
+
+/// Find the stack depth to keep so the top of the stack is the scope for
+/// `parent` (`None` = the questionnaire root): closed sibling groups pop,
+/// while an ID whose parent is not on the stack at all is misplaced
+/// (`None`).
+fn resolve_scope(stack: &[Scope], parent: Option<&str>) -> Option<usize> {
+    match parent {
+        None => Some(0),
+        Some(parent) => stack
+            .iter()
+            .rposition(|scope| scope.group_id == parent)
+            .map(|found| found + 1),
     }
 }

--- a/crates/standout-input/src/questionnaire/render.rs
+++ b/crates/standout-input/src/questionnaire/render.rs
@@ -2,13 +2,21 @@
 //!
 //! Rendering writes the prose document described in the
 //! [module documentation](crate::questionnaire): a three-line `#!` metadata
-//! preamble followed by one numbered question block per field, with declared
-//! defaults pre-filled on their answer marker lines. The same definition
-//! always renders byte-identical output.
+//! preamble followed by one numbered question block per item, with declared
+//! defaults pre-filled on their answer marker lines. Groups render a heading
+//! line followed by their nested, dot-numbered children; a repeatable group
+//! renders exactly its declared minimum number of occurrences plus one-line
+//! guidance for copying a complete block. The same definition always renders
+//! byte-identical output.
+//!
+//! All numbering is cosmetic. Each occurrence of a repeatable group renders
+//! with the *same* display numbers — the parser counts occurrences of the
+//! stable group header, never numbers — which also keeps every block an
+//! exact copy of its siblings, so "copy the block" needs no renumbering.
 
 use std::fmt::Write as _;
 
-use super::definition::Questionnaire;
+use super::definition::{Item, Questionnaire};
 
 /// The exact first preamble line of a version-1 answer sheet.
 pub(crate) const FORMAT_LINE: &str = "#! standout-answers 1";
@@ -19,6 +27,12 @@ pub(crate) const FINGERPRINT_PREFIX: &str = "#! fingerprint:";
 /// The marker introducing answer text under a field header.
 pub(crate) const ANSWER_MARKER: &str = "->";
 
+/// The copy-the-block guidance line rendered under a repeatable group's
+/// first heading. Deliberately bracket-free so it can never look like a
+/// header to the parser.
+const REPEAT_GUIDANCE: &str =
+    "(Add an item by copying one complete block - its heading line and its questions - below the last block, then answering the copy.)";
+
 impl Questionnaire {
     /// Render a blank answer sheet for this questionnaire.
     ///
@@ -28,33 +42,75 @@ impl Questionnaire {
     /// wording, the bracketed stable ID, and a parenthesized type hint —
     /// followed by the `->` answer marker. A field with a declared default
     /// renders the default pre-filled on the marker line; every other field
-    /// renders a bare marker awaiting the answer.
+    /// renders a bare marker awaiting the answer. A group renders its
+    /// heading line and its children with nested cosmetic numbering; a
+    /// repeatable group renders exactly its declared minimum number of
+    /// occurrence blocks and concise guidance to copy a complete block when
+    /// adding an item.
     pub fn render_answer_sheet(&self) -> String {
         let mut out = String::new();
         out.push_str(FORMAT_LINE);
         out.push('\n');
         let _ = writeln!(out, "{QUESTIONNAIRE_PREFIX} {}", self.id());
         let _ = writeln!(out, "{FINGERPRINT_PREFIX} {}", self.fingerprint());
-        for (index, field) in self.fields().iter().enumerate() {
-            out.push('\n');
-            let _ = writeln!(
-                out,
-                "{}. {} [{}] ({})",
-                index + 1,
-                field.prompt(),
-                field.id(),
-                field.type_hint()
-            );
-            match field.default() {
-                Some(default) => {
-                    let _ = writeln!(out, "{ANSWER_MARKER} {default}");
+        render_items(self.items(), "", &mut out);
+        out
+    }
+}
+
+/// Render one scope's items, numbering them `1.`/`2.`… at the root and
+/// `<prefix>.1`/`<prefix>.2`… when nested.
+fn render_items(items: &[Item], number_prefix: &str, out: &mut String) {
+    for (index, item) in items.iter().enumerate() {
+        let number = display_number(number_prefix, index + 1);
+        match item {
+            Item::Field(field) => {
+                out.push('\n');
+                let _ = writeln!(
+                    out,
+                    "{number} {} [{}] ({})",
+                    field.prompt(),
+                    field.id(),
+                    field.type_hint()
+                );
+                match field.default() {
+                    Some(default) => {
+                        let _ = writeln!(out, "{ANSWER_MARKER} {default}");
+                    }
+                    None => {
+                        out.push_str(ANSWER_MARKER);
+                        out.push('\n');
+                    }
                 }
-                None => {
-                    out.push_str(ANSWER_MARKER);
+            }
+            Item::Group(group) => {
+                let occurrences = group.repeat().map_or(1, |repeat| repeat.min());
+                for occurrence in 0..occurrences {
                     out.push('\n');
+                    let _ = writeln!(
+                        out,
+                        "{number} {} [{}] ({})",
+                        group.prompt(),
+                        group.id(),
+                        group.type_hint()
+                    );
+                    if group.repeat().is_some() && occurrence == 0 {
+                        out.push_str(REPEAT_GUIDANCE);
+                        out.push('\n');
+                    }
+                    render_items(group.children(), number.trim_end_matches('.'), out);
                 }
             }
         }
-        out
+    }
+}
+
+/// The cosmetic display number for one item: `3.` at the root, `3.1` when
+/// nested (matching the rendered examples in the module documentation).
+fn display_number(prefix: &str, ordinal: usize) -> String {
+    if prefix.is_empty() {
+        format!("{ordinal}.")
+    } else {
+        format!("{prefix}.{ordinal}")
     }
 }

--- a/crates/standout-input/tests/questionnaire.rs
+++ b/crates/standout-input/tests/questionnaire.rs
@@ -80,10 +80,7 @@ fn definition_rejects_invalid_field_id() {
         vec![ScalarField::new("Project.Name", "A?", ScalarKind::String)],
     )
     .unwrap_err();
-    assert_eq!(
-        err,
-        QuestionnaireError::InvalidFieldId("Project.Name".into())
-    );
+    assert_eq!(err, QuestionnaireError::InvalidId("Project.Name".into()));
 }
 
 #[test]
@@ -96,12 +93,12 @@ fn definition_rejects_duplicate_field_ids() {
         ],
     )
     .unwrap_err();
-    assert_eq!(err, QuestionnaireError::DuplicateFieldId("a".into()));
+    assert_eq!(err, QuestionnaireError::DuplicateId("a".into()));
 }
 
 #[test]
 fn definition_rejects_empty_field_list() {
-    let err = Questionnaire::new("demo", vec![]).unwrap_err();
+    let err = Questionnaire::new("demo", Vec::<ScalarField>::new()).unwrap_err();
     assert_eq!(err, QuestionnaireError::NoFields);
 }
 
@@ -464,7 +461,7 @@ fn duplicate_field_header_is_a_diagnostic() {
     assert_eq!(
         diags,
         vec![AnswerSheetDiagnostic::DuplicateField {
-            id: "project.name".into(),
+            path: "project.name".into(),
             line: 8,
         }]
     );

--- a/crates/standout-input/tests/questionnaire_collection.rs
+++ b/crates/standout-input/tests/questionnaire_collection.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use serial_test::serial;
 use standout_input::env::{reset_default_stdin_reader, set_default_stdin_reader, MockStdin};
 use standout_input::questionnaire::{
-    AnswerSheetDiagnostic, Questionnaire, ScalarField, ScalarKind,
+    AnswerSheetDiagnostic, Group, Item, Questionnaire, ScalarField, ScalarKind,
 };
 use standout_input::{
     reset_default_prompt_responder, set_default_prompt_responder, InputError, MockTerminal,
@@ -306,8 +306,169 @@ fn interactive_collection_refuses_a_non_terminal_without_a_responder() {
 }
 
 // ============================================================================
+// Interactive adapter: repeatable groups
+// ============================================================================
+
+/// A repeatable group (minimum 1, maximum 3) with a per-occurrence
+/// conditional field.
+fn repeatable_questionnaire() -> Questionnaire {
+    Questionnaire::new(
+        "demo.repeats",
+        vec![Item::from(
+            Group::new(
+                "inputs",
+                "Describe an input.",
+                vec![
+                    ScalarField::new("inputs.name", "Name?", ScalarKind::String),
+                    ScalarField::new("inputs.flag", "Expose a flag?", ScalarKind::Bool)
+                        .with_default("no"),
+                    ScalarField::new("inputs.flag_name", "Flag name?", ScalarKind::String)
+                        .active_when("inputs.flag", "yes"),
+                ],
+            )
+            .repeatable(1)
+            .max_occurrences(3),
+        )],
+    )
+    .unwrap()
+}
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_collection_walks_repeatable_occurrences() {
+    let q = repeatable_questionnaire();
+    // Occurrence 0: name, flag=yes, flag_name. Add another? yes.
+    // Occurrence 1: name, flag=no (skip), flag_name skipped (inactive).
+    // Add another? no.
+    let _guard = ResponderGuard::install([
+        PromptResponse::text("alpha"),
+        PromptResponse::text("yes"),
+        PromptResponse::text("alpha-flag"),
+        PromptResponse::text("yes"), // add another?
+        PromptResponse::text("beta"),
+        PromptResponse::Skip,       // flag: default "no"
+        PromptResponse::text("no"), // add another?
+    ]);
+    let raw = q.collect_interactive().unwrap();
+    assert_eq!(raw.occurrence_count("inputs"), 2);
+    let answers = q.decode_answers(&raw).unwrap();
+    assert_eq!(answers.occurrence_count("inputs"), 2);
+    assert_eq!(answers.get_text("inputs[0].name"), Some("alpha"));
+    assert_eq!(answers.get_text("inputs[0].flag_name"), Some("alpha-flag"));
+    assert_eq!(answers.get_text("inputs[1].name"), Some("beta"));
+    assert_eq!(answers.get_bool("inputs[1].flag"), Some(false));
+    assert_eq!(answers.get("inputs[1].flag_name"), None);
+}
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_collection_stops_at_the_maximum_without_asking() {
+    let q = Questionnaire::new(
+        "demo.capped",
+        vec![Item::from(
+            Group::new(
+                "items",
+                "Item?",
+                vec![ScalarField::new("items.name", "Name?", ScalarKind::String)],
+            )
+            .repeatable(1)
+            .max_occurrences(1),
+        )],
+    )
+    .unwrap();
+    // Exactly one prompt: the scripted responder would panic on an
+    // unexpected add-another question.
+    let _guard = ResponderGuard::install([PromptResponse::text("only")]);
+    let raw = q.collect_interactive().unwrap();
+    assert_eq!(raw.occurrence_count("items"), 1);
+    assert_eq!(raw.get("items[0].name"), Some("only"));
+}
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_blank_add_another_means_no() {
+    let q = repeatable_questionnaire();
+    let _guard = ResponderGuard::install([
+        PromptResponse::text("alpha"),
+        PromptResponse::Skip, // flag: default "no"
+        PromptResponse::Skip, // add another? blank = no
+    ]);
+    let raw = q.collect_interactive().unwrap();
+    assert_eq!(raw.occurrence_count("inputs"), 1);
+}
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_add_another_retries_on_a_non_bool_answer() {
+    let q = repeatable_questionnaire();
+    let _guard = ResponderGuard::install([
+        PromptResponse::text("alpha"),
+        PromptResponse::Skip,          // flag: default "no"
+        PromptResponse::text("maybe"), // add another: not yes/no -> re-ask
+        PromptResponse::text("no"),
+    ]);
+    let raw = q.collect_interactive().unwrap();
+    assert_eq!(raw.occurrence_count("inputs"), 1);
+}
+
+#[test]
+#[serial(prompt_responder)]
+fn interactive_cancellation_inside_an_occurrence_aborts() {
+    let q = repeatable_questionnaire();
+    let _guard = ResponderGuard::install([PromptResponse::text("alpha"), PromptResponse::Cancel]);
+    let err = q.collect_interactive().unwrap_err();
+    assert!(matches!(err, InputError::PromptCancelled));
+}
+
+// ============================================================================
 // Cross-source equivalence
 // ============================================================================
+
+#[test]
+#[serial(prompt_responder)]
+fn nested_interactive_and_sheet_submissions_decode_identically() {
+    let q = repeatable_questionnaire();
+
+    let _guard = ResponderGuard::install([
+        PromptResponse::text("alpha"),
+        PromptResponse::text("yes"),
+        PromptResponse::text("alpha-flag"),
+        PromptResponse::text("yes"), // add another?
+        PromptResponse::text("beta"),
+        PromptResponse::Skip,       // flag: default "no"
+        PromptResponse::text("no"), // add another?
+    ]);
+    let interactive = q.decode_answers(&q.collect_interactive().unwrap()).unwrap();
+
+    // The same answers as a sheet: the rendered block answered, plus one
+    // copied block for the second occurrence.
+    let sheet = q.render_answer_sheet();
+    let block_start = sheet.find("Describe an input.").unwrap();
+    let block = sheet[block_start..].to_string();
+    let first = sheet
+        .replace(
+            "[inputs.name] (string)\n->",
+            "[inputs.name] (string)\n-> alpha",
+        )
+        .replace("-> no", "-> yes")
+        .replace(
+            "[inputs.flag_name] (string; only when inputs.flag is true)\n->",
+            "[inputs.flag_name] (string; only when inputs.flag is true)\n-> alpha-flag",
+        );
+    let second = block.replace(
+        "[inputs.name] (string)\n->",
+        "[inputs.name] (string)\n-> beta",
+    );
+    let document = format!("{first}\n{second}");
+    let batch = q
+        .decode_answers(
+            &q.read_answer_sheet_stdin_with(&MockStdin::piped(document))
+                .unwrap(),
+        )
+        .unwrap();
+
+    assert_eq!(interactive, batch);
+}
 
 #[test]
 #[serial(prompt_responder)]

--- a/crates/standout-input/tests/questionnaire_groups.rs
+++ b/crates/standout-input/tests/questionnaire_groups.rs
@@ -1,0 +1,910 @@
+//! Pure answer-sheet engine tests for nested and repeatable groups:
+//! definition validation, minimum-count rendering, copied blocks, occurrence
+//! paths, malformed boundaries, cosmetic edits, structural fingerprinting,
+//! conditional repeated fields, and accumulated diagnostics.
+
+use standout_input::questionnaire::{
+    AnswerSheetDiagnostic, FormError, Group, Item, Questionnaire, QuestionnaireError, ScalarField,
+    ScalarKind, ValidationDiagnostic,
+};
+
+/// A nested fixture: a root field, a section, and inside the section a
+/// repeatable group (minimum 1, maximum 3) with a defaulted child.
+fn commands() -> Questionnaire {
+    Questionnaire::new(
+        "demo.commands",
+        vec![
+            Item::from(ScalarField::new(
+                "project.name",
+                "What is the project name?",
+                ScalarKind::String,
+            )),
+            Item::from(Group::new(
+                "command",
+                "Describe the initial command.",
+                vec![
+                    Item::from(ScalarField::new(
+                        "command.name",
+                        "What is the command name?",
+                        ScalarKind::String,
+                    )),
+                    Item::from(
+                        Group::new(
+                            "command.inputs",
+                            "Describe a command input.",
+                            vec![
+                                ScalarField::new(
+                                    "command.inputs.name",
+                                    "What is its name?",
+                                    ScalarKind::String,
+                                ),
+                                ScalarField::new(
+                                    "command.inputs.value_type",
+                                    "What type of value is it?",
+                                    ScalarKind::String,
+                                )
+                                .with_default("string"),
+                            ],
+                        )
+                        .repeatable(1)
+                        .max_occurrences(3),
+                    ),
+                ],
+            )),
+        ],
+    )
+    .unwrap()
+}
+
+/// A repeatable fixture with conditions: a per-occurrence controller
+/// (`inputs.flag` gates `inputs.flag_name`) and a root controller
+/// (`advanced` gates `inputs.doc` in every occurrence).
+fn conditional_inputs() -> Questionnaire {
+    Questionnaire::new(
+        "demo.cond",
+        vec![
+            Item::from(
+                ScalarField::new("advanced", "Advanced mode?", ScalarKind::Bool).with_default("no"),
+            ),
+            Item::from(
+                Group::new(
+                    "inputs",
+                    "Describe an input.",
+                    vec![
+                        ScalarField::new("inputs.name", "Name?", ScalarKind::String),
+                        ScalarField::new("inputs.flag", "Expose a flag?", ScalarKind::Bool)
+                            .with_default("no"),
+                        ScalarField::new("inputs.flag_name", "Flag name?", ScalarKind::String)
+                            .active_when("inputs.flag", "yes"),
+                        ScalarField::new("inputs.doc", "Document it?", ScalarKind::String)
+                            .active_when("advanced", "yes"),
+                    ],
+                )
+                .repeatable(1),
+            ),
+        ],
+    )
+    .unwrap()
+}
+
+/// Replace the `n`th (0-based) rendered marker following a header of `id`.
+fn answer_nth(sheet: &str, id: &str, n: usize, answer: &str) -> String {
+    let needle = format!("[{id}]");
+    let mut out = String::new();
+    let mut seen = 0;
+    let mut lines = sheet.lines().peekable();
+    while let Some(line) = lines.next() {
+        out.push_str(line);
+        out.push('\n');
+        if line.contains(&needle) {
+            let marker = lines.next().expect("marker follows header");
+            assert!(marker.starts_with("->"), "expected a marker line");
+            if seen == n {
+                out.push_str("-> ");
+                out.push_str(answer);
+            } else {
+                out.push_str(marker);
+            }
+            out.push('\n');
+            seen += 1;
+        }
+    }
+    assert!(seen > n, "found only {seen} markers for {id}");
+    out
+}
+
+/// Split a sheet at the first header line of `id`: everything before it,
+/// and the block from the header line to the end of the sheet.
+fn split_at_header(sheet: &str, id: &str) -> (String, String) {
+    let needle = format!("[{id}]");
+    let mut offset = 0;
+    for line in sheet.lines() {
+        if line.contains(&needle) {
+            return (sheet[..offset].to_string(), sheet[offset..].to_string());
+        }
+        offset += line.len() + 1;
+    }
+    panic!("no header found for {id}");
+}
+
+/// The `commands()` sheet with every scalar answered and one input block.
+fn answered_commands_sheet(q: &Questionnaire) -> String {
+    let sheet = q.render_answer_sheet();
+    let sheet = answer_nth(&sheet, "project.name", 0, "demo");
+    let sheet = answer_nth(&sheet, "command.name", 0, "generate");
+    answer_nth(&sheet, "command.inputs.name", 0, "definition")
+}
+
+// ============================================================================
+// Definition validation
+// ============================================================================
+
+#[test]
+fn definition_rejects_empty_group() {
+    let err = Questionnaire::new(
+        "demo",
+        vec![Item::from(Group::new("g", "?", Vec::<Item>::new()))],
+    )
+    .unwrap_err();
+    assert_eq!(err, QuestionnaireError::EmptyGroup("g".into()));
+}
+
+#[test]
+fn definition_rejects_child_id_that_does_not_extend_the_group() {
+    let err = Questionnaire::new(
+        "demo",
+        vec![Item::from(Group::new(
+            "cmd",
+            "?",
+            vec![ScalarField::new("name", "?", ScalarKind::String)],
+        ))],
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        QuestionnaireError::GroupChildId {
+            group: "cmd".into(),
+            child: "name".into(),
+        }
+    );
+}
+
+#[test]
+fn definition_rejects_a_zero_minimum() {
+    let err = Questionnaire::new(
+        "demo",
+        vec![Item::from(
+            Group::new(
+                "g",
+                "?",
+                vec![ScalarField::new("g.a", "?", ScalarKind::String)],
+            )
+            .repeatable(0),
+        )],
+    )
+    .unwrap_err();
+    assert!(matches!(err, QuestionnaireError::InvalidRepeat { id, .. } if id == "g"));
+}
+
+#[test]
+fn definition_rejects_a_maximum_below_the_minimum() {
+    let err = Questionnaire::new(
+        "demo",
+        vec![Item::from(
+            Group::new(
+                "g",
+                "?",
+                vec![ScalarField::new("g.a", "?", ScalarKind::String)],
+            )
+            .repeatable(2)
+            .max_occurrences(1),
+        )],
+    )
+    .unwrap_err();
+    assert!(matches!(err, QuestionnaireError::InvalidRepeat { id, .. } if id == "g"));
+}
+
+#[test]
+fn definition_rejects_a_maximum_without_repeatable() {
+    let err = Questionnaire::new(
+        "demo",
+        vec![Item::from(
+            Group::new(
+                "g",
+                "?",
+                vec![ScalarField::new("g.a", "?", ScalarKind::String)],
+            )
+            .max_occurrences(2),
+        )],
+    )
+    .unwrap_err();
+    assert!(matches!(err, QuestionnaireError::InvalidRepeat { id, .. } if id == "g"));
+}
+
+#[test]
+fn definition_rejects_duplicate_ids_across_fields_and_groups() {
+    let err = Questionnaire::new(
+        "demo",
+        vec![
+            Item::from(ScalarField::new("a.b", "?", ScalarKind::String)),
+            Item::from(Group::new(
+                "a",
+                "?",
+                vec![ScalarField::new("a.b", "?", ScalarKind::String)],
+            )),
+        ],
+    )
+    .unwrap_err();
+    assert_eq!(err, QuestionnaireError::DuplicateId("a.b".into()));
+}
+
+#[test]
+fn definition_rejects_a_condition_into_a_sibling_group() {
+    // g2.b's controller lives inside sibling group g1: with repeats there
+    // would be no single occurrence to resolve it against.
+    let err = Questionnaire::new(
+        "demo",
+        vec![
+            Item::from(Group::new(
+                "g1",
+                "?",
+                vec![ScalarField::new("g1.a", "?", ScalarKind::Bool)],
+            )),
+            Item::from(Group::new(
+                "g2",
+                "?",
+                vec![ScalarField::new("g2.b", "?", ScalarKind::String).active_when("g1.a", "yes")],
+            )),
+        ],
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        QuestionnaireError::ConditionScope {
+            id: "g2.b".into(),
+            controller: "g1.a".into(),
+        }
+    );
+}
+
+#[test]
+fn definition_rejects_a_condition_on_a_group() {
+    let err = Questionnaire::new(
+        "demo",
+        vec![
+            Item::from(Group::new(
+                "g",
+                "?",
+                vec![ScalarField::new("g.a", "?", ScalarKind::String)],
+            )),
+            Item::from(ScalarField::new("b", "?", ScalarKind::String).active_when("g", "x")),
+        ],
+    )
+    .unwrap_err();
+    assert!(matches!(err, QuestionnaireError::InvalidCondition { id, .. } if id == "b"));
+}
+
+// ============================================================================
+// Rendering
+// ============================================================================
+
+#[test]
+fn render_emits_exactly_the_declared_minimum_of_blocks() {
+    let q = Questionnaire::new(
+        "demo",
+        vec![Item::from(
+            Group::new(
+                "items",
+                "Describe an item.",
+                vec![ScalarField::new("items.name", "Name?", ScalarKind::String)],
+            )
+            .repeatable(2),
+        )],
+    )
+    .unwrap();
+    let sheet = q.render_answer_sheet();
+    let headers = sheet
+        .matches("[items] (repeatable section, minimum 2)")
+        .count();
+    assert_eq!(headers, 2, "exactly the minimum number of blocks: {sheet}");
+    assert_eq!(sheet.matches("[items.name]").count(), 2);
+}
+
+#[test]
+fn render_includes_copy_the_block_guidance_once_per_group() {
+    let q = commands();
+    let sheet = q.render_answer_sheet();
+    assert_eq!(
+        sheet.matches("copying one complete block").count(),
+        1,
+        "concise guidance rendered once: {sheet}"
+    );
+}
+
+#[test]
+fn render_numbers_nested_items_cosmetically() {
+    let q = commands();
+    let sheet = q.render_answer_sheet();
+    assert!(sheet.contains("2. Describe the initial command. [command] (section)"));
+    assert!(sheet.contains("2.1 What is the command name? [command.name] (string)"));
+    assert!(sheet.contains(
+        "2.2 Describe a command input. [command.inputs] (repeatable section, minimum 1, maximum 3)"
+    ));
+    assert!(sheet.contains("2.2.1 What is its name? [command.inputs.name] (string)"));
+}
+
+#[test]
+fn render_prefills_defaults_in_every_occurrence() {
+    let q = Questionnaire::new(
+        "demo",
+        vec![Item::from(
+            Group::new(
+                "items",
+                "Describe an item.",
+                vec![ScalarField::new("items.kind", "Kind?", ScalarKind::String)
+                    .with_default("basic")],
+            )
+            .repeatable(2),
+        )],
+    )
+    .unwrap();
+    let sheet = q.render_answer_sheet();
+    assert_eq!(sheet.matches("-> basic").count(), 2);
+}
+
+#[test]
+fn render_is_deterministic_for_nested_definitions() {
+    let q = commands();
+    assert_eq!(q.render_answer_sheet(), q.render_answer_sheet());
+}
+
+// ============================================================================
+// Round trips and copied blocks
+// ============================================================================
+
+#[test]
+fn minimum_sheet_round_trips_with_occurrence_paths() {
+    let q = commands();
+    let raw = q.parse_answer_sheet(&answered_commands_sheet(&q)).unwrap();
+    assert_eq!(raw.occurrence_count("command.inputs"), 1);
+    let answers = q.decode_answers(&raw).unwrap();
+    assert_eq!(answers.get_text("project.name"), Some("demo"));
+    assert_eq!(answers.get_text("command.name"), Some("generate"));
+    assert_eq!(answers.occurrence_count("command.inputs"), 1);
+    assert_eq!(
+        answers.get_text("command.inputs[0].name"),
+        Some("definition")
+    );
+    assert_eq!(
+        answers.get_text("command.inputs[0].value_type"),
+        Some("string"),
+        "the pre-filled default decodes"
+    );
+}
+
+#[test]
+fn copying_a_complete_block_adds_an_occurrence() {
+    let q = commands();
+    let sheet = answered_commands_sheet(&q);
+    let (_, block) = split_at_header(&sheet, "command.inputs");
+    let copied = format!("{sheet}\n{}", block.replace("-> definition", "-> output"));
+
+    let answers = q
+        .decode_answers(&q.parse_answer_sheet(&copied).unwrap())
+        .unwrap();
+    assert_eq!(answers.occurrence_count("command.inputs"), 2);
+    assert_eq!(
+        answers.get_text("command.inputs[0].name"),
+        Some("definition")
+    );
+    assert_eq!(answers.get_text("command.inputs[1].name"), Some("output"));
+}
+
+#[test]
+fn occurrence_counts_come_from_headers_not_numbers_or_wording() {
+    let q = commands();
+    let sheet = answered_commands_sheet(&q);
+    let (_, block) = split_at_header(&sheet, "command.inputs");
+    // The copied block keeps the same display numbers, gets reworded, and
+    // even claims a count in prose — none of which means anything.
+    let copy = block
+        .replace(
+            "Describe a command input.",
+            "One more input (this is the 9th of 12).",
+        )
+        .replace("What is its name?", "Name for this one?")
+        .replace("-> definition", "-> output");
+    let copied = format!("{sheet}\n{copy}");
+
+    let answers = q
+        .decode_answers(&q.parse_answer_sheet(&copied).unwrap())
+        .unwrap();
+    assert_eq!(answers.occurrence_count("command.inputs"), 2);
+    assert_eq!(answers.get_text("command.inputs[1].name"), Some("output"));
+}
+
+#[test]
+fn a_root_field_after_a_group_block_closes_the_group_scope() {
+    let q = Questionnaire::new(
+        "demo",
+        vec![
+            Item::from(Group::new(
+                "g",
+                "Group?",
+                vec![ScalarField::new("g.a", "A?", ScalarKind::String)],
+            )),
+            Item::from(ScalarField::new("notes", "Notes?", ScalarKind::Text).optional()),
+        ],
+    )
+    .unwrap();
+    let sheet = q.render_answer_sheet();
+    let sheet = answer_nth(&sheet, "g.a", 0, "inside");
+    let sheet = answer_nth(&sheet, "notes", 0, "outside");
+    let raw = q.parse_answer_sheet(&sheet).unwrap();
+    assert_eq!(raw.get("g.a"), Some("inside"));
+    assert_eq!(raw.get("notes"), Some("outside"));
+}
+
+// ============================================================================
+// Malformed boundaries
+// ============================================================================
+
+#[test]
+fn group_prose_without_a_valid_child_is_answer_content() {
+    let q = Questionnaire::new(
+        "demo",
+        vec![
+            Item::from(Group::new(
+                "g",
+                "Group?",
+                vec![ScalarField::new("g.a", "A?", ScalarKind::String)],
+            )),
+            Item::from(ScalarField::new("notes", "Notes?", ScalarKind::Text).optional()),
+        ],
+    )
+    .unwrap();
+    let sheet = q.render_answer_sheet();
+    let sheet = answer_nth(&sheet, "g.a", 0, "inside");
+    // A known group ID inside prose, with no valid child following: the
+    // header contract fails, so it stays answer content.
+    let sheet = answer_nth(&sheet, "notes", 0, "see [g] for details\nand more prose");
+    let raw = q.parse_answer_sheet(&sheet).unwrap();
+    assert_eq!(
+        raw.get("notes"),
+        Some("see [g] for details\nand more prose")
+    );
+    assert_eq!(raw.occurrence_count("g"), 0, "sections are not counted");
+}
+
+#[test]
+fn a_child_without_its_group_header_is_misplaced() {
+    let q = commands();
+    let sheet = answered_commands_sheet(&q);
+    // Delete the group header line: its children now sit in the enclosing
+    // scope, where they are not valid.
+    let sheet: String = sheet
+        .lines()
+        .filter(|line| !line.contains("[command.inputs]"))
+        .map(|line| format!("{line}\n"))
+        .collect();
+    let diags = q.parse_answer_sheet(&sheet).unwrap_err();
+    assert!(
+        diags
+            .iter()
+            .all(|d| matches!(d, AnswerSheetDiagnostic::MisplacedId { id, .. } if id.starts_with("command.inputs."))),
+        "children without their group header are misplaced: {diags:?}"
+    );
+    assert_eq!(diags.len(), 2);
+}
+
+#[test]
+fn a_duplicate_section_header_is_a_diagnostic() {
+    let q = commands();
+    let sheet = answered_commands_sheet(&q);
+    let (_, block) = split_at_header(&sheet, "command");
+    let copied = format!("{sheet}\n{block}");
+    let diags = q.parse_answer_sheet(&copied).unwrap_err();
+    assert_eq!(
+        diags.len(),
+        1,
+        "no cascade from the discarded copy: {diags:?}"
+    );
+    assert!(
+        matches!(&diags[0], AnswerSheetDiagnostic::DuplicateGroup { id, .. } if id == "command"),
+        "{diags:?}"
+    );
+}
+
+#[test]
+fn a_duplicate_child_in_one_occurrence_reports_the_indexed_path() {
+    let q = commands();
+    let sheet = answered_commands_sheet(&q);
+    let extra = "9. Name again? [command.inputs.name] (string)\n-> twice\n";
+    let sheet = format!("{sheet}{extra}");
+    let diags = q.parse_answer_sheet(&sheet).unwrap_err();
+    assert_eq!(diags.len(), 1);
+    assert!(
+        matches!(
+            &diags[0],
+            AnswerSheetDiagnostic::DuplicateField { path, .. } if path == "command.inputs[0].name"
+        ),
+        "duplicate within an occurrence is indexed: {diags:?}"
+    );
+}
+
+#[test]
+fn a_group_header_with_an_answer_marker_is_a_diagnostic() {
+    let q = commands();
+    let sheet = answered_commands_sheet(&q);
+    let sheet = format!("{sheet}\n9. Inputs? [command.inputs] (section)\n-> nope\n");
+    let diags = q.parse_answer_sheet(&sheet).unwrap_err();
+    assert_eq!(diags.len(), 1);
+    assert!(
+        matches!(
+            &diags[0],
+            AnswerSheetDiagnostic::GroupAnswerMarker { id, .. } if id == "command.inputs"
+        ),
+        "{diags:?}"
+    );
+}
+
+#[test]
+fn an_unknown_child_inside_a_block_is_a_diagnostic() {
+    let q = conditional_inputs();
+    let sheet = q.render_answer_sheet();
+    let sheet = answer_nth(&sheet, "inputs.name", 0, "alpha");
+    // A header-shaped line with a marker but an ID the schema never
+    // declared, inside a group block: diagnosed, not silently swallowed.
+    let sheet = format!("{sheet}9. Ghost? [inputs.ghost] (string)\n-> boo\n");
+    let diags = q.parse_answer_sheet(&sheet).unwrap_err();
+    assert_eq!(diags.len(), 1);
+    assert!(
+        matches!(&diags[0], AnswerSheetDiagnostic::UnknownFieldId { id, .. } if id == "inputs.ghost"),
+        "{diags:?}"
+    );
+}
+
+// ============================================================================
+// Decoding: bounds, indexed paths, conditions, accumulation
+// ============================================================================
+
+#[test]
+fn under_minimum_occurrences_is_a_structural_diagnostic() {
+    let q = commands();
+    let sheet = answered_commands_sheet(&q);
+    let (head, _) = split_at_header(&sheet, "command.inputs");
+    let raw = q.parse_answer_sheet(&head).unwrap();
+    assert_eq!(raw.occurrence_count("command.inputs"), 0);
+    let diags = q.decode_answers(&raw).unwrap_err();
+    assert_eq!(
+        diags,
+        vec![ValidationDiagnostic::TooFewOccurrences {
+            path: "command.inputs".into(),
+            minimum: 1,
+            found: 0,
+        }],
+        "no speculative missing-field errors for absent occurrences: {diags:?}"
+    );
+}
+
+#[test]
+fn over_maximum_occurrences_is_a_structural_diagnostic() {
+    let q = commands();
+    let sheet = answered_commands_sheet(&q);
+    let (_, block) = split_at_header(&sheet, "command.inputs");
+    let mut copied = sheet.clone();
+    for n in 1..=3 {
+        copied = format!(
+            "{copied}\n{}",
+            block.replace("-> definition", &format!("-> in{n}"))
+        );
+    }
+    let diags = q
+        .decode_answers(&q.parse_answer_sheet(&copied).unwrap())
+        .unwrap_err();
+    assert_eq!(
+        diags,
+        vec![ValidationDiagnostic::TooManyOccurrences {
+            path: "command.inputs".into(),
+            maximum: 3,
+            found: 4,
+        }]
+    );
+}
+
+#[test]
+fn missing_required_answers_use_indexed_occurrence_paths() {
+    let q = commands();
+    let sheet = answered_commands_sheet(&q);
+    let (_, block) = split_at_header(&sheet, "command.inputs");
+    // The copied block's name is left blank.
+    let copied = format!("{sheet}\n{}", block.replace("-> definition", "->"));
+    let diags = q
+        .decode_answers(&q.parse_answer_sheet(&copied).unwrap())
+        .unwrap_err();
+    assert_eq!(
+        diags,
+        vec![ValidationDiagnostic::MissingAnswer {
+            id: "command.inputs[1].name".into(),
+        }]
+    );
+}
+
+#[test]
+fn a_condition_inside_a_repeatable_group_controls_per_occurrence() {
+    let q = conditional_inputs();
+    let sheet = q.render_answer_sheet();
+    let sheet = answer_nth(&sheet, "inputs.name", 0, "alpha");
+    let sheet = answer_nth(&sheet, "inputs.flag", 0, "yes");
+    let sheet = answer_nth(&sheet, "inputs.flag_name", 0, "alpha-flag");
+    let (_, block) = split_at_header(&sheet, "inputs");
+    // Second occurrence keeps flag=no (the default), so its flag_name must
+    // stay blank — and does.
+    let copy = block
+        .replace("-> alpha-flag", "->")
+        .replace("-> yes", "-> no")
+        .replace("-> alpha", "-> beta");
+    let copied = format!("{sheet}\n{copy}");
+
+    let answers = q
+        .decode_answers(&q.parse_answer_sheet(&copied).unwrap())
+        .unwrap();
+    assert_eq!(answers.occurrence_count("inputs"), 2);
+    assert_eq!(answers.get_text("inputs[0].flag_name"), Some("alpha-flag"));
+    assert_eq!(answers.get("inputs[1].flag_name"), None);
+}
+
+#[test]
+fn a_populated_inactive_field_in_an_occurrence_is_indexed() {
+    let q = conditional_inputs();
+    let sheet = q.render_answer_sheet();
+    let sheet = answer_nth(&sheet, "inputs.name", 0, "alpha");
+    // flag stays "no" (default) but flag_name is populated anyway.
+    let sheet = answer_nth(&sheet, "inputs.flag_name", 0, "stale");
+    let diags = q
+        .decode_answers(&q.parse_answer_sheet(&sheet).unwrap())
+        .unwrap_err();
+    assert_eq!(
+        diags,
+        vec![ValidationDiagnostic::InactiveAnswered {
+            id: "inputs[0].flag_name".into(),
+            controller: "inputs.flag".into(),
+            expected: "true".into(),
+        }]
+    );
+}
+
+#[test]
+fn a_root_controller_gates_fields_in_every_occurrence() {
+    let q = conditional_inputs();
+    let sheet = q.render_answer_sheet();
+    let sheet = answer_nth(&sheet, "advanced", 0, "yes");
+    let sheet = answer_nth(&sheet, "inputs.name", 0, "alpha");
+    let sheet = answer_nth(&sheet, "inputs.doc", 0, "documented");
+    let answers = q
+        .decode_answers(&q.parse_answer_sheet(&sheet).unwrap())
+        .unwrap();
+    assert_eq!(answers.get_text("inputs[0].doc"), Some("documented"));
+
+    // With advanced left at its default (no), a populated doc is an error.
+    let sheet = q.render_answer_sheet();
+    let sheet = answer_nth(&sheet, "inputs.name", 0, "alpha");
+    let sheet = answer_nth(&sheet, "inputs.doc", 0, "stale");
+    let diags = q
+        .decode_answers(&q.parse_answer_sheet(&sheet).unwrap())
+        .unwrap_err();
+    assert_eq!(
+        diags,
+        vec![ValidationDiagnostic::InactiveAnswered {
+            id: "inputs[0].doc".into(),
+            controller: "advanced".into(),
+            expected: "true".into(),
+        }]
+    );
+}
+
+#[test]
+fn diagnostics_accumulate_across_occurrences() {
+    let q = conditional_inputs();
+    let sheet = q.render_answer_sheet();
+    // Occurrence 0: name blank (missing). Occurrence 1: flag not a bool.
+    let (_, block) = split_at_header(&sheet, "inputs");
+    let copy = block
+        .replace("-> no", "-> maybe")
+        .replace("Name?", "Name for the second one?");
+    let copy = answer_nth(&copy, "inputs.name", 0, "beta");
+    let copied = format!("{sheet}\n{copy}");
+
+    let diags = q
+        .decode_answers(&q.parse_answer_sheet(&copied).unwrap())
+        .unwrap_err();
+    assert_eq!(diags.len(), 2, "{diags:?}");
+    assert!(diags.iter().any(
+        |d| matches!(d, ValidationDiagnostic::MissingAnswer { id } if id == "inputs[0].name")
+    ));
+    assert!(diags.iter().any(
+        |d| matches!(d, ValidationDiagnostic::InvalidValue { id, .. } if id == "inputs[1].flag")
+    ));
+}
+
+#[test]
+fn whole_form_rules_run_over_indexed_answers() {
+    let q = commands();
+    let sheet = answered_commands_sheet(&q);
+    // The copied block keeps the same name answer, violating the app rule.
+    let (_, block) = split_at_header(&sheet, "command.inputs");
+    let copied = format!("{sheet}\n{block}");
+    let raw = q.parse_answer_sheet(&copied).unwrap();
+    let diags = q
+        .decode_answers_with(&raw, |answers| {
+            // An application rule spanning occurrences: input names unique.
+            let count = answers.occurrence_count("command.inputs");
+            let mut names: Vec<&str> = (0..count)
+                .filter_map(|i| answers.get_text(&format!("command.inputs[{i}].name")))
+                .collect();
+            names.sort_unstable();
+            names.dedup();
+            if names.len() != count {
+                vec![FormError::new(
+                    ["command.inputs"],
+                    "input names must be unique",
+                )]
+            } else {
+                Vec::new()
+            }
+        })
+        .unwrap_err();
+    assert_eq!(diags.len(), 1);
+    assert!(matches!(&diags[0], ValidationDiagnostic::Form { .. }));
+}
+
+// ============================================================================
+// Fingerprint: structure and bounds are semantic; wording and order are not
+// ============================================================================
+
+/// The `commands()` fixture with different wording and item order.
+fn reworded_commands() -> Questionnaire {
+    Questionnaire::new(
+        "demo.commands",
+        vec![
+            Item::from(Group::new(
+                "command",
+                "Tell us about your first command!",
+                vec![
+                    Item::from(
+                        Group::new(
+                            "command.inputs",
+                            "An input for the command.",
+                            vec![
+                                ScalarField::new(
+                                    "command.inputs.value_type",
+                                    "Value type, please?",
+                                    ScalarKind::String,
+                                )
+                                .with_default("string"),
+                                ScalarField::new(
+                                    "command.inputs.name",
+                                    "Call it what?",
+                                    ScalarKind::String,
+                                ),
+                            ],
+                        )
+                        .repeatable(1)
+                        .max_occurrences(3),
+                    ),
+                    Item::from(ScalarField::new(
+                        "command.name",
+                        "Command name, please?",
+                        ScalarKind::String,
+                    )),
+                ],
+            )),
+            Item::from(ScalarField::new(
+                "project.name",
+                "Project name, please?",
+                ScalarKind::String,
+            )),
+        ],
+    )
+    .unwrap()
+}
+
+#[test]
+fn fingerprint_ignores_wording_and_presentation_order() {
+    assert_eq!(commands().fingerprint(), reworded_commands().fingerprint());
+}
+
+#[test]
+fn a_reworded_sheet_still_parses_for_the_equivalent_definition() {
+    // A sheet rendered by one wording parses under the other: cosmetic
+    // definition changes never invalidate distributed sheets.
+    let rendered_by = commands();
+    let parsed_by = reworded_commands();
+    let raw = parsed_by
+        .parse_answer_sheet(&answered_commands_sheet(&rendered_by))
+        .unwrap();
+    assert_eq!(raw.get("command.inputs[0].name"), Some("definition"));
+}
+
+#[test]
+fn fingerprint_covers_repeat_bounds() {
+    let with_bounds = |min: usize, max: Option<usize>| {
+        let mut group = Group::new(
+            "items",
+            "Item?",
+            vec![ScalarField::new("items.name", "?", ScalarKind::String)],
+        )
+        .repeatable(min);
+        if let Some(max) = max {
+            group = group.max_occurrences(max);
+        }
+        Questionnaire::new("demo", vec![Item::from(group)]).unwrap()
+    };
+    let base = with_bounds(1, None);
+    assert_ne!(base.fingerprint(), with_bounds(2, None).fingerprint());
+    assert_ne!(base.fingerprint(), with_bounds(1, Some(3)).fingerprint());
+}
+
+#[test]
+fn fingerprint_covers_group_structure() {
+    // Same ID set, different nesting: a.c inside the group vs at the root.
+    let nested = Questionnaire::new(
+        "demo",
+        vec![Item::from(Group::new(
+            "a",
+            "?",
+            vec![
+                ScalarField::new("a.b", "?", ScalarKind::String),
+                ScalarField::new("a.c", "?", ScalarKind::String),
+            ],
+        ))],
+    )
+    .unwrap();
+    let flat = Questionnaire::new(
+        "demo",
+        vec![
+            Item::from(Group::new(
+                "a",
+                "?",
+                vec![ScalarField::new("a.b", "?", ScalarKind::String)],
+            )),
+            Item::from(ScalarField::new("a.c", "?", ScalarKind::String)),
+        ],
+    )
+    .unwrap();
+    assert_ne!(nested.fingerprint(), flat.fingerprint());
+}
+
+#[test]
+fn a_sheet_from_changed_bounds_is_stale() {
+    let one = Questionnaire::new(
+        "demo",
+        vec![Item::from(
+            Group::new(
+                "items",
+                "Item?",
+                vec![ScalarField::new("items.name", "?", ScalarKind::String)],
+            )
+            .repeatable(1),
+        )],
+    )
+    .unwrap();
+    let two = Questionnaire::new(
+        "demo",
+        vec![Item::from(
+            Group::new(
+                "items",
+                "Item?",
+                vec![ScalarField::new("items.name", "?", ScalarKind::String)],
+            )
+            .repeatable(2),
+        )],
+    )
+    .unwrap();
+    let sheet = one.render_answer_sheet();
+    let diags = two.parse_answer_sheet(&sheet).unwrap_err();
+    assert!(matches!(
+        &diags[..],
+        [AnswerSheetDiagnostic::FingerprintMismatch { .. }]
+    ));
+}


### PR DESCRIPTION
for #255

## Context

**Why this approach.** The scalar answer-sheet engine from WS01/WS02 already had the right seams (definition → render → parse → decode → collect, one shared validation pipeline), so this workstream generalizes each stage to a definition *tree* instead of adding a parallel group path:

- **Definition** (`definition.rs`): new `Item`/`Group`/`Repeat` public types. `Questionnaire::new` stays source-compatible for flat questionnaires (`Vec<ScalarField>` still works via `impl Into<Item>`). Construction validates the tree: globally unique IDs, non-empty groups, repeat bounds, and a **child-ID prefix rule** (every child extends its group's ID, `command.inputs` → `command.inputs.name`) so occurrence paths are always derivable from definition IDs. Conditions are scope-checked: a controller must live in the same group occurrence or an enclosing one, and gates per occurrence.
- **Render** (`render.rs`): recursive, nested cosmetic numbering (`2.2.1`), exactly the declared minimum of repeatable blocks, bracket-free copy-the-block guidance rendered once per group. Every occurrence block renders identically (same display numbers), so copying needs no renumbering.
- **Parse** (`parse.rs`): a scope-stack parser. A group occurrence opens only when its ID is valid in the current scope **and** the next header-shaped line is a child its definition permits (the acceptance-criteria header contract); bracketed prose in answers stays content. Occurrence counts come only from stable group headers. New diagnostics: `MisplacedId`, `DuplicateGroup`, `GroupAnswerMarker`; discard scopes prevent diagnostic cascades from a rejected block.
- **Decode + interactive collect** (`decode.rs`, `collect.rs`): both walk the same tree with the same scope chain, addressing instances by indexed occurrence path (`command.inputs[1].name`) through the unchanged shared pipeline (defaults, kinds, constraints, validators, conditions, whole-form rules). Under-minimum / over-maximum are decode-stage structural diagnostics; the interactive adapter collects min occurrences then asks add-another (blank = no) up to max, so interactive submissions satisfy bounds by construction.
- **Fingerprint** (`fingerprint.rs`): canonical form bumped to v3; group structure (parent links) and repeat bounds are hashed, wording/numbering/order are not.

**Spec/ADR self-check.** Verified the diff against `docs/spec/questionnaire-answer-sheets.md` and ADR-0014 before opening: minimum-count rendering + copy-block guidance (Spec §prose format), group-header recognition contract incl. answer-marker exclusion (§format, acceptance #3), occurrence counts from stable headers only (ADR ¶2, acceptance #4), definition IDs vs indexed instance paths (§format ¶6, acceptance #5), one shared decode/validation path (§collection, acceptance #6), fingerprint semantic surface (§fingerprint, acceptance #7), accumulated batch diagnostics on occurrence paths (§collection, acceptance #8), public docs with nested examples + ID-vs-index explanation (module docs + doctests, acceptance #9), pure + adapter tests incl. copied blocks, malformed boundaries, cosmetic edits, stale fingerprints, conditional repeated fields (acceptance #10). `pixi run test`: 2008/2008 green; commit/push hooks ran the full lint gate.

**Decisions worth noting.**
- **Repeatable minimum must be ≥ 1** (`InvalidRepeat` otherwise): the Spec requires rendering exactly the minimum number of blocks *and* a complete block to copy; a zero-minimum group would render no block at all. An optional list belongs behind a conditional or optional child. Flagging explicitly since the Spec doesn't state it verbatim — it falls out of the two requirements above.
- **Contract extension, documented per the brief**: `RawAnswers`/`Answers` keys are now occurrence paths (identical to field IDs for scalar questionnaires — existing callers unaffected), plus `occurrence_count()` accessors; `QuestionnaireError::{InvalidFieldId,DuplicateFieldId}` → `{InvalidId,DuplicateId}` now that groups share the ID namespace; `AnswerSheetDiagnostic::DuplicateField` carries `path`. Only this crate's module consumes these today (bootstrap-wizard adoption is #256).
- A known group ID in prose **followed by a schema-valid child header** does open an occurrence — the deterministic contract the Spec asks for instead of guesswork; documented in `parse_answer_sheet`.

**Out of scope / do not fix here:** bootstrap-wizard questionnaire adoption (#256), wizard stdin/confirmation/`--yes` policy (#257), application domain types in `standout-input`, answer-source merging, fuzzy migration of stale sheets, and any `standout` bin wizard changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)