### PR TITLE
STANDOUT-WIZ02-WS05: Epic: Questionnaire Answer Sheets - Workstream: Support safe attended and automated stdin answer sheets

### DIFF
--- a/crates/standout/src/bin/standout.rs
+++ b/crates/standout/src/bin/standout.rs
@@ -7,9 +7,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Parser, Subcommand};
 use minijinja::context;
+use standout_input::env::{DefaultStdin, StdinReader};
 use standout_input::questionnaire::{
-    AnswerValue, Answers, FieldValidator, FormError, Group, Item, Questionnaire, ScalarField,
-    ScalarKind,
+    AnswerSheetDiagnostic, AnswerValue, Answers, FieldValidator, FormError, Group, Item,
+    Questionnaire, RawAnswers, ScalarField, ScalarKind,
 };
 use standout_render::template::new_environment;
 
@@ -25,10 +26,18 @@ enum Commands {
     /// Generate the smallest runnable Standout workspace.
     NewProject {
         /// Generate from a completed answer sheet instead of interactive
-        /// prompts. The named file replaces question collection entirely;
-        /// the review and confirmation gate still follows.
+        /// prompts: a named file, or `-` to read exactly one complete sheet
+        /// from piped stdin. Either form replaces question collection
+        /// entirely; the review and confirmation gate still follows, and
+        /// submitting a sheet never implies consent to generate.
         #[arg(long, value_name = "FILE")]
         answers: Option<PathBuf>,
+
+        /// Skip the confirmation prompt (for automation). Parsing,
+        /// validation, the review output, and atomic publication all still
+        /// run; only the final "type 'yes'" gate is bypassed.
+        #[arg(long)]
+        yes: bool,
 
         #[command(subcommand)]
         command: Option<NewProjectCommand>,
@@ -48,31 +57,78 @@ enum NewProjectCommand {
 
 fn main() -> Result<()> {
     match Cli::parse().command {
-        Commands::NewProject { answers, command } => match (command, answers) {
-            (Some(NewProjectCommand::Questions { file }), None) => {
+        Commands::NewProject {
+            answers,
+            yes,
+            command,
+        } => match (command, answers, yes) {
+            (Some(NewProjectCommand::Questions { file }), None, false) => {
                 render_questions(file.as_deref())
             }
-            (Some(NewProjectCommand::Questions { .. }), Some(_)) => {
+            (Some(NewProjectCommand::Questions { .. }), _, _) => {
                 bail!(
                     "`questions` renders the blank answer sheet and cannot be combined \
-                     with --answers; run `standout new-project --answers FILE` to \
-                     generate from a completed sheet"
+                     with --answers or --yes; run `standout new-project --answers FILE` \
+                     to generate from a completed sheet"
                 )
             }
-            (None, answers) => run_new_project(answers.as_deref()),
+            (None, answers, yes) => run_new_project(answers.as_deref(), yes),
         },
+    }
+}
+
+/// The answer-sheet source an `--answers` value selects: a named file, or
+/// exactly one complete sheet read from piped stdin (`--answers -`). Sheets
+/// never merge with prompts or with each other.
+enum SheetSource {
+    File(PathBuf),
+    Stdin,
+}
+
+impl SheetSource {
+    fn from_flag(value: &Path) -> Self {
+        if value == Path::new("-") {
+            Self::Stdin
+        } else {
+            Self::File(value.to_path_buf())
+        }
+    }
+
+    /// The source's name in diagnostics ("answer sheet <label> has …").
+    fn label(&self) -> String {
+        match self {
+            Self::File(path) => path.display().to_string(),
+            Self::Stdin => "from stdin".to_string(),
+        }
+    }
+
+    fn answers(&self) -> Result<WizardAnswers, Vec<String>> {
+        match self {
+            Self::File(path) => sheet_answers(path),
+            Self::Stdin => stdin_sheet_answers(&DefaultStdin),
+        }
     }
 }
 
 /// Run the wizard end to end: collect [`WizardAnswers`] from exactly one
 /// source — interactive prompts, or a completed answer sheet named by
-/// `answers_file` (sources never merge) — then take both through the same
-/// review, confirmation, and atomic publication gate. Every collection or
-/// validation failure, a rejected confirmation, and cancellation all return
+/// `answers_file` (a file path, or `-` for piped stdin; sources never
+/// merge) — then take every mode through the same review, confirmation,
+/// and atomic publication gate.
+///
+/// Confirmation policy: submitting a sheet never implies consent, and no
+/// stdin byte or EOF can ever confirm. Interactive runs confirm on the
+/// prompt stream they were already attending. Sheet runs without
+/// `assume_yes` confirm through the attended-terminal seam
+/// ([`AttendedTerminal`]) — independent of stdin by construction — and fail
+/// with guidance when no attended terminal exists. `assume_yes` (`--yes`)
+/// skips only that final gate. Every collection or validation failure, a
+/// missing terminal, a rejected confirmation, and cancellation all return
 /// before any destination file is written.
-fn run_new_project(answers_file: Option<&Path>) -> Result<()> {
-    let answers = match answers_file {
-        Some(path) => match sheet_answers(path) {
+fn run_new_project(answers_file: Option<&Path>, assume_yes: bool) -> Result<()> {
+    let source = answers_file.map(SheetSource::from_flag);
+    let answers = match &source {
+        Some(sheet) => match sheet.answers() {
             Ok(answers) => answers,
             Err(diagnostics) => {
                 for diagnostic in &diagnostics {
@@ -80,7 +136,7 @@ fn run_new_project(answers_file: Option<&Path>) -> Result<()> {
                 }
                 bail!(
                     "answer sheet {} has {} problem(s); nothing was generated",
-                    path.display(),
+                    sheet.label(),
                     diagnostics.len()
                 );
             }
@@ -96,7 +152,14 @@ fn run_new_project(answers_file: Option<&Path>) -> Result<()> {
     };
     let spec = ProjectSpec::from_answers(answers)?;
     write_review(&spec, &mut io::stdout())?;
-    if !confirm(&mut io::stdin().lock(), &mut io::stdout())? {
+    let confirmed = if assume_yes {
+        true
+    } else if source.is_some() {
+        confirm_attended(attended_terminal_from_env()?.as_mut())?
+    } else {
+        confirm(&mut io::stdin().lock(), &mut io::stdout())?
+    };
+    if !confirmed {
         println!("Generation cancelled.");
         return Ok(());
     }
@@ -531,12 +594,160 @@ fn prompt_command_input(input: &mut dyn BufRead, output: &mut dyn Write) -> Resu
     })
 }
 
+/// The confirmation question every mode asks; only an exact trimmed `yes`
+/// reply confirms, everything else — including EOF — cancels.
+const CONFIRM_QUESTION: &str = "Generate this project? Type 'yes' to continue: ";
+
+/// Interactive-mode confirmation on the prompt stream the user is already
+/// attending. Answer-sheet runs never come here — they confirm through
+/// [`confirm_attended`], independent of stdin.
 fn confirm(input: &mut dyn BufRead, output: &mut dyn Write) -> Result<bool> {
-    write!(output, "Generate this project? Type 'yes' to continue: ")?;
+    write!(output, "{CONFIRM_QUESTION}")?;
     output.flush()?;
     let mut line = String::new();
     input.read_line(&mut line)?;
     Ok(line.trim() == "yes")
+}
+
+/// The attended-terminal seam answer-sheet runs confirm through.
+///
+/// By construction it is independent of stdin: the production
+/// implementation talks to the controlling terminal device, so nothing an
+/// answer sheet pipes in — content, trailing bytes, or EOF — can ever reach
+/// the confirmation gate.
+trait AttendedTerminal {
+    /// Whether a human-attended terminal is present to prompt.
+    fn is_attended(&self) -> bool;
+
+    /// Show `question` on the terminal and read one reply line.
+    /// `Ok(None)` is end of input — the caller treats it as a rejection,
+    /// never as consent.
+    fn ask(&mut self, question: &str) -> Result<Option<String>>;
+}
+
+/// Ask the attended confirmation question through `terminal`. Fails with
+/// actionable guidance when no attended terminal exists — an absent
+/// terminal is an error, never implicit approval — and confirms only on an
+/// exact trimmed `yes` reply.
+fn confirm_attended(terminal: &mut dyn AttendedTerminal) -> Result<bool> {
+    if !terminal.is_attended() {
+        bail!(
+            "confirmation requires an attended terminal, but none is available; \
+             rerun in a terminal to review and confirm, or pass --yes to generate \
+             without a confirmation prompt; nothing was generated"
+        );
+    }
+    let reply = terminal.ask(CONFIRM_QUESTION)?;
+    Ok(reply.is_some_and(|line| line.trim() == "yes"))
+}
+
+/// The production [`AttendedTerminal`]: the process's controlling terminal
+/// device (`/dev/tty` on Unix, `CONIN$`/`CONOUT$` on Windows), opened at
+/// confirmation time. Opening the device fails exactly when no attended
+/// terminal exists, whatever stdin/stdout are redirected to.
+struct ControllingTerminal;
+
+#[cfg(unix)]
+fn open_controlling_terminal() -> Option<(fs::File, fs::File)> {
+    let read = fs::OpenOptions::new().read(true).open("/dev/tty").ok()?;
+    let write = fs::OpenOptions::new().write(true).open("/dev/tty").ok()?;
+    Some((read, write))
+}
+
+#[cfg(windows)]
+fn open_controlling_terminal() -> Option<(fs::File, fs::File)> {
+    let read = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("CONIN$")
+        .ok()?;
+    let write = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("CONOUT$")
+        .ok()?;
+    Some((read, write))
+}
+
+impl AttendedTerminal for ControllingTerminal {
+    fn is_attended(&self) -> bool {
+        open_controlling_terminal().is_some()
+    }
+
+    fn ask(&mut self, question: &str) -> Result<Option<String>> {
+        let (read, mut write) = open_controlling_terminal()
+            .ok_or_else(|| anyhow!("the controlling terminal is no longer available"))?;
+        write.write_all(question.as_bytes())?;
+        write.flush()?;
+        let mut line = String::new();
+        if io::BufReader::new(read).read_line(&mut line)? == 0 {
+            return Ok(None);
+        }
+        Ok(Some(line))
+    }
+}
+
+/// A scripted [`AttendedTerminal`] for tests that must run the production
+/// binary without a real terminal: either no terminal at all, or a fixed
+/// reply script. Questions echo to stdout so CLI transcripts can assert the
+/// prompt appeared without a terminal device in the loop.
+struct ScriptedTerminal {
+    attended: bool,
+    replies: std::collections::VecDeque<String>,
+}
+
+impl ScriptedTerminal {
+    fn absent() -> Self {
+        Self {
+            attended: false,
+            replies: std::collections::VecDeque::new(),
+        }
+    }
+
+    fn from_replies(replies: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            attended: true,
+            replies: replies.into_iter().collect(),
+        }
+    }
+}
+
+impl AttendedTerminal for ScriptedTerminal {
+    fn is_attended(&self) -> bool {
+        self.attended
+    }
+
+    fn ask(&mut self, question: &str) -> Result<Option<String>> {
+        print!("{question}");
+        io::stdout().flush()?;
+        Ok(self.replies.pop_front())
+    }
+}
+
+/// The env var that swaps the attended-terminal seam for tests. This is a
+/// TEST SEAM, not user configuration: unset means the real controlling
+/// terminal; `absent` simulates a missing terminal; any other value names a
+/// file whose lines are the scripted terminal replies.
+const TERMINAL_SEAM_VAR: &str = "STANDOUT_NEW_PROJECT_TERMINAL";
+
+/// Resolve the [`AttendedTerminal`] the confirmation gate uses, honoring
+/// the [`TERMINAL_SEAM_VAR`] test seam.
+fn attended_terminal_from_env() -> Result<Box<dyn AttendedTerminal>> {
+    match std::env::var_os(TERMINAL_SEAM_VAR) {
+        None => Ok(Box::new(ControllingTerminal)),
+        Some(value) if value == "absent" => Ok(Box::new(ScriptedTerminal::absent())),
+        Some(path) => {
+            let script = fs::read_to_string(&path).with_context(|| {
+                format!(
+                    "failed to read the scripted terminal replies from {}",
+                    Path::new(&path).display()
+                )
+            })?;
+            Ok(Box::new(ScriptedTerminal::from_replies(
+                script.lines().map(ToOwned::to_owned),
+            )))
+        }
+    }
 }
 
 fn prompt_result_shape(input: &mut dyn BufRead, output: &mut dyn Write) -> Result<ResultShape> {
@@ -1135,31 +1346,47 @@ fn wizard_answers_from(answers: &Answers) -> WizardAnswers {
     }
 }
 
-/// Collect [`WizardAnswers`] from one completed answer sheet.
+/// Collect [`WizardAnswers`] from one completed answer sheet named by path.
 ///
 /// Reading, parsing, decoding, and the wizard's whole-form rules all run
 /// before anything else happens; failures return every accumulated
 /// diagnostic, already rendered for display. This path never merges other
 /// sources and performs no generation itself — the caller still runs the
-/// review, confirmation, and publication gate.
+/// review, confirmation, and publication gate ([`stdin_sheet_answers`] is
+/// the `--answers -` counterpart sharing the same [`decode_sheet`] tail).
 fn sheet_answers(path: &Path) -> Result<WizardAnswers, Vec<String>> {
     let questionnaire = wizard_questionnaire();
-    let raw = questionnaire
-        .read_answer_sheet_file(path)
-        .map_err(|diagnostics| {
-            diagnostics
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-        })?;
+    let raw = questionnaire.read_answer_sheet_file(path);
+    decode_sheet(&questionnaire, raw)
+}
+
+/// [`sheet_answers`] for `--answers -`: read exactly one complete answer
+/// sheet from `reader` (piped stdin in production, an injected
+/// [`StdinReader`] in tests) to end of input, then decode it through the
+/// identical parse, decode, and whole-form pipeline as a named file — the
+/// two sources produce identical validated answers for identical documents.
+/// Interactive-terminal stdin is a collection error, and nothing read here
+/// ever reaches the confirmation gate.
+fn stdin_sheet_answers(reader: &dyn StdinReader) -> Result<WizardAnswers, Vec<String>> {
+    let questionnaire = wizard_questionnaire();
+    let raw = questionnaire.read_answer_sheet_stdin_with(reader);
+    decode_sheet(&questionnaire, raw)
+}
+
+/// The collection-source-independent tail of sheet reading: decode raw
+/// sheet answers with the wizard's whole-form rules and convert them to
+/// [`WizardAnswers`], rendering any accumulated diagnostics for display.
+fn decode_sheet(
+    questionnaire: &Questionnaire,
+    raw: Result<RawAnswers, Vec<AnswerSheetDiagnostic>>,
+) -> Result<WizardAnswers, Vec<String>> {
+    fn rendered(diagnostics: Vec<impl ToString>) -> Vec<String> {
+        diagnostics.iter().map(ToString::to_string).collect()
+    }
+    let raw = raw.map_err(rendered)?;
     let answers = questionnaire
         .decode_answers_with(&raw, wizard_form_rules)
-        .map_err(|diagnostics| {
-            diagnostics
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-        })?;
+        .map_err(rendered)?;
     Ok(wizard_answers_from(&answers))
 }
 
@@ -3778,13 +4005,8 @@ mod tests {
     /// parse, shared decoding, wizard whole-form rules, domain conversion.
     fn decode_sheet(sheet: &str) -> Result<WizardAnswers, Vec<String>> {
         let questionnaire = wizard_questionnaire();
-        let raw = questionnaire
-            .parse_answer_sheet(sheet)
-            .map_err(|d| d.iter().map(ToString::to_string).collect::<Vec<_>>())?;
-        let answers = questionnaire
-            .decode_answers_with(&raw, wizard_form_rules)
-            .map_err(|d| d.iter().map(ToString::to_string).collect::<Vec<_>>())?;
-        Ok(wizard_answers_from(&answers))
+        let raw = questionnaire.parse_answer_sheet(sheet);
+        super::decode_sheet(&questionnaire, raw)
     }
 
     #[test]
@@ -3994,5 +4216,69 @@ mod tests {
 
         assert_eq!(errors.len(), 1);
         assert!(errors[0].contains("render a fresh answer sheet"));
+    }
+
+    /// One minimal valid `hello-tool` sheet for source-equivalence tests.
+    fn minimal_sheet() -> String {
+        let sheet = wizard_questionnaire().render_answer_sheet();
+        let sheet = fill(&sheet, "project.name", "hello-tool");
+        let sheet = fill(&sheet, "command.name", "greet");
+        let sheet = fill(&sheet, "command.description", "Greet one value");
+        fill(&sheet, "command.inputs.name", "name")
+    }
+
+    #[test]
+    fn file_and_stdin_sheets_decode_to_identical_answers_and_specs() {
+        let sheet = minimal_sheet();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("answers.txt");
+        fs::write(&path, &sheet).unwrap();
+
+        let from_file = sheet_answers(&path).unwrap();
+        let from_stdin = stdin_sheet_answers(&standout_input::MockStdin::piped(&sheet)).unwrap();
+
+        assert_eq!(from_file, from_stdin);
+        assert_eq!(
+            ProjectSpec::from_answers(from_file).unwrap(),
+            ProjectSpec::from_answers(from_stdin).unwrap()
+        );
+    }
+
+    #[test]
+    fn terminal_stdin_cannot_supply_an_answer_sheet() {
+        let errors = stdin_sheet_answers(&standout_input::MockStdin::terminal()).unwrap_err();
+
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("interactive terminal"));
+    }
+
+    #[test]
+    fn attended_confirmation_accepts_only_an_exact_yes() {
+        let confirmed = |reply: &str| {
+            confirm_attended(&mut ScriptedTerminal::from_replies([reply.to_string()])).unwrap()
+        };
+
+        assert!(confirmed("yes"));
+        assert!(confirmed("  yes  "));
+        assert!(!confirmed("no"));
+        assert!(!confirmed("YES please"));
+        assert!(!confirmed(""));
+    }
+
+    #[test]
+    fn attended_end_of_input_is_a_rejection_not_consent() {
+        let mut terminal = ScriptedTerminal::from_replies(Vec::<String>::new());
+
+        assert!(!confirm_attended(&mut terminal).unwrap());
+    }
+
+    #[test]
+    fn missing_attended_terminal_fails_with_guidance() {
+        let error = confirm_attended(&mut ScriptedTerminal::absent()).unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("attended terminal"));
+        assert!(message.contains("--yes"));
+        assert!(message.contains("nothing was generated"));
     }
 }

--- a/crates/standout/src/bin/standout.rs
+++ b/crates/standout/src/bin/standout.rs
@@ -625,17 +625,23 @@ trait AttendedTerminal {
     fn ask(&mut self, question: &str) -> Result<Option<String>>;
 }
 
+/// The guidance for a missing attended terminal at confirmation time —
+/// shared by [`confirm_attended`]'s upfront check and
+/// [`ControllingTerminal::ask`] (the terminal can disappear between the
+/// two), so the same user-visible condition always gets the same
+/// rerun-or-`--yes` advice.
+const NO_ATTENDED_TERMINAL: &str =
+    "confirmation requires an attended terminal, but none is available; \
+     rerun in a terminal to review and confirm, or pass --yes to generate \
+     without a confirmation prompt; nothing was generated";
+
 /// Ask the attended confirmation question through `terminal`. Fails with
 /// actionable guidance when no attended terminal exists — an absent
 /// terminal is an error, never implicit approval — and confirms only on an
 /// exact trimmed `yes` reply.
 fn confirm_attended(terminal: &mut dyn AttendedTerminal) -> Result<bool> {
     if !terminal.is_attended() {
-        bail!(
-            "confirmation requires an attended terminal, but none is available; \
-             rerun in a terminal to review and confirm, or pass --yes to generate \
-             without a confirmation prompt; nothing was generated"
-        );
+        bail!(NO_ATTENDED_TERMINAL);
     }
     let reply = terminal.ask(CONFIRM_QUESTION)?;
     Ok(reply.is_some_and(|line| line.trim() == "yes"))
@@ -656,16 +662,11 @@ fn open_controlling_terminal() -> Option<(fs::File, fs::File)> {
 
 #[cfg(windows)]
 fn open_controlling_terminal() -> Option<(fs::File, fs::File)> {
-    let read = fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open("CONIN$")
-        .ok()?;
-    let write = fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open("CONOUT$")
-        .ok()?;
+    // Minimal access only: broader access (e.g. GENERIC_WRITE on CONIN$) is
+    // needed solely for console-mode changes this gate never makes, and
+    // requesting it can fail on consoles a read/write-only open accepts.
+    let read = fs::OpenOptions::new().read(true).open("CONIN$").ok()?;
+    let write = fs::OpenOptions::new().write(true).open("CONOUT$").ok()?;
     Some((read, write))
 }
 
@@ -675,8 +676,8 @@ impl AttendedTerminal for ControllingTerminal {
     }
 
     fn ask(&mut self, question: &str) -> Result<Option<String>> {
-        let (read, mut write) = open_controlling_terminal()
-            .ok_or_else(|| anyhow!("the controlling terminal is no longer available"))?;
+        let (read, mut write) =
+            open_controlling_terminal().ok_or_else(|| anyhow!(NO_ATTENDED_TERMINAL))?;
         write.write_all(question.as_bytes())?;
         write.flush()?;
         let mut line = String::new();

--- a/crates/standout/tests/new_project_answer_sheets.rs
+++ b/crates/standout/tests/new_project_answer_sheets.rs
@@ -1,11 +1,17 @@
 //! Real CLI flows for the bootstrap wizard's answer sheets: questionnaire
 //! rendering to stdout and a file, successful and failing `--answers FILE`
-//! submissions through the review and confirmation gate, stale fingerprints,
-//! accumulated batch errors, and the no-partial-write guarantee.
+//! and `--answers -` submissions through the review and confirmation gate,
+//! attended and rejected terminal confirmation, missing-terminal failure,
+//! automated `--yes` runs, stale fingerprints, accumulated batch errors, and
+//! the no-partial-write guarantee.
 //!
 //! Every test runs the production `standout` binary in a fresh temporary
-//! working directory without a real terminal; confirmation answers arrive on
-//! piped stdin, exactly as the wizard reads them in production.
+//! working directory without a real terminal. Confirmation never reads
+//! stdin — stdin only ever carries an answer sheet — so every run pins the
+//! binary's attended-terminal seam (`STANDOUT_NEW_PROJECT_TERMINAL`): to
+//! `absent` by default (a regression that reaches the confirmation gate
+//! fails fast instead of prompting the developer's terminal), or to a
+//! scripted replies file for attended flows.
 
 use std::fs;
 use std::io::Write as _;
@@ -14,15 +20,22 @@ use std::process::{Command, Output, Stdio};
 
 use tempfile::TempDir;
 
-/// Run the production wizard binary in `cwd` with `stdin` piped in. A run
-/// that fails fast (a missing answers file, a rejected sheet) may exit
-/// before reading stdin; the broken pipe that write then reports is an
-/// expected outcome, so the helper still returns the child's output for
-/// failure-mode assertions.
-fn run_standout(cwd: &Path, args: &[&str], stdin: &str) -> Output {
+/// The binary's attended-terminal test seam (see `ScriptedTerminal` in the
+/// binary): `absent` simulates no terminal; any other value names a file of
+/// scripted reply lines.
+const TERMINAL_SEAM_VAR: &str = "STANDOUT_NEW_PROJECT_TERMINAL";
+
+/// Run the production wizard binary in `cwd` with `stdin` piped in and the
+/// attended-terminal seam pinned to `terminal_seam`. A run that fails fast
+/// (a missing answers file, a rejected sheet) may exit before reading
+/// stdin; the broken pipe that write then reports is an expected outcome,
+/// so the helper still returns the child's output for failure-mode
+/// assertions.
+fn run_seamed(cwd: &Path, args: &[&str], stdin: &str, terminal_seam: &str) -> Output {
     let mut child = Command::new(env!("CARGO_BIN_EXE_standout"))
         .current_dir(cwd)
         .args(args)
+        .env(TERMINAL_SEAM_VAR, terminal_seam)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -36,6 +49,22 @@ fn run_standout(cwd: &Path, args: &[&str], stdin: &str) -> Output {
         );
     }
     child.wait_with_output().unwrap()
+}
+
+/// [`run_seamed`] with no attended terminal — the default, so any run that
+/// unexpectedly reaches the confirmation gate fails fast.
+fn run_standout(cwd: &Path, args: &[&str], stdin: &str) -> Output {
+    run_seamed(cwd, args, stdin, "absent")
+}
+
+/// [`run_seamed`] with an attended terminal scripted to answer `replies`
+/// (one line per prompt). The replies file lives outside `cwd`, keeping
+/// whole-directory no-partial-write assertions exact.
+fn run_attended(cwd: &Path, args: &[&str], stdin: &str, replies: &str) -> Output {
+    let terminal = TempDir::new().unwrap();
+    let script = terminal.path().join("replies.txt");
+    fs::write(&script, replies).unwrap();
+    run_seamed(cwd, args, stdin, script.to_str().unwrap())
 }
 
 fn stdout(output: &Output) -> String {
@@ -125,13 +154,14 @@ fn questions_writes_the_same_sheet_to_a_named_file() {
 }
 
 #[test]
-fn answers_file_generates_after_review_and_confirmation() {
+fn answers_file_generates_after_review_and_attended_confirmation() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("answers.txt"), completed_sheet(dir.path())).unwrap();
 
-    let output = run_standout(
+    let output = run_attended(
         dir.path(),
         &["new-project", "--answers", "answers.txt"],
+        "",
         "yes\n",
     );
 
@@ -151,15 +181,195 @@ fn rejected_confirmation_leaves_the_destination_unwritten() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("answers.txt"), completed_sheet(dir.path())).unwrap();
 
-    let output = run_standout(
+    let output = run_attended(
         dir.path(),
         &["new-project", "--answers", "answers.txt"],
+        "",
         "no\n",
     );
 
     assert!(output.status.success());
     assert!(stdout(&output).contains("Generation cancelled."));
     assert_eq!(dir_entries(dir.path()), ["answers.txt"]);
+}
+
+#[test]
+fn stdin_sheet_generates_after_review_and_attended_confirmation() {
+    let dir = TempDir::new().unwrap();
+    let sheet = completed_sheet(dir.path());
+
+    let output = run_attended(
+        dir.path(),
+        &["new-project", "--answers", "-"],
+        &sheet,
+        "yes\n",
+    );
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let transcript = stdout(&output);
+    assert!(transcript.contains("Review"));
+    assert!(transcript.contains("Generate this project? Type 'yes' to continue:"));
+    assert!(transcript.contains("Created hello-tool"));
+    assert!(dir.path().join("hello-tool/Cargo.toml").is_file());
+    assert_eq!(dir_entries(dir.path()), ["hello-tool"]);
+}
+
+#[test]
+fn stdin_sheet_rejected_on_the_terminal_writes_nothing() {
+    let dir = TempDir::new().unwrap();
+    let sheet = completed_sheet(dir.path());
+
+    let output = run_attended(
+        dir.path(),
+        &["new-project", "--answers", "-"],
+        &sheet,
+        "no\n",
+    );
+
+    assert!(output.status.success());
+    assert!(stdout(&output).contains("Generation cancelled."));
+    assert!(dir_entries(dir.path()).is_empty());
+}
+
+#[test]
+fn stdin_sheet_without_a_terminal_fails_before_publication_with_guidance() {
+    let dir = TempDir::new().unwrap();
+    let sheet = completed_sheet(dir.path());
+
+    let output = run_standout(dir.path(), &["new-project", "--answers", "-"], &sheet);
+
+    assert!(!output.status.success());
+    let errors = stderr(&output);
+    assert!(errors.contains("attended terminal"));
+    assert!(errors.contains("--yes"));
+    assert!(errors.contains("nothing was generated"));
+    assert!(dir_entries(dir.path()).is_empty());
+}
+
+#[test]
+fn stdin_sheet_with_yes_generates_without_any_terminal() {
+    let dir = TempDir::new().unwrap();
+    let sheet = completed_sheet(dir.path());
+
+    let output = run_standout(
+        dir.path(),
+        &["new-project", "--answers", "-", "--yes"],
+        &sheet,
+    );
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let transcript = stdout(&output);
+    assert!(transcript.contains("Review"));
+    assert!(!transcript.contains("Generate this project?"));
+    assert!(transcript.contains("Created hello-tool"));
+    assert!(dir.path().join("hello-tool/Cargo.toml").is_file());
+    assert_eq!(dir_entries(dir.path()), ["hello-tool"]);
+}
+
+#[test]
+fn named_file_with_yes_generates_without_any_terminal() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("answers.txt"), completed_sheet(dir.path())).unwrap();
+
+    let output = run_standout(
+        dir.path(),
+        &["new-project", "--answers", "answers.txt", "--yes"],
+        "",
+    );
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let transcript = stdout(&output);
+    assert!(transcript.contains("Review"));
+    assert!(!transcript.contains("Generate this project?"));
+    assert!(transcript.contains("Created hello-tool"));
+    assert_eq!(dir_entries(dir.path()), ["answers.txt", "hello-tool"]);
+}
+
+#[test]
+fn attended_end_of_terminal_input_cancels_instead_of_confirming() {
+    let dir = TempDir::new().unwrap();
+    let sheet = completed_sheet(dir.path());
+
+    let output = run_attended(dir.path(), &["new-project", "--answers", "-"], &sheet, "");
+
+    assert!(output.status.success());
+    assert!(stdout(&output).contains("Generation cancelled."));
+    assert!(dir_entries(dir.path()).is_empty());
+}
+
+#[test]
+fn stdin_trailing_yes_never_confirms_and_writes_nothing() {
+    let dir = TempDir::new().unwrap();
+    let mut sheet = completed_sheet(dir.path());
+    sheet.push_str("yes\n");
+
+    let output = run_standout(dir.path(), &["new-project", "--answers", "-"], &sheet);
+
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("nothing was generated"));
+    assert!(dir_entries(dir.path()).is_empty());
+}
+
+#[test]
+fn stdin_stale_fingerprint_is_rejected_before_any_write() {
+    let dir = TempDir::new().unwrap();
+    let stale = completed_sheet(dir.path()).replacen(
+        "#! fingerprint: sha256:",
+        "#! fingerprint: sha256:00",
+        1,
+    );
+
+    let output = run_standout(
+        dir.path(),
+        &["new-project", "--answers", "-", "--yes"],
+        &stale,
+    );
+
+    assert!(!output.status.success());
+    let errors = stderr(&output);
+    assert!(errors.contains("render a fresh answer sheet"));
+    assert!(errors.contains("answer sheet from stdin"));
+    assert!(errors.contains("nothing was generated"));
+    assert!(dir_entries(dir.path()).is_empty());
+}
+
+#[test]
+fn stdin_sheet_accumulates_errors_and_writes_nothing() {
+    let dir = TempDir::new().unwrap();
+    let rendered = run_standout(dir.path(), &["new-project", "questions"], "");
+    let sheet = stdout(&rendered);
+    let sheet = fill(&sheet, "project.name", "9bad");
+    let sheet = fill(&sheet, "command.name", "greet");
+    let sheet = fill(&sheet, "command.description", "Greet one value");
+    let sheet = fill(&sheet, "command.inputs.name", "name");
+    let sheet = fill(&sheet, "command.inputs.sources", "argument,teleport");
+
+    let output = run_standout(
+        dir.path(),
+        &["new-project", "--answers", "-", "--yes"],
+        &sheet,
+    );
+
+    assert!(!output.status.success());
+    let errors = stderr(&output);
+    assert!(errors.contains("[project.name]"));
+    assert!(errors.contains("[command.inputs[0].sources]"));
+    assert!(errors.contains("2 problem(s)"));
+    assert!(dir_entries(dir.path()).is_empty());
+}
+
+#[test]
+fn interactive_stdin_cannot_supply_the_dash_answer_sheet() {
+    // Piped-but-empty stdin is the closest a real CLI test can get to the
+    // no-document case; the unit tests cover the interactive-terminal
+    // refusal through the injected reader.
+    let dir = TempDir::new().unwrap();
+
+    let output = run_standout(dir.path(), &["new-project", "--answers", "-", "--yes"], "");
+
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("nothing was generated"));
+    assert!(dir_entries(dir.path()).is_empty());
 }
 
 #[test]

--- a/crates/standout/tests/new_project_answer_sheets.rs
+++ b/crates/standout/tests/new_project_answer_sheets.rs
@@ -31,7 +31,12 @@ const TERMINAL_SEAM_VAR: &str = "STANDOUT_NEW_PROJECT_TERMINAL";
 /// stdin; the broken pipe that write then reports is an expected outcome,
 /// so the helper still returns the child's output for failure-mode
 /// assertions.
-fn run_seamed(cwd: &Path, args: &[&str], stdin: &str, terminal_seam: &str) -> Output {
+fn run_seamed(
+    cwd: &Path,
+    args: &[&str],
+    stdin: &str,
+    terminal_seam: impl AsRef<std::ffi::OsStr>,
+) -> Output {
     let mut child = Command::new(env!("CARGO_BIN_EXE_standout"))
         .current_dir(cwd)
         .args(args)
@@ -64,7 +69,7 @@ fn run_attended(cwd: &Path, args: &[&str], stdin: &str, replies: &str) -> Output
     let terminal = TempDir::new().unwrap();
     let script = terminal.path().join("replies.txt");
     fs::write(&script, replies).unwrap();
-    run_seamed(cwd, args, stdin, script.to_str().unwrap())
+    run_seamed(cwd, args, stdin, &script)
 }
 
 fn stdout(output: &Output) -> String {

--- a/docs/guides/bootstrap-a-project.md
+++ b/docs/guides/bootstrap-a-project.md
@@ -60,6 +60,15 @@ standout new-project questions --file answers.txt
 
 # Generate from the completed file.
 standout new-project --answers answers.txt
+
+# Generate from an answer sheet on stdin, with attended confirmation.
+standout new-project --answers - < answers.txt
+
+# Generate from stdin without prompting for confirmation.
+standout new-project --answers - --yes < answers.txt
+
+# Automate a named-file run the same way.
+standout new-project --answers answers.txt --yes
 ```
 
 Each question renders with a cosmetic number, its wording, a bracketed stable
@@ -76,19 +85,33 @@ it means.
 `--answers` replaces question collection entirely — it never merges file
 answers with prompts — but everything after collection is the interactive
 experience: the same validation, the same review, and the same `yes`
-confirmation before anything is published. A sheet that fails to parse or
-validate reports every independent problem in one pass, each identified by
-its stable ID (for repeated inputs, an indexed path such as
+confirmation before anything is published. `--answers -` reads exactly one
+complete sheet from piped standard input instead of a file; both sources
+produce identical results for identical documents. A sheet that fails to
+parse or validate reports every independent problem in one pass, each
+identified by its stable ID (for repeated inputs, an indexed path such as
 `command.inputs[1].sources`), and publishes nothing; the same no-partial-write
 guarantee as the interactive wizard applies to every failure and rejection.
+
+Submitting a sheet is not consent to generate. Piping a file — or reaching
+its end — never confirms anything: without `--yes`, the wizard shows the
+review and asks for confirmation on your terminal, independent of the answer
+stream, and only an exact `yes` reply publishes the project. If confirmation
+is required but no attended terminal is available (a CI job, a redirected
+shell), the run fails before publishing anything and says so. Automation
+opts out of the prompt explicitly with `--yes`, which skips only the
+confirmation gate — parsing, validation, the review output, and atomic
+publication all still run.
 
 The sheet's `#!` preamble pins the answer format, the questionnaire ID, and a
 fingerprint of the questionnaire's semantics. A sheet rendered by an older
 `standout` whose questionnaire has since changed is rejected with a
 compatibility error rather than reinterpreted; render a fresh sheet with
 `standout new-project questions` and copy your answers into it. Answer sheets
-are plain text and hold whatever you answered — keep them out of version
-control and shared locations, and delete them when done.
+are plain text and hold whatever you answered — including any sensitive
+values — so keep them out of version control, shared locations, and shell
+history (piping with `< answers.txt` beats inlining a heredoc), and delete
+them when done.
 
 ## Supported inputs
 


### PR DESCRIPTION
for #257

## Context

**Why this approach.** WS04 (umbrella commit `0756376`) left one collection gap and one policy ambiguity: no stdin sheets, and confirmation read from the same stdin that a piped sheet would occupy. This PR closes both with the smallest coherent design:

- `--answers -` reads exactly one complete sheet from piped stdin via the existing `read_answer_sheet_stdin_with` adapter, then flows through the *identical* decode tail as a named file (`decode_sheet`, shared by both sources and by the pre-existing unit tests) — so file and stdin sheets produce identical validated answers and `ProjectSpec` values by construction.
- Confirmation for sheet runs moved to an attended-terminal seam (`AttendedTerminal`): the production impl opens the controlling terminal device (`/dev/tty` / `CONIN$`), so stdin content, trailing bytes, EOF, or malformed markers structurally *cannot* reach the confirmation gate. Missing terminal + no `--yes` fails before publication with rerun-or-`--yes` guidance.
- `--yes` skips only the confirmation prompt (file and stdin runs alike); parsing, validation, review output, domain conversion, and atomic publication are untouched. Interactive collection keeps confirming on the prompt stream the user is already attending.
- Test injection: unit tests inject `MockStdin` and a `ScriptedTerminal`; real CLI tests pin the seam through the `STANDOUT_NEW_PROJECT_TERMINAL` env var (a documented test seam — `absent`, or a scripted replies file), so no test ever touches a real terminal and a regression that reaches the gate fails fast instead of prompting the developer.

**Self-check against governing docs.** Verified the diff against `docs/spec/questionnaire-answer-sheets.md` (stdin CLI shape, confirmation-independent-of-answer-stream requirement §Constraints/Terminal behavior, testing strategy §2/§4), `docs/adr/0014-adopt-prose-answer-sheets-with-stable-identities.md` (no format or identity changes; parsing untouched), `docs/specs/wizard.md` (§5 review + explicit confirmation before writing preserved in every mode), and `docs/adr/0001-wizard.md` (explicit confirmation before writing; no generated-code execution before confirmation). Verified with `pixi run test` (2037/2037 green) before opening this PR.

**Out of scope / do not "fix".** Answer-sheet format or engine semantics, answer-source merging, public `ProjectSpec`, generated-project input wiring, fuzzy migration, unrelated cleanup. WS04 named-file behavior is preserved except confirmation now riding the attended-terminal seam (per this issue's acceptance criteria) and the new `--yes` opt-out.

## What changed

- `crates/standout/src/bin/standout.rs`: `--answers -` (SheetSource), `--yes`, `AttendedTerminal` seam (`ControllingTerminal` / `ScriptedTerminal` + env test seam), shared `decode_sheet` tail, `stdin_sheet_answers`; unit tests for source equivalence, exact-`yes` policy, EOF-as-rejection, missing-terminal guidance.
- `crates/standout/tests/new_project_answer_sheets.rs`: every run now pins the terminal seam; new real-CLI coverage for attended stdin confirmation, explicit rejection, no-terminal failure, automated `--yes` (stdin + file), EOF cancellation, trailing-`yes`-never-confirms, stdin stale fingerprint, stdin accumulated errors, empty stdin — each asserting no partial writes.
- `docs/guides/bootstrap-a-project.md`: exact stdin and automation commands, input-is-not-consent policy, sensitive-contents warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)