### PR TITLE
STANDOUT-WIZ03-WS05: Epic: Derived Questionnaires - Workstream: Injected command surface

### DIFF
--- a/crates/standout-macros/src/dispatch.rs
+++ b/crates/standout-macros/src/dispatch.rs
@@ -37,6 +37,7 @@
 //! | `pre_dispatch = fn` | Pre-dispatch hook | None |
 //! | `post_dispatch = fn` | Post-dispatch hook | None |
 //! | `post_output = fn` | Post-output hook | None |
+//! | `questionnaire = path::Type` | Inject questionnaire CLI surface and resolved typed input | None |
 //! | `nested` | Treat variant as nested subcommand | false |
 //! | `skip` | Skip this variant | false |
 //! | `default` | Use as default command when no subcommand specified | false |
@@ -72,6 +73,7 @@ struct VariantAttrs {
     pre_dispatch: Option<Path>,
     post_dispatch: Option<Path>,
     post_output: Option<Path>,
+    questionnaire: Option<Path>,
     nested: bool,
     skip: bool,
     default: bool,
@@ -169,6 +171,13 @@ impl Parse for VariantAttrs {
                         return Err(Error::new(nv.value.span(), "expected path"));
                     }
                 }
+                Meta::NameValue(nv) if nv.path.is_ident("questionnaire") => {
+                    if let Expr::Path(expr_path) = &nv.value {
+                        attrs.questionnaire = Some(expr_path.path.clone());
+                    } else {
+                        return Err(Error::new(nv.value.span(), "expected path"));
+                    }
+                }
                 Meta::Path(p) if p.is_ident("nested") => {
                     attrs.nested = true;
                 }
@@ -226,7 +235,7 @@ impl Parse for VariantAttrs {
                 _ => {
                     return Err(Error::new(
                         meta.span(),
-                        "unknown attribute, expected one of: handler, template, pre_dispatch, post_dispatch, post_output, nested, skip, default, list_view, item_type, pipe_to, pipe_through, pipe_to_clipboard, simple, pure",
+                        "unknown attribute, expected one of: handler, template, pre_dispatch, post_dispatch, post_output, questionnaire, nested, skip, default, list_view, item_type, pipe_to, pipe_through, pipe_to_clipboard, simple, pure",
                     ));
                 }
             }
