### PR TITLE
STANDOUT-WIZ03-WS02: Epic: Derived Questionnaires - Workstream: Choice enums as vocabularies

### DIFF
--- a/crates/standout-input/src/questionnaire/derive.rs
+++ b/crates/standout-input/src/questionnaire/derive.rs
@@ -46,7 +46,7 @@ impl QuestionnaireChoiceParseError {
 
 impl std::fmt::Display for QuestionnaireChoiceParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "expected one of: {}", self.choices.to_vec().join(", "))
+        write!(f, "expected one of: {}", self.choices.join(", "))
     }
 }
 

--- a/crates/standout-input/src/questionnaire/derive.rs
+++ b/crates/standout-input/src/questionnaire/derive.rs
@@ -7,6 +7,51 @@
 
 use super::{Answers, Questionnaire, QuestionnaireError, RawAnswers, ValidationDiagnostic};
 
+/// A Rust enum-backed choice vocabulary for derived questionnaires.
+///
+/// Implemented by `standout-macros` for enums that derive
+/// `QuestionnaireChoices`. The enum is then the single source for the
+/// accepted answer strings, rendered hints, parsing, and display: a derived
+/// questionnaire field of this enum type lowers to a string field constrained
+/// with [`ScalarField::one_of`](super::ScalarField::one_of), and typed filling
+/// parses the validated answer back into the enum.
+pub trait QuestionnaireChoices:
+    Sized + std::str::FromStr<Err = QuestionnaireChoiceParseError> + std::fmt::Display
+{
+    /// The declared user-facing choices for this enum.
+    fn choices() -> &'static [&'static str];
+}
+
+/// Error returned when parsing an undeclared enum choice.
+///
+/// The invalid submitted value is intentionally not retained or displayed;
+/// diagnostics elsewhere in the questionnaire pipeline follow the same
+/// no-echo rule for answer values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuestionnaireChoiceParseError {
+    choices: &'static [&'static str],
+}
+
+impl QuestionnaireChoiceParseError {
+    /// Create an error for a vocabulary with the given declared choices.
+    pub const fn new(choices: &'static [&'static str]) -> Self {
+        Self { choices }
+    }
+
+    /// The choices accepted by the enum parser.
+    pub fn choices(&self) -> &'static [&'static str] {
+        self.choices
+    }
+}
+
+impl std::fmt::Display for QuestionnaireChoiceParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "expected one of: {}", self.choices.to_vec().join(", "))
+    }
+}
+
+impl std::error::Error for QuestionnaireChoiceParseError {}
+
 /// A derived questionnaire definition and typed filler.
 ///
 /// Implemented by `standout-macros` for structs that derive