@@ -407,6 +416,7 @@ pub fn dispatch_derive_impl(input: DeriveInput) -> Result<TokenStream> {
                     || v.attrs.pre_dispatch.is_some()
                     || v.attrs.post_dispatch.is_some()
                     || v.attrs.post_output.is_some()
+                    || v.attrs.questionnaire.is_some()
                     || (v.attrs.list_view && v.attrs.item_type.is_some())
                     || v.attrs.pipe_to.is_some()
                     || v.attrs.pipe_through.is_some()
@@ -479,6 +489,9 @@ pub fn dispatch_derive_impl(input: DeriveInput) -> Result<TokenStream> {
                     let post_output_call = v.attrs.post_output.as_ref().map(|p| {
                         quote! { __cfg = __cfg.post_output(#p); }
                     });
+                    let questionnaire_call = v.attrs.questionnaire.as_ref().map(|p| {
+                        quote! { __cfg = __cfg.questionnaire::<#p>(); }
+                    });
                     let pipe_to_call = v.attrs.pipe_to.as_ref().map(|p| {
                         quote! { __cfg = __cfg.pipe_to(#p); }
                     });
@@ -494,6 +507,7 @@ pub fn dispatch_derive_impl(input: DeriveInput) -> Result<TokenStream> {
                     quote! {
                         let __builder = __builder.command_with(#cmd_name, #handler_expr, |mut __cfg| {
                             #template_call
+                            #questionnaire_call
                             #pre_dispatch_call
                             #post_dispatch_call
                             #post_output_call

--- a/crates/standout-test/tests/questionnaire_command_surface.rs
+++ b/crates/standout-test/tests/questionnaire_command_surface.rs
@@ -1,0 +1,357 @@
+//! Integration tests for framework-injected questionnaire command wiring.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use clap::{Arg, Command, Subcommand};
+use serde_json::json;
+use serial_test::serial;
+use standout::cli::{
+    App, CommandContext, CommandContextInput, Dispatch, HandlerResult, Output, RunResult,
+};
+use standout::input::questionnaire::QuestionnaireInput;
+use standout::input::{PromptResponse, ScriptedResponder};
+use standout_test::{TestHarness, TestResult};
+
+#[derive(Debug, Clone, PartialEq, Eq, standout::Questionnaire)]
+#[question(id = "fixture.profile")]
+struct FixtureAnswers {
+    /// Project name.
+    name: String,
+}
+
+#[derive(Clone)]
+struct Calls(Arc<AtomicUsize>);
+
+mod handlers {
+    use super::*;
+
+    pub fn collect(
+        _matches: &clap::ArgMatches,
+        ctx: &CommandContext,
+    ) -> HandlerResult<serde_json::Value> {
+        let calls = ctx.app_state.get_required::<Calls>()?;
+        calls.0.fetch_add(1, Ordering::SeqCst);
+        let answers: &FixtureAnswers = ctx.questionnaire()?;
+        Ok(Output::Render(json!({ "name": answers.name })))
+    }
+
+    pub fn other(
+        _matches: &clap::ArgMatches,
+        ctx: &CommandContext,
+    ) -> HandlerResult<serde_json::Value> {
+        let calls = ctx.app_state.get_required::<Calls>()?;
+        calls.0.fetch_add(1, Ordering::SeqCst);
+        Ok(Output::Render(json!({ "name": "other" })))
+    }
+}
+
+#[derive(Subcommand, Dispatch)]
+#[dispatch(handlers = handlers)]
+enum Commands {
+    #[dispatch(questionnaire = FixtureAnswers, template = "{{ name }}")]
+    Collect,
+    #[dispatch(template = "{{ name }}")]
+    Other,
+}
+
+fn command() -> Command {
+    Command::new("fixture")
+        .subcommand_required(true)
+        .subcommand(Command::new("collect"))
+        .subcommand(Command::new("other"))
+}
+
+fn derived_app(calls: Arc<AtomicUsize>) -> standout::cli::App {
+    App::builder()
+        .app_state(Calls(calls))
+        .commands(Commands::dispatch_config())
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+fn builder_app(calls: Arc<AtomicUsize>) -> standout::cli::App {
+    App::builder()
+        .app_state(Calls(calls))
+        .command_with("collect", handlers::collect, |cfg| {
+            cfg.template("{{ name }}").questionnaire::<FixtureAnswers>()
+        })
+        .unwrap()
+        .command("other", handlers::other, "{{ name }}")
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+fn answered_sheet(name: &str) -> String {
+    FixtureAnswers::questionnaire()
+        .unwrap()
+        .render_answer_sheet()
+        .replace("<id:name>\n", &format!("<id:name>\n{name}\n"))
+}
+
+fn error_text(result: &TestResult) -> String {
+    match result.outcome() {
+        RunResult::Error(error) => error.to_string(),
+        other => panic!("expected error, got {other:?}"),
+    }
+}
+
+#[test]
+#[serial(questionnaire)]
+fn derive_injects_answers_flag_and_yes_gate() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = derived_app(calls.clone());
+
+    let result = TestHarness::new()
+        .fixture("answers.txt", answered_sheet("from-file"))
+        .run(
+            &app,
+            command(),
+            ["fixture", "collect", "--answers", "answers.txt", "--yes"],
+        );
+
+    result.assert_success();
+    assert_eq!(result.stdout(), "from-file");
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+#[serial(questionnaire)]
+fn builder_config_injects_equivalent_answers_surface() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = builder_app(calls.clone());
+
+    let result = TestHarness::new()
+        .fixture("answers.txt", answered_sheet("from-builder"))
+        .run(
+            &app,
+            command(),
+            ["fixture", "collect", "--answers", "answers.txt", "--yes"],
+        );
+
+    result.assert_success();
+    assert_eq!(result.stdout(), "from-builder");
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+#[serial(questionnaire)]
+fn stdin_answers_decode_through_shared_pipeline() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = derived_app(calls);
+
+    let result = TestHarness::new()
+        .piped_stdin(answered_sheet("from-stdin"))
+        .run(
+            &app,
+            command(),
+            ["fixture", "collect", "--answers", "-", "--yes"],
+        );
+
+    result.assert_success();
+    assert_eq!(result.stdout(), "from-stdin");
+}
+
+#[test]
+#[serial(questionnaire)]
+fn terminal_stdin_is_rejected_for_explicit_answers_dash() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = derived_app(calls.clone());
+
+    let result = TestHarness::new().interactive_stdin().run(
+        &app,
+        command(),
+        ["fixture", "collect", "--answers", "-", "--yes"],
+    );
+
+    assert!(result.stdout().is_empty());
+    let error = error_text(&result);
+    assert!(
+        error.contains("stdin is an interactive terminal"),
+        "{error}"
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+#[serial(questionnaire)]
+fn invalid_answer_sheet_does_not_fall_back_to_prompts() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = derived_app(calls.clone());
+
+    let result = TestHarness::new()
+        .fixture("answers.txt", "")
+        .prompts(Arc::new(ScriptedResponder::new([PromptResponse::text(
+            "fallback",
+        )])))
+        .run(
+            &app,
+            command(),
+            ["fixture", "collect", "--answers", "answers.txt", "--yes"],
+        );
+
+    let error = error_text(&result);
+    assert!(error.contains("answer sheet answers.txt has"), "{error}");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+#[serial(questionnaire)]
+fn no_flags_collects_interactively_before_handler() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = derived_app(calls);
+
+    let result = TestHarness::new()
+        .prompts(Arc::new(ScriptedResponder::new([PromptResponse::text(
+            "interactive",
+        )])))
+        .run(&app, command(), ["fixture", "collect", "--yes"]);
+
+    result.assert_success();
+    assert_eq!(result.stdout(), "interactive");
+}
+
+#[test]
+#[serial(questionnaire)]
+fn questions_renders_blank_sheet_without_running_handler() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = derived_app(calls.clone());
+
+    let result = TestHarness::new().run(&app, command(), ["fixture", "collect", "questions"]);
+
+    result.assert_success();
+    assert!(result
+        .stdout()
+        .contains("#! questionnaire: fixture.profile"));
+    assert!(result.stdout().contains("<id:name>"));
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+#[serial(questionnaire)]
+fn questions_writes_file_without_running_handler() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = derived_app(calls.clone());
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("questions.txt");
+    let output_arg = output.to_str().unwrap();
+
+    let result = TestHarness::new().run(
+        &app,
+        command(),
+        ["fixture", "collect", "questions", "--file", output_arg],
+    );
+
+    result.assert_success();
+    assert_eq!(result.stdout(), "");
+    let written = std::fs::read_to_string(output).unwrap();
+    assert!(written.contains("#! questionnaire: fixture.profile"));
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+#[serial(questionnaire)]
+fn questions_rejects_answers_and_yes_combination() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = derived_app(calls.clone());
+
+    let result = TestHarness::new()
+        .fixture("answers.txt", answered_sheet("x"))
+        .run(
+            &app,
+            command(),
+            [
+                "fixture",
+                "collect",
+                "--answers",
+                "answers.txt",
+                "--yes",
+                "questions",
+            ],
+        );
+
+    let error = error_text(&result);
+    assert!(
+        error.contains("cannot be combined with --answers or --yes"),
+        "{error}"
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+#[serial(questionnaire)]
+fn confirmation_gate_rejects_missing_attended_terminal() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = derived_app(calls.clone());
+
+    let result = TestHarness::new()
+        .fixture("answers.txt", answered_sheet("from-file"))
+        .env("STANDOUT_QUESTIONNAIRE_TERMINAL", "absent")
+        .run(
+            &app,
+            command(),
+            ["fixture", "collect", "--answers", "answers.txt"],
+        );
+
+    let error = error_text(&result);
+    assert!(
+        error.contains("confirmation requires an attended terminal"),
+        "{error}"
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+#[serial(questionnaire)]
+fn confirmation_gate_accepts_scripted_attended_yes() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = derived_app(calls);
+    let harness = TestHarness::new()
+        .fixture("answers.txt", answered_sheet("confirmed"))
+        .fixture("terminal.txt", "yes\n");
+    let terminal = harness.tempdir().unwrap().join("terminal.txt");
+    let terminal_arg = terminal.to_str().unwrap().to_string();
+
+    let result = harness
+        .env("STANDOUT_QUESTIONNAIRE_TERMINAL", terminal_arg)
+        .run(
+            &app,
+            command(),
+            ["fixture", "collect", "--answers", "answers.txt"],
+        );
+
+    result.assert_success();
+    assert_eq!(result.stdout(), "confirmed");
+}
+
+#[test]
+#[serial(questionnaire)]
+fn non_questionnaire_command_is_unaffected() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = derived_app(calls.clone());
+
+    let ok = TestHarness::new().run(&app, command(), ["fixture", "other"]);
+    ok.assert_success();
+    assert_eq!(ok.stdout(), "other");
+
+    let unknown = TestHarness::new().run(&app, command(), ["fixture", "other", "--answers", "x"]);
+    let error = error_text(&unknown);
+    assert!(error.contains("unexpected argument '--answers'"), "{error}");
+}
+
+#[test]
+fn reserved_answers_collision_fails_verification() {
+    let app = App::builder()
+        .command_with("collect", handlers::collect, |cfg| {
+            cfg.template("{{ name }}").questionnaire::<FixtureAnswers>()
+        })
+        .unwrap();
+    let cmd = Command::new("fixture")
+        .subcommand(Command::new("collect").arg(Arg::new("answers").long("answers")));
+
+    let error = app.verify_command(&cmd).unwrap_err().to_string();
+    assert!(error.contains("reserved name"), "{error}");
+    assert!(error.contains("--answers"), "{error}");
+}

--- a/crates/standout-test/tests/questionnaire_command_surface.rs
+++ b/crates/standout-test/tests/questionnaire_command_surface.rs
@@ -10,7 +10,7 @@ use standout::cli::{
     App, CommandContext, CommandContextInput, Dispatch, HandlerResult, Output, RunResult,
 };
 use standout::input::questionnaire::QuestionnaireInput;
-use standout::input::{PromptResponse, ScriptedResponder};
+use standout::input::{DefaultSource, InputChain, PromptResponse, ScriptedResponder};
 use standout_test::{TestHarness, TestResult};
 
 #[derive(Debug, Clone, PartialEq, Eq, standout::Questionnaire)]
@@ -354,4 +354,102 @@ fn reserved_answers_collision_fails_verification() {
     let error = app.verify_command(&cmd).unwrap_err().to_string();
     assert!(error.contains("reserved name"), "{error}");
     assert!(error.contains("--answers"), "{error}");
+}
+
+#[test]
+fn reserved_answer_alias_collision_fails_verification() {
+    let app = App::builder()
+        .command_with("collect", handlers::collect, |cfg| {
+            cfg.template("{{ name }}").questionnaire::<FixtureAnswers>()
+        })
+        .unwrap();
+    let cmd = Command::new("fixture")
+        .subcommand(Command::new("collect").arg(Arg::new("other").long("other").alias("answers")));
+
+    let error = app.verify_command(&cmd).unwrap_err().to_string();
+    assert!(error.contains("reserved name"), "{error}");
+    assert!(error.contains("--answers"), "{error}");
+}
+
+#[test]
+fn reserved_questions_alias_collision_fails_verification() {
+    let app = App::builder()
+        .command_with("collect", handlers::collect, |cfg| {
+            cfg.template("{{ name }}").questionnaire::<FixtureAnswers>()
+        })
+        .unwrap();
+    let cmd = Command::new("fixture")
+        .subcommand(Command::new("collect").subcommand(Command::new("local").alias("questions")));
+
+    let error = app.verify_command(&cmd).unwrap_err().to_string();
+    assert!(error.contains("reserved name"), "{error}");
+    assert!(error.contains("questions"), "{error}");
+}
+
+#[test]
+#[serial(questionnaire)]
+fn questionnaire_rejects_existing_input_name() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = App::builder()
+        .app_state(Calls(calls.clone()))
+        .command_with("collect", handlers::collect, |cfg| {
+            cfg.template("{{ name }}")
+                .input(
+                    "questionnaire",
+                    InputChain::new().try_source(DefaultSource::new("already-taken".to_string())),
+                )
+                .questionnaire::<FixtureAnswers>()
+        })
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = TestHarness::new()
+        .fixture("answers.txt", answered_sheet("from-file"))
+        .run(
+            &app,
+            command(),
+            ["fixture", "collect", "--answers", "answers.txt", "--yes"],
+        );
+
+    let error = error_text(&result);
+    assert!(
+        error.contains("reserved for command questionnaires"),
+        "{error}"
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+#[serial(questionnaire)]
+fn generic_input_rejects_questionnaire_name_after_questionnaire() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = App::builder()
+        .app_state(Calls(calls.clone()))
+        .command_with("collect", handlers::collect, |cfg| {
+            cfg.template("{{ name }}")
+                .questionnaire::<FixtureAnswers>()
+                .input(
+                    "questionnaire",
+                    InputChain::new().try_source(DefaultSource::new("already-taken".to_string())),
+                )
+        })
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let result = TestHarness::new()
+        .fixture("answers.txt", answered_sheet("from-file"))
+        .run(
+            &app,
+            command(),
+            ["fixture", "collect", "--answers", "answers.txt", "--yes"],
+        );
+
+    let error = error_text(&result);
+    assert!(
+        error.contains("duplicate input names are not supported"),
+        "{error}"
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
 }

--- a/crates/standout/src/cli/builder/commands.rs
+++ b/crates/standout/src/cli/builder/commands.rs
@@ -85,6 +85,10 @@ impl AppBuilder {
         if let Some(hooks) = config.hooks.take() {
             self.command_hooks.insert(path.to_string(), hooks);
         }
+        if let Some(questionnaire) = config.questionnaire.take() {
+            self.questionnaire_commands
+                .insert(path.to_string(), questionnaire);
+        }
 
         // Create a recipe for deferred closure creation using the handler
         let mut recipe = ClosureRecipe::new(config.handler);
@@ -128,6 +132,10 @@ impl AppBuilder {
                     // Extract and register hooks
                     if let Some(hooks) = handler.take_hooks() {
                         self.command_hooks.insert(path.clone(), hooks);
+                    }
+                    if let Some(questionnaire) = handler.take_questionnaire() {
+                        self.questionnaire_commands
+                            .insert(path.clone(), questionnaire);
                     }
 
                     // Create a recipe for deferred closure creation

--- a/crates/standout/src/cli/builder/execution.rs
+++ b/crates/standout/src/cli/builder/execution.rs
@@ -23,6 +23,10 @@ use crate::cli::handler::{
     RunErrorKind, RunOutput, RunResult,
 };
 use crate::cli::hooks::{ArtifactOutput, RenderedOutput, TextOutput};
+use crate::cli::questionnaire::{
+    augment_questionnaire_command, render_questions_result, validate_questionnaire_surface,
+    ANSWERS_ARG_ID, QUESTIONS_SUBCOMMAND, YES_ARG_ID,
+};
 use crate::SetupError;
 
 impl AppBuilder {
@@ -70,6 +74,10 @@ impl AppBuilder {
 
                     if let Some(hooks) = handler.take_hooks() {
                         self.command_hooks.insert(name.clone(), hooks);
+                    }
+                    if let Some(questionnaire) = handler.take_questionnaire() {
+                        self.questionnaire_commands
+                            .insert(name.clone(), questionnaire);
                     }
 
                     // Create a recipe for deferred closure creation
@@ -290,7 +298,11 @@ impl AppBuilder {
             .map(|a| a.into().to_string_lossy().into_owned())
             .collect();
 
-        // Augment command with --output flag
+        if let Err(error) = self.validate_questionnaire_surfaces(&cmd) {
+            return RunResult::Error(RunError::new(error.to_string(), RunErrorKind::ClapUsage));
+        }
+
+        // Augment command with framework-owned flags and questionnaire command surface.
         let augmented_cmd = self.augment_command_for_dispatch(cmd.clone());
 
         // Parse arguments. Clap's "errors" include `--help` and `--version`,
@@ -347,6 +359,28 @@ impl AppBuilder {
                 }
             }
         };
+
+        if let Some((path, questionnaire)) = self.questionnaire_questions_invocation(&matches) {
+            if let Some(parent_matches) =
+                command_matches_for_path(&matches, &path.split('.').collect::<Vec<_>>())
+            {
+                let has_answers = parent_matches
+                    .try_get_one::<String>(ANSWERS_ARG_ID)
+                    .unwrap_or(None)
+                    .is_some();
+                let has_yes = parent_matches
+                    .try_get_one::<bool>(YES_ARG_ID)
+                    .unwrap_or(None)
+                    == Some(&true);
+                if has_answers || has_yes {
+                    return RunResult::Error(RunError::new(
+                        "`questions` renders the blank answer sheet and cannot be combined with --answers or --yes",
+                        RunErrorKind::ClapUsage,
+                    ));
+                }
+            }
+            return render_questions_result(questionnaire, &matches);
+        }
 
         // Extract output mode
         let output_mode = if self.output_flag.is_some() {
@@ -486,6 +520,8 @@ impl AppBuilder {
 
     /// Augments a command for dispatch (adds --output flag without help subcommand).
     pub(crate) fn augment_command_for_dispatch(&self, mut cmd: Command) -> Command {
+        self.augment_questionnaire_commands(&mut cmd, &[]);
+
         if let Some(ref flag_name) = self.output_flag {
             let flag: &'static str = Box::leak(flag_name.clone().into_boxed_str());
             cmd = cmd.arg(
@@ -523,6 +559,53 @@ impl AppBuilder {
 
         cmd
     }
+
+    fn augment_questionnaire_commands(&self, cmd: &mut Command, path: &[String]) {
+        let path_str = path.join(".");
+        if self.questionnaire_commands.contains_key(&path_str) {
+            *cmd = augment_questionnaire_command(cmd.clone());
+        }
+
+        for subcommand in cmd.get_subcommands_mut() {
+            let mut child_path = path.to_vec();
+            child_path.push(subcommand.get_name().to_string());
+            self.augment_questionnaire_commands(subcommand, &child_path);
+        }
+    }
+
+    pub(crate) fn validate_questionnaire_surfaces(&self, cmd: &Command) -> Result<(), SetupError> {
+        for path in self.questionnaire_commands.keys() {
+            let parts = path.split('.').collect::<Vec<_>>();
+            let Some(command) = crate::cli::app::find_subcommand_recursive(cmd, &parts) else {
+                continue;
+            };
+            validate_questionnaire_surface(command, path)?;
+        }
+        Ok(())
+    }
+
+    fn questionnaire_questions_invocation(
+        &self,
+        matches: &ArgMatches,
+    ) -> Option<(&str, &crate::cli::questionnaire::QuestionnaireCommand)> {
+        let path = extract_command_path(matches);
+        let (last, parent) = path.split_last()?;
+        if last.as_str() != QUESTIONS_SUBCOMMAND || parent.is_empty() {
+            return None;
+        }
+        let parent_path = parent.join(".");
+        self.questionnaire_commands
+            .get_key_value(&parent_path)
+            .map(|(path, command)| (path.as_str(), command))
+    }
+}
+
+fn command_matches_for_path<'a>(matches: &'a ArgMatches, path: &[&str]) -> Option<&'a ArgMatches> {
+    let mut current = matches;
+    for segment in path {
+        current = current.subcommand_matches(segment)?;
+    }
+    Some(current)
 }
 
 /// Selects the destination for an artifact, deterministically.

--- a/crates/standout/src/cli/builder/mod.rs
+++ b/crates/standout/src/cli/builder/mod.rs
@@ -50,6 +50,7 @@ use super::group::CommandRecipe;
 use super::handler::{CommandContext, Extensions, HandlerResult, Output as HandlerOutput};
 use super::help::{render_help, render_help_with_topics, CommandGroup, HelpConfig};
 use super::hooks::{ArtifactOutput, HookError, Hooks, RenderedOutput, TextOutput};
+use super::questionnaire::QuestionnaireCommand;
 use super::result::HelpResult;
 use standout_dispatch::verify::ExpectedArg;
 
@@ -117,6 +118,7 @@ pub struct AppBuilder {
     /// Finalized dispatch functions (lazily created from pending_commands)
     finalized_commands: RefCell<Option<HashMap<String, DispatchFn>>>,
     pub(crate) command_hooks: HashMap<String, Hooks>,
+    pub(crate) questionnaire_commands: HashMap<String, QuestionnaireCommand>,
     pub(crate) context_registry: ContextRegistry,
     pub(crate) template_dir: Option<PathBuf>,
     pub(crate) template_ext: String,
@@ -176,6 +178,7 @@ impl AppBuilder {
             pending_commands: RefCell::new(HashMap::new()),
             finalized_commands: RefCell::new(None),
             command_hooks: HashMap::new(),
+            questionnaire_commands: HashMap::new(),
             context_registry: ContextRegistry::new(),
             template_dir: None,
             template_ext: ".j2".to_string(),
@@ -958,6 +961,7 @@ impl AppBuilder {
     /// Checks that all required arguments expected by handlers are present
     /// in the clap Command definition with compatible types.
     pub fn verify_command(&self, cmd: &Command) -> Result<(), SetupError> {
+        self.validate_questionnaire_surfaces(cmd)?;
         let expected_args: HashMap<String, Vec<ExpectedArg>> = self
             .pending_commands
             .borrow()

--- a/crates/standout/src/cli/group.rs
+++ b/crates/standout/src/cli/group.rs
@@ -14,8 +14,10 @@ use std::rc::Rc;
 use super::dispatch::{render_handler_output, DispatchFn};
 use crate::cli::handler::{CommandContext, FnHandler, Handler, HandlerResult};
 use crate::cli::hooks::{Hooks, RenderedOutput, TextOutput};
+use crate::cli::questionnaire::{questionnaire_pre_dispatch, QuestionnaireCommand};
 use crate::StructuredOutputProjection;
 use standout_dispatch::verify::ExpectedArg;
+use standout_input::questionnaire::QuestionnaireInput;
 use standout_pipe::PipeTarget;
 
 // ============================================================================
@@ -43,6 +45,10 @@ pub(crate) trait CommandRecipe {
     /// Returns hooks for this command, if set.
     #[allow(dead_code)]
     fn hooks(&self) -> Option<&Hooks>;
+
+    /// Takes ownership of questionnaire metadata, if set.
+    #[allow(dead_code)]
+    fn take_questionnaire(&mut self) -> Option<QuestionnaireCommand>;
 
     /// Takes ownership of hooks (for registration with AppBuilder).
     #[allow(dead_code)]
@@ -73,6 +79,7 @@ where
     handler: Rc<RefCell<FnHandler<F, T>>>,
     template: Option<String>,
     hooks: Option<Hooks>,
+    questionnaire: Option<QuestionnaireCommand>,
     structured_output_projection: Option<StructuredOutputProjection>,
 }
 
@@ -86,6 +93,7 @@ where
             handler: Rc::new(RefCell::new(handler)),
             template: None,
             hooks: None,
+            questionnaire: None,
             structured_output_projection: None,
         }
     }
@@ -126,6 +134,10 @@ where
 
     fn take_hooks(&mut self) -> Option<Hooks> {
         self.hooks.take()
+    }
+
+    fn take_questionnaire(&mut self) -> Option<QuestionnaireCommand> {
+        self.questionnaire.take()
     }
 
     fn create_dispatch(
@@ -179,6 +191,7 @@ where
     #[allow(dead_code)]
     template: Option<String>,
     hooks: Option<Hooks>,
+    questionnaire: Option<QuestionnaireCommand>,
     structured_output_projection: Option<StructuredOutputProjection>,
     _phantom: std::marker::PhantomData<T>,
 }
@@ -193,6 +206,7 @@ where
             handler: Rc::new(RefCell::new(handler)),
             template: None,
             hooks: None,
+            questionnaire: None,
             structured_output_projection: None,
             _phantom: std::marker::PhantomData,
         }
@@ -235,6 +249,10 @@ where
 
     fn take_hooks(&mut self) -> Option<Hooks> {
         self.hooks.take()
+    }
+
+    fn take_questionnaire(&mut self) -> Option<QuestionnaireCommand> {
+        self.questionnaire.take()
     }
 
     fn create_dispatch(
@@ -327,6 +345,10 @@ impl CommandRecipe for ErasedConfigRecipe {
         self.hooks.borrow_mut().take()
     }
 
+    fn take_questionnaire(&mut self) -> Option<QuestionnaireCommand> {
+        None
+    }
+
     fn create_dispatch(
         &self,
         template: &str,
@@ -395,6 +417,10 @@ where
         None
     }
 
+    fn take_questionnaire(&mut self) -> Option<QuestionnaireCommand> {
+        None
+    }
+
     fn create_dispatch(
         &self,
         _template: &str,
@@ -432,6 +458,7 @@ pub struct CommandConfig<H> {
     pub(crate) handler: H,
     pub(crate) template: Option<String>,
     pub(crate) hooks: Option<Hooks>,
+    pub(crate) questionnaire: Option<QuestionnaireCommand>,
     pub(crate) structured_output_projection: Option<StructuredOutputProjection>,
 }
 
@@ -442,6 +469,7 @@ impl<H> CommandConfig<H> {
             handler,
             template: None,
             hooks: None,
+            questionnaire: None,
             structured_output_projection: None,
         }
     }
@@ -459,6 +487,25 @@ impl<H> CommandConfig<H> {
     pub fn hooks(mut self, hooks: Hooks) -> Self {
         self.hooks = Some(hooks);
         self
+    }
+
+    /// Attaches a derived questionnaire input to this command.
+    ///
+    /// Standout injects the reserved questionnaire CLI surface into this
+    /// command at parse time: `--answers FILE|-`, `--yes`, and the
+    /// side-effect-free `questions` subcommand. Before the handler runs, the
+    /// framework resolves exactly one answer source (answer sheet file,
+    /// explicit stdin, or interactive prompts), decodes it through the shared
+    /// questionnaire pipeline, runs the attended confirmation gate unless
+    /// `--yes` was supplied, and stores the typed value in the command
+    /// context. Handlers read it with
+    /// [`CommandContextInput::questionnaire`](crate::cli::CommandContextInput::questionnaire).
+    pub fn questionnaire<T>(mut self) -> Self
+    where
+        T: QuestionnaireInput + Clone + Send + Sync + 'static,
+    {
+        self.questionnaire = Some(QuestionnaireCommand::new::<T>());
+        self.pre_dispatch(questionnaire_pre_dispatch::<T>)
     }
 
     /// Attaches a presentation-layer projection for structured output.
@@ -752,6 +799,7 @@ pub(crate) trait ErasedCommandConfig {
     #[allow(dead_code)]
     fn hooks(&self) -> Option<&Hooks>;
     fn take_hooks(&mut self) -> Option<Hooks>;
+    fn take_questionnaire(&mut self) -> Option<QuestionnaireCommand>;
     fn register(
         self: Box<Self>,
         path: &str,
@@ -857,6 +905,7 @@ impl GroupBuilder {
                     handler: Rc::new(RefCell::new(config.handler)),
                     template: config.template,
                     hooks: config.hooks,
+                    questionnaire: config.questionnaire,
                     structured_output_projection: config.structured_output_projection,
                 }),
             },
@@ -889,6 +938,7 @@ impl GroupBuilder {
                     handler: Rc::new(RefCell::new(config.handler)),
                     template: config.template,
                     hooks: config.hooks,
+                    questionnaire: config.questionnaire,
                     structured_output_projection: config.structured_output_projection,
                 }),
             },
@@ -989,6 +1039,7 @@ where
     handler: Rc<RefCell<FnHandler<F, T>>>,
     template: Option<String>,
     hooks: Option<Hooks>,
+    questionnaire: Option<QuestionnaireCommand>,
     structured_output_projection: Option<StructuredOutputProjection>,
 }
 
@@ -1007,6 +1058,10 @@ where
 
     fn take_hooks(&mut self) -> Option<Hooks> {
         self.hooks.take()
+    }
+
+    fn take_questionnaire(&mut self) -> Option<QuestionnaireCommand> {
+        self.questionnaire.take()
     }
 
     fn register(
@@ -1058,6 +1113,7 @@ where
     handler: Rc<RefCell<H>>,
     template: Option<String>,
     hooks: Option<Hooks>,
+    questionnaire: Option<QuestionnaireCommand>,
     structured_output_projection: Option<StructuredOutputProjection>,
 }
 
@@ -1076,6 +1132,10 @@ where
 
     fn take_hooks(&mut self) -> Option<Hooks> {
         self.hooks.take()
+    }
+
+    fn take_questionnaire(&mut self) -> Option<QuestionnaireCommand> {
+        self.questionnaire.take()
     }
 
     fn register(
@@ -1139,6 +1199,10 @@ where
     }
 
     fn take_hooks(&mut self) -> Option<Hooks> {
+        None
+    }
+
+    fn take_questionnaire(&mut self) -> Option<QuestionnaireCommand> {
         None
     }
 

--- a/crates/standout/src/cli/group.rs
+++ b/crates/standout/src/cli/group.rs
@@ -587,7 +587,9 @@ impl<H> CommandConfig<H> {
     ///     .build()?;
     /// ```
     ///
-    /// Multiple `.input(...)` calls on the same command accumulate; each
+    /// Multiple `.input(...)` calls on the same command accumulate under unique
+    /// names; duplicate names fail during pre-dispatch instead of overwriting
+    /// an earlier resolved value. Each
     /// registers a pre-dispatch hook that writes into the shared bag, so
     /// commands can declare several named inputs of any types.
     ///
@@ -618,6 +620,12 @@ impl<H> CommandConfig<H> {
                 .extensions
                 .get_mut::<standout_input::Inputs>()
                 .expect("Inputs just inserted");
+            if let Some(source) = bag.source_of(name.as_ref()) {
+                return Err(crate::cli::hooks::HookError::pre_dispatch(format!(
+                    "input `{}` is already resolved from {}; duplicate input names are not supported",
+                    name, source
+                )));
+            }
             bag.insert(name.clone(), resolved);
             Ok(())
         })

--- a/crates/standout/src/cli/handler.rs
+++ b/crates/standout/src/cli/handler.rs
@@ -63,6 +63,8 @@ pub use standout_dispatch::{
 
 use standout_input::{InputSourceKind, Inputs, MissingInput};
 
+use crate::cli::questionnaire::QUESTIONNAIRE_INPUT_NAME;
+
 /// Extension trait for [`CommandContext`] that exposes inputs registered with
 /// [`CommandConfig::input`](crate::cli::CommandConfig::input).
 ///
@@ -83,6 +85,15 @@ pub trait CommandContextInput {
     /// Returns the resolved value for `name`, or an error if no input with
     /// that name and type was registered.
     fn input<T: 'static>(&self, name: &str) -> Result<&T, MissingInput>;
+
+    /// Returns the typed questionnaire value resolved for this command.
+    ///
+    /// Commands opt into this with
+    /// [`CommandConfig::questionnaire`](crate::cli::CommandConfig::questionnaire),
+    /// which injects the answer-sheet CLI surface, resolves the submitted or
+    /// interactive answers before the handler runs, and stores the filled
+    /// derived questionnaire struct in the command context.
+    fn questionnaire<T: 'static>(&self) -> Result<&T, MissingInput>;
 
     /// Returns the source that provided `name`, if it was resolved.
     ///
@@ -105,6 +116,10 @@ impl CommandContextInput for CommandContext {
                 name: name.to_string(),
             }),
         }
+    }
+
+    fn questionnaire<T: 'static>(&self) -> Result<&T, MissingInput> {
+        self.input(QUESTIONNAIRE_INPUT_NAME)
     }
 
     fn input_source(&self, name: &str) -> Option<InputSourceKind> {

--- a/crates/standout/src/cli/mod.rs
+++ b/crates/standout/src/cli/mod.rs
@@ -122,6 +122,7 @@
 // Internal modules
 mod default_command;
 mod dispatch;
+mod questionnaire;
 mod result;
 
 // Helper functions (formerly the App struct lived here)

--- a/crates/standout/src/cli/questionnaire.rs
+++ b/crates/standout/src/cli/questionnaire.rs
@@ -97,6 +97,11 @@ where
         .extensions
         .get_mut::<Inputs>()
         .expect("Inputs just inserted");
+    if let Some(source) = bag.source_of(QUESTIONNAIRE_INPUT_NAME) {
+        return Err(HookError::pre_dispatch(format!(
+            "questionnaire input `{QUESTIONNAIRE_INPUT_NAME}` conflicts with an input already resolved from {source}; `{QUESTIONNAIRE_INPUT_NAME}` is reserved for command questionnaires"
+        )));
+    }
     bag.insert(QUESTIONNAIRE_INPUT_NAME, resolved);
     Ok(())
 }
@@ -326,23 +331,28 @@ pub(crate) fn augment_questionnaire_command(mut cmd: Command) -> Command {
 
 pub(crate) fn validate_questionnaire_surface(cmd: &Command, path: &str) -> Result<(), SetupError> {
     let mut conflicts = Vec::new();
-    if cmd.get_arguments().any(|arg| {
-        arg.get_long()
-            .is_some_and(|name| name == "answers" || name == "yes")
-    }) {
-        for arg in cmd.get_arguments() {
-            if let Some(long) = arg.get_long() {
-                if long == "answers" || long == "yes" {
-                    conflicts.push(format!("--{long}"));
+    for arg in cmd.get_arguments() {
+        if let Some(long) = arg.get_long() {
+            if long == "answers" || long == "yes" {
+                conflicts.push(format!("--{long}"));
+            }
+        }
+        if let Some(aliases) = arg.get_all_aliases() {
+            for alias in aliases {
+                if alias == "answers" || alias == "yes" {
+                    conflicts.push(format!("--{alias}"));
                 }
             }
         }
     }
-    if cmd
-        .get_subcommands()
-        .any(|subcommand| subcommand.get_name() == QUESTIONS_SUBCOMMAND)
-    {
-        conflicts.push(QUESTIONS_SUBCOMMAND.to_string());
+    for subcommand in cmd.get_subcommands() {
+        if subcommand.get_name() == QUESTIONS_SUBCOMMAND
+            || subcommand
+                .get_all_aliases()
+                .any(|alias| alias == QUESTIONS_SUBCOMMAND)
+        {
+            conflicts.push(QUESTIONS_SUBCOMMAND.to_string());
+        }
     }
 
     if conflicts.is_empty() {

--- a/crates/standout/src/cli/questionnaire.rs
+++ b/crates/standout/src/cli/questionnaire.rs
@@ -1,0 +1,381 @@
+//! Framework-owned questionnaire command surface.
+//!
+//! A command configured with a questionnaire gets reserved clap surface from
+//! the app builder (`--answers`, `--yes`, and a `questions` subcommand). The
+//! handler then reads the filled application type from
+//! [`CommandContextInput::questionnaire`](crate::cli::CommandContextInput::questionnaire).
+
+use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use standout_input::env::DefaultStdin;
+use standout_input::questionnaire::{
+    AnswerSheetDiagnostic, Questionnaire, QuestionnaireInput, QuestionnaireInputError, RawAnswers,
+};
+use standout_input::{InputError, InputSourceKind, Inputs, ResolvedInput};
+
+use crate::cli::dispatch::get_deepest_matches;
+use crate::cli::handler::{CommandContext, RunError, RunErrorKind};
+use crate::cli::hooks::HookError;
+use crate::SetupError;
+
+pub(crate) const QUESTIONNAIRE_INPUT_NAME: &str = "questionnaire";
+pub(crate) const ANSWERS_ARG_ID: &str = "_standout_questionnaire_answers";
+pub(crate) const YES_ARG_ID: &str = "_standout_questionnaire_yes";
+pub(crate) const QUESTIONS_FILE_ARG_ID: &str = "_standout_questionnaire_questions_file";
+pub(crate) const QUESTIONS_SUBCOMMAND: &str = "questions";
+
+const CONFIRM_QUESTION: &str = "Continue? Type 'yes' to continue: ";
+
+const NO_ATTENDED_TERMINAL: &str =
+    "confirmation requires an attended terminal, but none is available; \
+     rerun in a terminal to review and confirm, or pass --yes to continue \
+     without a confirmation prompt; nothing was run";
+
+#[cfg(debug_assertions)]
+const TERMINAL_SEAM_VAR: &str = "STANDOUT_QUESTIONNAIRE_TERMINAL";
+
+#[derive(Clone)]
+pub(crate) struct QuestionnaireCommand {
+    render: Rc<dyn Fn() -> Result<String, String>>,
+}
+
+impl QuestionnaireCommand {
+    pub(crate) fn new<T>() -> Self
+    where
+        T: QuestionnaireInput + Clone + Send + Sync + 'static,
+    {
+        Self {
+            render: Rc::new(|| {
+                T::questionnaire()
+                    .map(|questionnaire| questionnaire.render_answer_sheet())
+                    .map_err(|error| error.to_string())
+            }),
+        }
+    }
+
+    fn render_answer_sheet(&self) -> Result<String, RunError> {
+        (self.render)().map_err(|error| {
+            RunError::new(
+                format!("questionnaire definition is invalid: {error}"),
+                RunErrorKind::Handler,
+            )
+        })
+    }
+}
+
+pub(crate) fn questionnaire_pre_dispatch<T>(
+    matches: &ArgMatches,
+    ctx: &mut CommandContext,
+) -> Result<(), HookError>
+where
+    T: QuestionnaireInput + Clone + Send + Sync + 'static,
+{
+    let sub_matches = get_deepest_matches(matches);
+    let resolved = collect_questionnaire::<T>(sub_matches).map_err(|error| {
+        HookError::pre_dispatch(format!(
+            "questionnaire input `{QUESTIONNAIRE_INPUT_NAME}`: {error}"
+        ))
+    })?;
+
+    let assume_yes = sub_matches.get_flag(YES_ARG_ID);
+    if !assume_yes
+        && !confirm_attended_from_env()
+            .map_err(|error| HookError::pre_dispatch(error.to_string()))?
+    {
+        return Err(HookError::pre_dispatch(
+            "questionnaire confirmation declined; nothing was run",
+        ));
+    }
+
+    if !ctx.extensions.contains::<Inputs>() {
+        ctx.extensions.insert(Inputs::new());
+    }
+    let bag = ctx
+        .extensions
+        .get_mut::<Inputs>()
+        .expect("Inputs just inserted");
+    bag.insert(QUESTIONNAIRE_INPUT_NAME, resolved);
+    Ok(())
+}
+
+fn collect_questionnaire<T>(matches: &ArgMatches) -> Result<ResolvedInput<T>, InputError>
+where
+    T: QuestionnaireInput + Clone + Send + Sync + 'static,
+{
+    let questionnaire = T::questionnaire()
+        .map_err(|error| InputError::validation(format!("definition is invalid: {error}")))?;
+
+    if let Some(path) = matches.get_one::<String>(ANSWERS_ARG_ID) {
+        let source = if path == "-" {
+            AnswerSource::Stdin
+        } else {
+            AnswerSource::File(PathBuf::from(path))
+        };
+        let raw = source.raw_answers(&questionnaire).map_err(|diagnostics| {
+            InputError::validation(format_diagnostics(source.label(), &diagnostics))
+        })?;
+        let value = T::from_raw_answers(&raw).map_err(questionnaire_input_error)?;
+        return Ok(ResolvedInput {
+            value,
+            source: source.kind(),
+        });
+    }
+
+    let raw = questionnaire.collect_interactive()?;
+    let value = T::from_raw_answers(&raw).map_err(questionnaire_input_error)?;
+    Ok(ResolvedInput {
+        value,
+        source: InputSourceKind::Prompt,
+    })
+}
+
+enum AnswerSource {
+    File(PathBuf),
+    Stdin,
+}
+
+impl AnswerSource {
+    fn label(&self) -> String {
+        match self {
+            Self::File(path) => path.display().to_string(),
+            Self::Stdin => "from stdin".to_string(),
+        }
+    }
+
+    fn kind(&self) -> InputSourceKind {
+        match self {
+            Self::File(_) => InputSourceKind::Flag,
+            Self::Stdin => InputSourceKind::Stdin,
+        }
+    }
+
+    fn raw_answers(
+        &self,
+        questionnaire: &Questionnaire,
+    ) -> Result<RawAnswers, Vec<AnswerSheetDiagnostic>> {
+        match self {
+            Self::File(path) => questionnaire.read_answer_sheet_file(path),
+            Self::Stdin => questionnaire.read_answer_sheet_stdin_with(&DefaultStdin),
+        }
+    }
+}
+
+fn questionnaire_input_error(error: QuestionnaireInputError) -> InputError {
+    InputError::validation(error.to_string())
+}
+
+fn format_diagnostics(label: String, diagnostics: &[AnswerSheetDiagnostic]) -> String {
+    let details = diagnostics
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("; ");
+    format!(
+        "answer sheet {label} has {} problem(s): {details}",
+        diagnostics.len()
+    )
+}
+
+trait AttendedTerminal {
+    fn is_attended(&self) -> bool;
+    fn ask(&mut self, question: &str) -> anyhow::Result<Option<String>>;
+}
+
+struct ControllingTerminal;
+
+#[cfg(unix)]
+fn open_controlling_terminal() -> Option<(std::fs::File, std::fs::File)> {
+    let read = std::fs::OpenOptions::new()
+        .read(true)
+        .open("/dev/tty")
+        .ok()?;
+    let write = std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/tty")
+        .ok()?;
+    Some((read, write))
+}
+
+#[cfg(windows)]
+fn open_controlling_terminal() -> Option<(std::fs::File, std::fs::File)> {
+    let read = std::fs::OpenOptions::new().read(true).open("CONIN$").ok()?;
+    let write = std::fs::OpenOptions::new()
+        .write(true)
+        .open("CONOUT$")
+        .ok()?;
+    Some((read, write))
+}
+
+impl AttendedTerminal for ControllingTerminal {
+    fn is_attended(&self) -> bool {
+        open_controlling_terminal().is_some()
+    }
+
+    fn ask(&mut self, question: &str) -> anyhow::Result<Option<String>> {
+        let (read, mut write) =
+            open_controlling_terminal().ok_or_else(|| anyhow::anyhow!(NO_ATTENDED_TERMINAL))?;
+        write.write_all(question.as_bytes())?;
+        write.flush()?;
+        let mut line = String::new();
+        if io::BufReader::new(read).read_line(&mut line)? == 0 {
+            return Ok(None);
+        }
+        Ok(Some(line))
+    }
+}
+
+#[cfg(any(test, debug_assertions))]
+struct ScriptedTerminal {
+    attended: bool,
+    replies: std::collections::VecDeque<String>,
+}
+
+#[cfg(any(test, debug_assertions))]
+impl ScriptedTerminal {
+    fn absent() -> Self {
+        Self {
+            attended: false,
+            replies: std::collections::VecDeque::new(),
+        }
+    }
+
+    fn from_replies(replies: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            attended: true,
+            replies: replies.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg(any(test, debug_assertions))]
+impl AttendedTerminal for ScriptedTerminal {
+    fn is_attended(&self) -> bool {
+        self.attended
+    }
+
+    fn ask(&mut self, question: &str) -> anyhow::Result<Option<String>> {
+        print!("{question}");
+        io::stdout().flush()?;
+        Ok(self.replies.pop_front())
+    }
+}
+
+fn confirm_attended_from_env() -> anyhow::Result<bool> {
+    let mut terminal = attended_terminal_from_env()?;
+    confirm_attended(terminal.as_mut())
+}
+
+fn attended_terminal_from_env() -> anyhow::Result<Box<dyn AttendedTerminal>> {
+    #[cfg(debug_assertions)]
+    match std::env::var_os(TERMINAL_SEAM_VAR) {
+        None => Ok(Box::new(ControllingTerminal)),
+        Some(value) if value == "absent" => Ok(Box::new(ScriptedTerminal::absent())),
+        Some(path) => {
+            let script = std::fs::read_to_string(&path).map_err(|error| {
+                anyhow::anyhow!(
+                    "failed to read the scripted terminal replies from {}: {error}",
+                    Path::new(&path).display()
+                )
+            })?;
+            Ok(Box::new(ScriptedTerminal::from_replies(
+                script.lines().map(ToOwned::to_owned),
+            )))
+        }
+    }
+    #[cfg(not(debug_assertions))]
+    Ok(Box::new(ControllingTerminal))
+}
+
+fn confirm_attended(terminal: &mut dyn AttendedTerminal) -> anyhow::Result<bool> {
+    if !terminal.is_attended() {
+        anyhow::bail!(NO_ATTENDED_TERMINAL);
+    }
+    let reply = terminal.ask(CONFIRM_QUESTION)?;
+    Ok(reply.is_some_and(|line| line.trim() == "yes"))
+}
+
+pub(crate) fn augment_questionnaire_command(mut cmd: Command) -> Command {
+    cmd = cmd.arg(
+        Arg::new(ANSWERS_ARG_ID)
+            .long("answers")
+            .value_name("FILE")
+            .action(ArgAction::Set)
+            .help("Read questionnaire answers from a file, or '-' for piped stdin"),
+    );
+    cmd = cmd.arg(
+        Arg::new(YES_ARG_ID)
+            .long("yes")
+            .action(ArgAction::SetTrue)
+            .help("Bypass the attended confirmation prompt"),
+    );
+    cmd.subcommand(
+        Command::new(QUESTIONS_SUBCOMMAND)
+            .about("Render the blank questionnaire answer sheet")
+            .arg(
+                Arg::new(QUESTIONS_FILE_ARG_ID)
+                    .long("file")
+                    .value_name("FILE")
+                    .action(ArgAction::Set)
+                    .help("Write the answer sheet to a file instead of stdout"),
+            ),
+    )
+}
+
+pub(crate) fn validate_questionnaire_surface(cmd: &Command, path: &str) -> Result<(), SetupError> {
+    let mut conflicts = Vec::new();
+    if cmd.get_arguments().any(|arg| {
+        arg.get_long()
+            .is_some_and(|name| name == "answers" || name == "yes")
+    }) {
+        for arg in cmd.get_arguments() {
+            if let Some(long) = arg.get_long() {
+                if long == "answers" || long == "yes" {
+                    conflicts.push(format!("--{long}"));
+                }
+            }
+        }
+    }
+    if cmd
+        .get_subcommands()
+        .any(|subcommand| subcommand.get_name() == QUESTIONS_SUBCOMMAND)
+    {
+        conflicts.push(QUESTIONS_SUBCOMMAND.to_string());
+    }
+
+    if conflicts.is_empty() {
+        Ok(())
+    } else {
+        Err(SetupError::Config(format!(
+            "questionnaire command `{path}` declares reserved name(s): {}; \
+             --answers, --yes, and questions are injected by standout",
+            conflicts.join(", ")
+        )))
+    }
+}
+
+pub(crate) fn render_questions_result(
+    questionnaire: &QuestionnaireCommand,
+    matches: &ArgMatches,
+) -> crate::cli::handler::RunResult {
+    let sheet = match questionnaire.render_answer_sheet() {
+        Ok(sheet) => sheet,
+        Err(error) => return crate::cli::handler::RunResult::Error(error),
+    };
+    let sub_matches = get_deepest_matches(matches);
+    if let Some(path) = sub_matches.get_one::<String>(QUESTIONS_FILE_ARG_ID) {
+        if let Err(error) = std::fs::write(path, sheet) {
+            return crate::cli::handler::RunResult::Error(RunError::new(
+                format!("Error writing questionnaire answer sheet: {error}"),
+                RunErrorKind::FinalWrite(crate::cli::handler::OutputKind::Text),
+            ));
+        }
+        crate::cli::handler::RunResult::Handled(crate::cli::handler::RunOutput::command(
+            String::new(),
+        ))
+    } else {
+        crate::cli::handler::RunResult::Handled(crate::cli::handler::RunOutput::command(sheet))
+    }
+}


### PR DESCRIPTION
for #275

## Context

This implements the ADR 0017 injected questionnaire command surface in the framework layer rather than in the wizard binary. `CommandConfig::questionnaire::<T>()` records per-command questionnaire metadata, injects `--answers FILE|-`, `--yes`, and a side-effect-free `questions` subcommand into only that command, resolves file/stdin/interactive answers pre-dispatch through the existing questionnaire parse/decode pipeline, and stores the typed struct for handlers via `ctx.questionnaire::<T>()`. The `Dispatch` derive now lowers `#[dispatch(questionnaire = path::Type)]` to the same builder API.

Self-check: read `docs/spec/derived-questionnaires.md`, ADR 0017, and ADR 0015. This keeps full injection as decided, uses the existing InputChain/InputCollector-style pre-dispatch input bag seam, preserves non-merging answer sources, keeps submitting a sheet separate from consent, and keeps the attended confirmation debug seam debug-only. The fixture tests live in `standout-test` because that crate owns in-process app-surface verification.

Out of scope: no wizard binary rewrite, no choices/nesting/hooks derive work, no answer-sheet format changes, and no re-litigation of the fixed `--answers`, `--yes`, or `questions` names.

Verified: `pixi run test`; `pixi run lint --fix`; commit/push hooks ran `pixi run lint`.