@@ -28,9 +73,10 @@ pub trait QuestionnaireInput: Sized {
     /// Fill this type from answers decoded by its own questionnaire.
     ///
     /// This method is generated code for the closed questionnaire type
-    /// universe. Call [`from_raw_answers`](Self::from_raw_answers) for the
-    /// public checked path: it decodes with the generated definition first,
-    /// then fills only after field validation succeeds.
+    /// universe: scalars, `Option<T>`, and enum choices. Call
+    /// [`from_raw_answers`](Self::from_raw_answers) for the public checked
+    /// path: it decodes with the generated definition first, then fills only
+    /// after field validation succeeds.
     #[doc(hidden)]
     fn from_decoded_answers(answers: &Answers) -> Self;
 

--- a/crates/standout-input/src/questionnaire/mod.rs
+++ b/crates/standout-input/src/questionnaire/mod.rs
@@ -266,5 +266,8 @@ pub use definition::{
     Condition, Constraint, DynamicDefault, FieldValidator, Group, Item, Questionnaire,
     QuestionnaireError, Repeat, ScalarField, ScalarKind,
 };
-pub use derive::{QuestionnaireInput, QuestionnaireInputError};
+pub use derive::{
+    QuestionnaireChoiceParseError, QuestionnaireChoices, QuestionnaireInput,
+    QuestionnaireInputError,
+};
 pub use parse::{AnswerSheetDiagnostic, RawAnswers};

--- a/crates/standout-macros/src/lib.rs
+++ b/crates/standout-macros/src/lib.rs
@@ -17,6 +17,7 @@
 //! - [`TabularRow`] - Generate optimized row extraction without JSON serialization
 //! - [`Seekable`] - Generate query-enabled accessor functions for Seeker
 //! - [`Questionnaire`] - Generate questionnaire definitions and typed filling
+//! - [`QuestionnaireChoices`] - Generate enum-backed questionnaire vocabularies
 //!
 //! ## Attribute Macros
 //!
@@ -407,19 +408,32 @@ pub fn seekable_derive(input: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Derives a questionnaire definition and typed filling for a flat scalar struct.
+/// Derives a questionnaire definition and typed filling for a flat struct.
 ///
 /// The generated implementation lowers through `standout-input`'s public
 /// builder. Container `#[question(id = "...")]` declares the questionnaire ID;
 /// field doc comments become prompts; field identifiers become stable field
 /// IDs unless overridden with `#[question(id = "...")]`; supported field types
-/// are `String`, `PathBuf`, `bool`, and `Option<T>` over those scalar types.
-/// `#[question(default = "...")]` declares a static default, and
-/// `#[question(prose)]` opts a `String` field into multi-line text.
+/// are `String`, `PathBuf`, `bool`, enums deriving `QuestionnaireChoices`, and
+/// `Option<T>` over those types. `#[question(default = "...")]` declares a
+/// static default, and `#[question(prose)]` opts a `String` field into
+/// multi-line text.
 #[proc_macro_derive(Questionnaire, attributes(question))]
 pub fn questionnaire_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     questionnaire::questionnaire_derive_impl(input)
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// Derives a questionnaire choice vocabulary from a unit-variant enum.
+///
+/// Variant names render as kebab-case by default. A variant can override its
+/// user-facing spelling with `#[question(rename = "...")]`.
+#[proc_macro_derive(QuestionnaireChoices, attributes(question))]
+pub fn questionnaire_choices_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    questionnaire::questionnaire_choices_derive_impl(input)
         .unwrap_or_else(|e| e.to_compile_error())
         .into()
 }

--- a/crates/standout-macros/src/questionnaire/mod.rs
+++ b/crates/standout-macros/src/questionnaire/mod.rs
@@ -344,7 +344,7 @@ impl FieldKind {
         if let Some(kind) = ScalarKind::from_type(ty)? {
             return Ok(Self::Scalar(kind));
         }
-        if is_known_unsupported_primitive(ty) {
+        if is_known_unsupported_primitive(ty) || !can_be_choice_type(ty) {
             return Err(unsupported_type_error(ty));
         }
         Ok(Self::Choice(Box::new(ty.clone())))
@@ -438,6 +438,18 @@ fn is_known_unsupported_primitive(ty: &Type) -> bool {
             | "f32"
             | "f64"
     )
+}
+
+fn can_be_choice_type(ty: &Type) -> bool {
+    let Type::Path(type_path) = ty else {
+        return false;
+    };
+    type_path.qself.is_none()
+        && type_path
+            .path
+            .segments
+            .iter()
+            .all(|segment| matches!(segment.arguments, PathArguments::None))
 }
 
 fn unsupported_type_error(ty: &Type) -> Error {

--- a/crates/standout-macros/src/questionnaire/mod.rs
+++ b/crates/standout-macros/src/questionnaire/mod.rs
@@ -1,7 +1,9 @@
-//! Implementation of the `#[derive(Questionnaire)]` macro.
+//! Implementation of the questionnaire derive macros.
 //!
-//! The derive lowers a flat scalar struct to `standout-input`'s public
-//! questionnaire builder and emits direct typed filling from decoded answers.
+//! `Questionnaire` lowers a flat struct of scalar and enum-choice fields to
+//! `standout-input`'s public questionnaire builder and emits direct typed
+//! filling from decoded answers. `QuestionnaireChoices` lowers a unit-variant
+//! enum to the choice vocabulary consumed by that field lowering.
 
 use std::collections::HashSet;
 
@@ -12,7 +14,7 @@ use syn::{
     punctuated::Punctuated,
     spanned::Spanned,
     Attribute, Data, DeriveInput, Error, Expr, ExprLit, Field, Fields, GenericArgument, Lit, Meta,
-    PathArguments, Result, Token, Type,
+    PathArguments, Result, Token, Type, Variant,
 };
 
 /// Parsed `#[question(...)]` attributes.
@@ -21,6 +23,11 @@ struct QuestionAttr {
     id: Option<(String, Span)>,
     default: Option<(String, Span)>,
     prose: Option<Span>,
+}
+
+#[derive(Debug, Default)]
+struct ChoiceAttr {
+    rename: Option<(String, Span)>,
 }
 
 impl Parse for QuestionAttr {
@@ -60,6 +67,35 @@ impl Parse for QuestionAttr {
                     return Err(Error::new(
                         other.span(),
                         "unknown question attribute: expected id, default, or prose",
+                    ));
+                }
+            }
+        }
+
+        Ok(attr)
+    }
+}
+
+impl Parse for ChoiceAttr {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut attr = ChoiceAttr::default();
+        let content: Punctuated<Meta, Token![,]> = Punctuated::parse_terminated(input)?;
+
+        for meta in content {
+            match meta {
+                Meta::NameValue(nv) if nv.path.is_ident("rename") => {
+                    let (value, span) = string_lit(&nv.value, "rename must be a string literal")?;
+                    if attr.rename.replace((value, span)).is_some() {
+                        return Err(Error::new(
+                            nv.path.span(),
+                            "duplicate question rename attribute",
+                        ));
+                    }
+                }
+                other => {
+                    return Err(Error::new(
+                        other.span(),
+                        "unknown question attribute: expected rename",
                     ));
                 }
             }
@@ -148,14 +184,13 @@ pub fn questionnaire_derive_impl(input: DeriveInput) -> Result<TokenStream> {
     Ok(expanded)
 }
 
-#[derive(Debug)]
 struct FieldInfo {
     ident: syn::Ident,
     id: String,
     id_span: Span,
     prompt: String,
     default: Option<String>,
-    kind: ScalarKind,
+    kind: FieldKind,
     optional: bool,
 }
 
@@ -167,10 +202,10 @@ impl FieldInfo {
             .ok_or_else(|| Error::new(field.span(), "expected named field"))?;
         let attrs = parse_question_attrs(&field.attrs)?;
         let (base_ty, optional) = option_inner(&field.ty).unwrap_or((&field.ty, false));
-        let kind = ScalarKind::from_type(base_ty)?;
+        let mut kind = FieldKind::from_type(base_ty)?;
 
         if let Some(prose_span) = attrs.prose {
-            if kind != ScalarKind::String {
+            if !matches!(kind, FieldKind::Scalar(ScalarKind::String)) {
                 return Err(Error::new(
                     prose_span,
                     "prose is only supported on String fields",
@@ -179,7 +214,8 @@ impl FieldInfo {
         }
 
         if let Some((default, span)) = attrs.default.as_ref() {
-            if kind == ScalarKind::Bool && parse_bool(default).is_none() {
+            if matches!(kind, FieldKind::Scalar(ScalarKind::Bool)) && parse_bool(default).is_none()
+            {
                 return Err(Error::new(
                     *span,
                     "bool defaults must be one of true, false, yes, no, y, or n",
@@ -198,11 +234,9 @@ impl FieldInfo {
             .map(|(_, span)| *span)
             .unwrap_or(ident.span());
         let prompt = doc_prompt(&field.attrs);
-        let kind = if attrs.prose.is_some() {
-            ScalarKind::Text
-        } else {
-            kind
-        };
+        if attrs.prose.is_some() {
+            kind = FieldKind::Scalar(ScalarKind::Text);
+        }
 
         Ok(Self {
             ident,
@@ -218,12 +252,13 @@ impl FieldInfo {
     fn builder_tokens(&self) -> TokenStream {
         let id = &self.id;
         let prompt = &self.prompt;
-        let kind = self.kind.tokens();
+        let kind = self.kind.scalar_kind_tokens();
         let optional = self.optional.then(|| quote! { .optional() });
         let default = self
             .default
             .as_ref()
             .map(|default| quote! { .with_default(#default) });
+        let choices = self.kind.choice_tokens();
 
         quote! {
             ::standout_input::questionnaire::ScalarField::new(
@@ -232,6 +267,7 @@ impl FieldInfo {
                 #kind,
             )
             #optional
+            #choices
             #default
         }
     }
@@ -240,32 +276,101 @@ impl FieldInfo {
         let ident = &self.ident;
         let id = &self.id;
         let missing = format!("decoded answers are missing required field '{}'", self.id);
-        let value = match (self.kind, self.optional) {
-            (ScalarKind::Bool, false) => quote! {
+        let value = match (&self.kind, self.optional) {
+            (FieldKind::Scalar(ScalarKind::Bool), false) => quote! {
                 answers.get_bool(#id).unwrap_or_else(|| unreachable!(#missing))
             },
-            (ScalarKind::Bool, true) => quote! {
+            (FieldKind::Scalar(ScalarKind::Bool), true) => quote! {
                 answers.get_bool(#id)
             },
-            (ScalarKind::Path, false) => quote! {
+            (FieldKind::Scalar(ScalarKind::Path), false) => quote! {
                 ::std::path::PathBuf::from(
                     answers.get_text(#id).unwrap_or_else(|| unreachable!(#missing))
                 )
             },
-            (ScalarKind::Path, true) => quote! {
+            (FieldKind::Scalar(ScalarKind::Path), true) => quote! {
                 answers.get_text(#id).map(::std::path::PathBuf::from)
             },
-            (ScalarKind::String | ScalarKind::Text, false) => quote! {
+            (FieldKind::Scalar(ScalarKind::String | ScalarKind::Text), false) => quote! {
                 answers
                     .get_text(#id)
                     .unwrap_or_else(|| unreachable!(#missing))
                     .to_string()
             },
-            (ScalarKind::String | ScalarKind::Text, true) => quote! {
+            (FieldKind::Scalar(ScalarKind::String | ScalarKind::Text), true) => quote! {
                 answers.get_text(#id).map(|value| value.to_string())
             },
+            (FieldKind::Choice(ty), false) => {
+                let ty = ty.as_ref();
+                let parse_failure = format!(
+                    "decoded answers carried an undeclared choice for field '{}'",
+                    self.id
+                );
+                quote! {
+                    answers
+                        .get_text(#id)
+                        .unwrap_or_else(|| unreachable!(#missing))
+                        .parse::<#ty>()
+                        .unwrap_or_else(|_| unreachable!(#parse_failure))
+                }
+            }
+            (FieldKind::Choice(ty), true) => {
+                let ty = ty.as_ref();
+                let parse_failure = format!(
+                    "decoded answers carried an undeclared choice for field '{}'",
+                    self.id
+                );
+                quote! {
+                    answers.get_text(#id).map(|value| {
+                        value
+                            .parse::<#ty>()
+                            .unwrap_or_else(|_| unreachable!(#parse_failure))
+                    })
+                }
+            }
         };
         quote! { #ident: #value }
+    }
+}
+
+#[derive(Clone)]
+enum FieldKind {
+    Scalar(ScalarKind),
+    Choice(Box<Type>),
+}
+
+impl FieldKind {
+    fn from_type(ty: &Type) -> Result<Self> {
+        if let Some(kind) = ScalarKind::from_type(ty)? {
+            return Ok(Self::Scalar(kind));
+        }
+        if is_known_unsupported_primitive(ty) {
+            return Err(unsupported_type_error(ty));
+        }
+        Ok(Self::Choice(Box::new(ty.clone())))
+    }
+
+    fn scalar_kind_tokens(&self) -> TokenStream {
+        match self {
+            Self::Scalar(kind) => kind.tokens(),
+            Self::Choice(_) => quote! { ::standout_input::questionnaire::ScalarKind::String },
+        }
+    }
+
+    fn choice_tokens(&self) -> Option<TokenStream> {
+        match self {
+            Self::Scalar(_) => None,
+            Self::Choice(ty) => {
+                let ty = ty.as_ref();
+                Some(quote! {
+                .one_of(
+                    <#ty as ::standout_input::questionnaire::QuestionnaireChoices>::choices()
+                        .iter()
+                        .copied()
+                )
+                })
+            }
+        }
     }
 }
 
@@ -278,12 +383,9 @@ enum ScalarKind {
 }
 
 impl ScalarKind {
-    fn from_type(ty: &Type) -> Result<Self> {
+    fn from_type(ty: &Type) -> Result<Option<Self>> {
         let Type::Path(type_path) = ty else {
-            return Err(Error::new(
-                ty.span(),
-                "unsupported questionnaire field type; expected String, PathBuf, bool, or Option<T>",
-            ));
+            return Err(unsupported_type_error(ty));
         };
         let ident = type_path
             .path
@@ -293,13 +395,10 @@ impl ScalarKind {
             .ident
             .to_string();
         match ident.as_str() {
-            "String" => Ok(Self::String),
-            "PathBuf" => Ok(Self::Path),
-            "bool" => Ok(Self::Bool),
-            _ => Err(Error::new(
-                ty.span(),
-                "unsupported questionnaire field type; expected String, PathBuf, bool, or Option<T>",
-            )),
+            "String" => Ok(Some(Self::String)),
+            "PathBuf" => Ok(Some(Self::Path)),
+            "bool" => Ok(Some(Self::Bool)),
+            _ => Ok(None),
         }
     }
 
@@ -311,6 +410,41 @@ impl ScalarKind {
             Self::Path => quote! { ::standout_input::questionnaire::ScalarKind::Path },
         }
     }
+}
+
+fn is_known_unsupported_primitive(ty: &Type) -> bool {
+    let Type::Path(type_path) = ty else {
+        return false;
+    };
+    let Some(segment) = type_path.path.segments.last() else {
+        return false;
+    };
+    matches!(
+        segment.ident.to_string().as_str(),
+        "char"
+            | "str"
+            | "u8"
+            | "u16"
+            | "u32"
+            | "u64"
+            | "u128"
+            | "usize"
+            | "i8"
+            | "i16"
+            | "i32"
+            | "i64"
+            | "i128"
+            | "isize"
+            | "f32"
+            | "f64"
+    )
+}
+
+fn unsupported_type_error(ty: &Type) -> Error {
+    Error::new(
+        ty.span(),
+        "unsupported questionnaire field type; expected String, PathBuf, bool, Option<T>, or a QuestionnaireChoices enum",
+    )
 }
 
 fn option_inner(ty: &Type) -> Option<(&Type, bool)> {
@@ -393,4 +527,149 @@ fn parse_bool(text: &str) -> Option<bool> {
         "false" | "no" | "n" => Some(false),
         _ => None,
     }
+}
+
+/// Main implementation of the QuestionnaireChoices derive macro.
+pub fn questionnaire_choices_derive_impl(input: DeriveInput) -> Result<TokenStream> {
+    let enum_name = &input.ident;
+    if !input.generics.params.is_empty() {
+        return Err(Error::new(
+            input.generics.span(),
+            "QuestionnaireChoices can only be derived for enums without generics",
+        ));
+    }
+
+    let variants = match &input.data {
+        Data::Enum(data) => &data.variants,
+        _ => {
+            return Err(Error::new(
+                input.span(),
+                "QuestionnaireChoices can only be derived for enums",
+            ))
+        }
+    };
+
+    let mut seen_choices = HashSet::new();
+    let mut choice_literals = Vec::new();
+    let mut parse_arms = Vec::new();
+    let mut display_arms = Vec::new();
+
+    for variant in variants {
+        let info = ChoiceVariant::new(variant)?;
+        if !seen_choices.insert(info.choice.clone()) {
+            return Err(Error::new(
+                info.choice_span,
+                format!("duplicate questionnaire choice '{}'", info.choice),
+            ));
+        }
+        let ident = &info.ident;
+        let choice = &info.choice;
+        choice_literals.push(quote! { #choice });
+        parse_arms.push(quote! { #choice => ::core::result::Result::Ok(Self::#ident) });
+        display_arms.push(quote! { Self::#ident => #choice });
+    }
+
+    let expanded = quote! {
+        impl ::standout_input::questionnaire::QuestionnaireChoices for #enum_name {
+            fn choices() -> &'static [&'static str] {
+                &[#(#choice_literals),*]
+            }
+        }
+
+        impl ::core::str::FromStr for #enum_name {
+            type Err = ::standout_input::questionnaire::QuestionnaireChoiceParseError;
+
+            fn from_str(value: &str) -> ::core::result::Result<Self, Self::Err> {
+                match value.trim() {
+                    #(#parse_arms,)*
+                    _ => ::core::result::Result::Err(
+                        ::standout_input::questionnaire::QuestionnaireChoiceParseError::new(
+                            <Self as ::standout_input::questionnaire::QuestionnaireChoices>::choices()
+                        )
+                    ),
+                }
+            }
+        }
+
+        impl ::core::fmt::Display for #enum_name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                f.write_str(match self {
+                    #(#display_arms,)*
+                })
+            }
+        }
+    };
+
+    Ok(expanded)
+}
+
+struct ChoiceVariant {
+    ident: syn::Ident,
+    choice: String,
+    choice_span: Span,
+}
+
+impl ChoiceVariant {
+    fn new(variant: &Variant) -> Result<Self> {
+        if !matches!(variant.fields, Fields::Unit) {
+            return Err(Error::new(
+                variant.fields.span(),
+                "QuestionnaireChoices variants must be unit variants",
+            ));
+        }
+        let attrs = parse_choice_attrs(&variant.attrs)?;
+        let (choice, choice_span) = attrs.rename.unwrap_or_else(|| {
+            (
+                to_kebab_case(&variant.ident.to_string()),
+                variant.ident.span(),
+            )
+        });
+        Ok(Self {
+            ident: variant.ident.clone(),
+            choice,
+            choice_span,
+        })
+    }
+}
+
+fn parse_choice_attrs(attrs: &[Attribute]) -> Result<ChoiceAttr> {
+    let mut out = ChoiceAttr::default();
+    for attr in attrs {
+        if attr.path().is_ident("question") {
+            let parsed = attr.parse_args::<ChoiceAttr>()?;
+            if parsed.rename.is_some() && out.rename.replace(parsed.rename.unwrap()).is_some() {
+                return Err(Error::new(
+                    attr.span(),
+                    "duplicate question rename attribute",
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn to_kebab_case(name: &str) -> String {
+    let mut out = String::new();
+    let mut prev_was_separator = true;
+    for ch in name.chars() {
+        if ch == '_' || ch == '-' || ch.is_whitespace() {
+            if !out.is_empty() && !prev_was_separator {
+                out.push('-');
+            }
+            prev_was_separator = true;
+            continue;
+        }
+        if ch.is_uppercase() {
+            if !out.is_empty() && !prev_was_separator {
+                out.push('-');
+            }
+            for lower in ch.to_lowercase() {
+                out.push(lower);
+            }
+        } else {
+            out.push(ch);
+        }
+        prev_was_separator = false;
+    }
+    out.trim_matches('-').to_string()
 }

--- a/crates/standout-macros/tests/questionnaire_derive.rs
+++ b/crates/standout-macros/tests/questionnaire_derive.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use serial_test::serial;
 use standout_input::env::MockStdin;
+use standout_input::questionnaire::QuestionnaireChoices as _;
 use standout_input::questionnaire::{
     AnswerSheetDiagnostic, Questionnaire as RuntimeQuestionnaire, QuestionnaireError,
     QuestionnaireInput, QuestionnaireInputError, ScalarField, ScalarKind, ValidationDiagnostic,
@@ -10,7 +11,7 @@ use standout_input::questionnaire::{
 use standout_input::{
     reset_default_prompt_responder, set_default_prompt_responder, PromptResponse, ScriptedResponder,
 };
-use standout_macros::Questionnaire;
+use standout_macros::{Questionnaire, QuestionnaireChoices};
 
 #[derive(Debug, PartialEq, Eq, Questionnaire)]
 #[question(id = "demo.profile")]
@@ -283,6 +284,153 @@ fn stale_fingerprint_rejects_the_round_trip() {
         diagnostics.as_slice(),
         [AnswerSheetDiagnostic::FingerprintMismatch { .. }]
     ));
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, QuestionnaireChoices)]
+enum PackageKind {
+    CliApp,
+    #[question(rename = "library")]
+    LibraryCrate,
+    InternalTool,
+}
+
+#[derive(Debug, PartialEq, Eq, Questionnaire)]
+#[question(id = "demo.choices")]
+struct ChoiceProfile {
+    /// Package style?
+    #[question(default = "cli-app")]
+    kind: PackageKind,
+
+    /// Optional fallback style?
+    fallback: Option<PackageKind>,
+}
+
+fn hand_built_choice_profile() -> RuntimeQuestionnaire {
+    RuntimeQuestionnaire::new(
+        "demo.choices",
+        vec![
+            ScalarField::new("kind", "Package style?", ScalarKind::String)
+                .one_of(["cli-app", "library", "internal-tool"])
+                .with_default("cli-app"),
+            ScalarField::new("fallback", "Optional fallback style?", ScalarKind::String)
+                .optional()
+                .one_of(["cli-app", "library", "internal-tool"]),
+        ],
+    )
+    .unwrap()
+}
+
+#[test]
+fn choice_enum_generates_display_parse_and_declared_choices() {
+    assert_eq!(
+        PackageKind::choices(),
+        &["cli-app", "library", "internal-tool"]
+    );
+    assert_eq!(PackageKind::CliApp.to_string(), "cli-app");
+    assert_eq!(
+        "library".parse::<PackageKind>().unwrap(),
+        PackageKind::LibraryCrate
+    );
+
+    let err = "unknown".parse::<PackageKind>().unwrap_err();
+    assert_eq!(err.choices(), PackageKind::choices());
+    assert!(err.to_string().contains("cli-app, library, internal-tool"));
+}
+
+#[test]
+fn enum_choice_field_matches_hand_built_one_of_and_decodes_to_enum() {
+    let derived = ChoiceProfile::questionnaire().unwrap();
+    let hand_built = hand_built_choice_profile();
+
+    assert_eq!(derived, hand_built);
+    assert_eq!(derived.fingerprint(), hand_built.fingerprint());
+
+    let sheet = answer(&derived.render_answer_sheet(), "fallback", "internal-tool");
+    assert!(sheet.contains("cli-app, library, or internal-tool"));
+    let raw = derived.parse_answer_sheet(&sheet).unwrap();
+    assert_eq!(
+        ChoiceProfile::from_raw_answers(&raw).unwrap(),
+        ChoiceProfile {
+            kind: PackageKind::CliApp,
+            fallback: Some(PackageKind::InternalTool),
+        }
+    );
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.choice.default")]
+#[allow(dead_code)]
+struct InvalidChoiceDefault {
+    /// Package style?
+    #[question(default = "desktop")]
+    kind: PackageKind,
+}
+
+#[test]
+fn enum_choice_defaults_must_name_a_declared_choice() {
+    let err = InvalidChoiceDefault::questionnaire().unwrap_err();
+
+    assert!(matches!(
+        err,
+        QuestionnaireError::InvalidDefault { ref id, .. } if id == "kind"
+    ));
+    assert!(err.to_string().contains("cli-app, library, internal-tool"));
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, QuestionnaireChoices)]
+enum ChoiceOrderA {
+    Alpha,
+    Beta,
+    Gamma,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, QuestionnaireChoices)]
+enum ChoiceOrderB {
+    Gamma,
+    Alpha,
+    Beta,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, QuestionnaireChoices)]
+enum ChoiceRenamed {
+    Alpha,
+    #[question(rename = "release")]
+    Beta,
+    Gamma,
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.choice.fingerprint")]
+#[allow(dead_code)]
+struct ChoiceFingerprintA {
+    /// Stage?
+    stage: ChoiceOrderA,
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.choice.fingerprint")]
+#[allow(dead_code)]
+struct ChoiceFingerprintB {
+    /// Stage?
+    stage: ChoiceOrderB,
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.choice.fingerprint")]
+#[allow(dead_code)]
+struct ChoiceFingerprintRenamed {
+    /// Stage?
+    stage: ChoiceRenamed,
+}
+
+#[test]
+fn choice_order_is_cosmetic_but_renaming_is_semantic_for_fingerprints() {
+    let a = ChoiceFingerprintA::questionnaire().unwrap();
+    let b = ChoiceFingerprintB::questionnaire().unwrap();
+    let renamed = ChoiceFingerprintRenamed::questionnaire().unwrap();
+
+    assert_eq!(a.fingerprint(), b.fingerprint());
+    assert_ne!(a.fingerprint(), renamed.fingerprint());
 }
 
 #[test]

--- a/crates/standout-macros/tests/ui/questionnaire/choices_duplicate.rs
+++ b/crates/standout-macros/tests/ui/questionnaire/choices_duplicate.rs
@@ -1,0 +1,10 @@
+use standout_macros::QuestionnaireChoices;
+
+#[derive(QuestionnaireChoices)]
+enum DuplicateChoices {
+    One,
+    #[question(rename = "one")]
+    AlsoOne,
+}
+
+fn main() {}

--- a/crates/standout-macros/tests/ui/questionnaire/choices_duplicate.stderr
+++ b/crates/standout-macros/tests/ui/questionnaire/choices_duplicate.stderr
@@ -1,0 +1,5 @@
+error: duplicate questionnaire choice 'one'
+ --> tests/ui/questionnaire/choices_duplicate.rs:6:25
+  |
+6 |     #[question(rename = "one")]
+  |                         ^^^^^

--- a/crates/standout-macros/tests/ui/questionnaire/choices_non_enum.rs
+++ b/crates/standout-macros/tests/ui/questionnaire/choices_non_enum.rs
@@ -1,0 +1,8 @@
+use standout_macros::QuestionnaireChoices;
+
+#[derive(QuestionnaireChoices)]
+struct NotAnEnum {
+    value: String,
+}
+
+fn main() {}

--- a/crates/standout-macros/tests/ui/questionnaire/choices_non_enum.stderr
+++ b/crates/standout-macros/tests/ui/questionnaire/choices_non_enum.stderr
@@ -1,0 +1,5 @@
+error: QuestionnaireChoices can only be derived for enums
+ --> tests/ui/questionnaire/choices_non_enum.rs:4:1
+  |
+4 | struct NotAnEnum {
+  | ^^^^^^

--- a/crates/standout-macros/tests/ui/questionnaire/choices_non_unit.rs
+++ b/crates/standout-macros/tests/ui/questionnaire/choices_non_unit.rs
@@ -1,0 +1,9 @@
+use standout_macros::QuestionnaireChoices;
+
+#[derive(QuestionnaireChoices)]
+enum NonUnitChoices {
+    Plain,
+    Tuple(String),
+}
+
+fn main() {}

--- a/crates/standout-macros/tests/ui/questionnaire/choices_non_unit.stderr
+++ b/crates/standout-macros/tests/ui/questionnaire/choices_non_unit.stderr
@@ -1,0 +1,5 @@
+error: QuestionnaireChoices variants must be unit variants
+ --> tests/ui/questionnaire/choices_non_unit.rs:6:10
+  |
+6 |     Tuple(String),
+  |          ^^^^^^^^

--- a/crates/standout-macros/tests/ui/questionnaire/choices_unknown_attr.rs
+++ b/crates/standout-macros/tests/ui/questionnaire/choices_unknown_attr.rs
@@ -1,0 +1,9 @@
+use standout_macros::QuestionnaireChoices;
+
+#[derive(QuestionnaireChoices)]
+enum UnknownChoiceAttr {
+    #[question(id = "custom")]
+    Custom,
+}
+
+fn main() {}

--- a/crates/standout-macros/tests/ui/questionnaire/choices_unknown_attr.stderr
+++ b/crates/standout-macros/tests/ui/questionnaire/choices_unknown_attr.stderr
@@ -1,0 +1,5 @@
+error: unknown question attribute: expected rename
+ --> tests/ui/questionnaire/choices_unknown_attr.rs:5:16
+  |
+5 |     #[question(id = "custom")]
+  |                ^^

--- a/crates/standout-macros/tests/ui/questionnaire/unsupported_generic_type.rs
+++ b/crates/standout-macros/tests/ui/questionnaire/unsupported_generic_type.rs
@@ -1,0 +1,10 @@
+use standout_macros::Questionnaire;
+
+#[derive(Questionnaire)]
+#[question(id = "demo.unsupported")]
+struct UnsupportedGenericType {
+    /// Tags?
+    tags: Vec<String>,
+}
+
+fn main() {}

--- a/crates/standout-macros/tests/ui/questionnaire/unsupported_generic_type.stderr
+++ b/crates/standout-macros/tests/ui/questionnaire/unsupported_generic_type.stderr
@@ -1,0 +1,5 @@
+error: unsupported questionnaire field type; expected String, PathBuf, bool, Option<T>, or a QuestionnaireChoices enum
+ --> tests/ui/questionnaire/unsupported_generic_type.rs:7:11
+  |
+7 |     tags: Vec<String>,
+  |           ^^^

--- a/crates/standout-macros/tests/ui/questionnaire/unsupported_type.stderr
+++ b/crates/standout-macros/tests/ui/questionnaire/unsupported_type.stderr
@@ -1,4 +1,4 @@
-error: unsupported questionnaire field type; expected String, PathBuf, bool, or Option<T>
+error: unsupported questionnaire field type; expected String, PathBuf, bool, Option<T>, or a QuestionnaireChoices enum
  --> tests/ui/questionnaire/unsupported_type.rs:7:12
   |
 7 |     count: u32,


### PR DESCRIPTION
for #272

## Context

This implements WIZ03 WS02 by adding `QuestionnaireChoices` in `standout-input` and `#[derive(QuestionnaireChoices)]` in `standout-macros`, then teaching the existing `#[derive(Questionnaire)]` field lowering to treat enum and `Option<enum>` fields as string scalar fields constrained by the enum-owned `one_of` vocabulary. The runtime builder, decoder, renderer, and fingerprint code remain the semantic path; the enum derive only supplies the declared vocabulary plus `FromStr` and `Display`.

Self-check: this matches `docs/spec/derived-questionnaires.md` and ADRs 0015/0016 by keeping filling derive-generated with no serde, preserving the single-line scalar default, using `#[question(...)]` as the only attribute namespace, and making enum choices the source for constraint, parse, display, hint, and fingerprint. WS01's landed flat derive remains the lowering surface; this extends it without changing groups, repeated fields, dynamic defaults, validators, or command wiring.

Out of scope for this PR: groups/`Vec` (WS03), behavior hooks (WS04), command wiring and answer-sheet CLI injection (WS05), bootstrap wizard changes (WS06), and any new answer-sheet format or fingerprint algorithm.

Do not reopen the decided defaults here: variant names render kebab-case unless `#[question(rename = "...")]` overrides them; field defaults are validated by construction through the existing `one_of` constraint path; choice order is cosmetic in the canonical fingerprint while renames are semantic.

## Verification

- `pixi run lint --fix`
- `pixi run test`
- commit and push hooks: `pixi run lint`
