### PR TITLE
STANDOUT-WIZ03-WS04: Epic: Derived Questionnaires - Workstream: Behavior hooks: conditions, dynamic defaults, validators

### DIFF
--- a/crates/standout-macros/src/lib.rs
+++ b/crates/standout-macros/src/lib.rs
@@ -423,7 +423,11 @@ pub fn seekable_derive(input: TokenStream) -> TokenStream {
 /// `Vec<PathBuf>` lower to a single comma-separated scalar answer unless
 /// `#[question(repeated)]` opts them into a single-field repeatable group.
 /// `#[question(default = "...")]` declares a static default, and
-/// `#[question(prose)]` opts a `String` field into multi-line text.
+/// `#[question(default_with = path::to::fn, revision = "...")]` declares a
+/// dynamic default. `#[question(validate = path::to::fn, revision = "...")]`
+/// attaches a field validator, `#[question(active_when(field = "...", is =
+/// "..."))]` declares conditional applicability, and `#[question(prose)]`
+/// opts a `String` field into multi-line text.
 #[proc_macro_derive(Questionnaire, attributes(question))]
 pub fn questionnaire_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/crates/standout-macros/src/questionnaire/mod.rs
+++ b/crates/standout-macros/src/questionnaire/mod.rs
@@ -14,12 +14,12 @@ use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
     spanned::Spanned,
-    Attribute, Data, DeriveInput, Error, Expr, ExprLit, Field, Fields, GenericArgument, Lit, Meta,
-    PathArguments, Result, Token, Type, Variant,
+    Attribute, Data, DeriveInput, Error, Expr, ExprLit, ExprPath, Field, Fields, GenericArgument,
+    Lit, Meta, Path, PathArguments, Result, Token, Type, Variant,
 };
 
 /// Parsed `#[question(...)]` attributes.
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct QuestionAttr {
     id: Option<(String, Span)>,
     default: Option<(String, Span)>,
@@ -28,11 +28,75 @@ struct QuestionAttr {
     repeated: Option<Span>,
     min: Option<(usize, Span)>,
     max: Option<(usize, Span)>,
+    active_when: Option<ActiveWhenAttr>,
+    default_with: Option<(Path, Span)>,
+    validate: Option<(Path, Span)>,
+    revision: Option<(String, Span)>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct ChoiceAttr {
     rename: Option<(String, Span)>,
+}
+
+#[derive(Clone)]
+struct ActiveWhenAttr {
+    field: String,
+    expected: String,
+}
+
+impl Parse for ActiveWhenAttr {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let content: Punctuated<Meta, Token![,]> = Punctuated::parse_terminated(input)?;
+        let mut field = None;
+        let mut expected = None;
+
+        for meta in content {
+            match meta {
+                Meta::NameValue(nv) if nv.path.is_ident("field") => {
+                    let (value, span) =
+                        string_lit(&nv.value, "active_when field must be a string literal")?;
+                    if field.replace((value, span)).is_some() {
+                        return Err(Error::new(
+                            nv.path.span(),
+                            "duplicate active_when field attribute",
+                        ));
+                    }
+                }
+                Meta::NameValue(nv) if nv.path.is_ident("is") => {
+                    let (value, span) =
+                        string_lit(&nv.value, "active_when is must be a string literal")?;
+                    if expected.replace((value, span)).is_some() {
+                        return Err(Error::new(
+                            nv.path.span(),
+                            "duplicate active_when is attribute",
+                        ));
+                    }
+                }
+                other => {
+                    return Err(Error::new(
+                        other.span(),
+                        "unknown active_when attribute: expected field or is",
+                    ));
+                }
+            }
+        }
+
+        let (field, _) = field.ok_or_else(|| {
+            Error::new(
+                input.span(),
+                "active_when requires field = \"...\" and is = \"...\"",
+            )
+        })?;
+        let (expected, _) = expected.ok_or_else(|| {
+            Error::new(
+                input.span(),
+                "active_when requires field = \"...\" and is = \"...\"",
+            )
+        })?;
+
+        Ok(Self { field, expected })
+    }
 }
 
 impl Parse for QuestionAttr {
@@ -102,10 +166,47 @@ impl Parse for QuestionAttr {
                         ));
                     }
                 }
+                Meta::List(list) if list.path.is_ident("active_when") => {
+                    let parsed = list.parse_args::<ActiveWhenAttr>()?;
+                    if attr.active_when.replace(parsed).is_some() {
+                        return Err(Error::new(
+                            list.path.span(),
+                            "duplicate question active_when attribute",
+                        ));
+                    }
+                }
+                Meta::NameValue(nv) if nv.path.is_ident("default_with") => {
+                    let (path, span) =
+                        path_expr(&nv.value, "default_with must be a function path")?;
+                    if attr.default_with.replace((path, span)).is_some() {
+                        return Err(Error::new(
+                            nv.path.span(),
+                            "duplicate question default_with attribute",
+                        ));
+                    }
+                }
+                Meta::NameValue(nv) if nv.path.is_ident("validate") => {
+                    let (path, span) = path_expr(&nv.value, "validate must be a function path")?;
+                    if attr.validate.replace((path, span)).is_some() {
+                        return Err(Error::new(
+                            nv.path.span(),
+                            "duplicate question validate attribute",
+                        ));
+                    }
+                }
+                Meta::NameValue(nv) if nv.path.is_ident("revision") => {
+                    let (value, span) = string_lit(&nv.value, "revision must be a string literal")?;
+                    if attr.revision.replace((value, span)).is_some() {
+                        return Err(Error::new(
+                            nv.path.span(),
+                            "duplicate question revision attribute",
+                        ));
+                    }
+                }
                 other => {
                     return Err(Error::new(
                         other.span(),
-                        "unknown question attribute: expected id, default, prose, choice, repeated, min, or max",
+                        "unknown question attribute: expected id, default, prose, choice, repeated, min, max, active_when, default_with, validate, or revision",
                     ));
                 }
             }
@@ -161,6 +262,10 @@ pub fn questionnaire_derive_impl(input: DeriveInput) -> Result<TokenStream> {
         || container.repeated.is_some()
         || container.min.is_some()
         || container.max.is_some()
+        || container.active_when.is_some()
+        || container.default_with.is_some()
+        || container.validate.is_some()
+        || container.revision.is_some()
     {
         return Err(Error::new(
             input.span(),
@@ -190,6 +295,23 @@ pub fn questionnaire_derive_impl(input: DeriveInput) -> Result<TokenStream> {
     let mut builder_fields = Vec::new();
     let mut fill_fields = Vec::new();
 
+    let field_ids = fields
+        .iter()
+        .map(|field| {
+            let ident = field
+                .ident
+                .clone()
+                .ok_or_else(|| Error::new(field.span(), "expected named field"))?;
+            let attrs = parse_question_attrs(&field.attrs)?;
+            let id = attrs
+                .id
+                .as_ref()
+                .map(|(id, _)| id.clone())
+                .unwrap_or_else(|| ident.to_string());
+            Ok((ident.to_string(), id))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
     for field in fields {
         let info = FieldInfo::new(field)?;
         if !seen_ids.insert(info.id.clone()) {
@@ -198,7 +320,7 @@ pub fn questionnaire_derive_impl(input: DeriveInput) -> Result<TokenStream> {
                 format!("duplicate question id '{}'", info.id),
             ));
         }
-        builder_fields.push(info.builder_tokens());
+        builder_fields.push(info.builder_tokens(&field_ids));
         fill_fields.push(info.fill_tokens());
     }
 
@@ -253,6 +375,10 @@ struct FieldInfo {
     optional: bool,
     min: Option<usize>,
     max: Option<usize>,
+    active_when: Option<ActiveWhenAttr>,
+    default_with: Option<Path>,
+    validate: Option<Path>,
+    revision: Option<String>,
 }
 
 impl FieldInfo {
@@ -292,6 +418,18 @@ impl FieldInfo {
             };
         }
 
+        if attrs.default.is_some() && attrs.default_with.is_some() {
+            let span = attrs
+                .default_with
+                .as_ref()
+                .map(|(_, span)| *span)
+                .expect("checked existing default_with");
+            return Err(Error::new(
+                span,
+                "default and default_with cannot be declared on the same field",
+            ));
+        }
+
         if let Some((default, span)) = attrs.default.as_ref() {
             match kind {
                 FieldKind::Scalar {
@@ -312,6 +450,55 @@ impl FieldInfo {
                     ));
                 }
             }
+        }
+
+        if let Some((_, span)) = attrs.default_with.as_ref() {
+            if !matches!(
+                kind,
+                FieldKind::Scalar { .. } | FieldKind::ScalarVec { .. } | FieldKind::Choice { .. }
+            ) {
+                return Err(Error::new(
+                    *span,
+                    "default_with is only supported on scalar fields, flat scalar Vec fields, and choice fields",
+                ));
+            }
+        }
+
+        if let Some((_, span)) = attrs.validate.as_ref() {
+            if !matches!(
+                kind,
+                FieldKind::Scalar { .. } | FieldKind::ScalarVec { .. } | FieldKind::Choice { .. }
+            ) {
+                return Err(Error::new(
+                    *span,
+                    "validate is only supported on scalar fields, flat scalar Vec fields, and choice fields",
+                ));
+            }
+        }
+
+        if (attrs.default_with.is_some() || attrs.validate.is_some()) && attrs.revision.is_none() {
+            let span = attrs
+                .default_with
+                .as_ref()
+                .map(|(_, span)| *span)
+                .or_else(|| attrs.validate.as_ref().map(|(_, span)| *span))
+                .expect("checked existing hook");
+            return Err(Error::new(
+                span,
+                "default_with and validate require revision = \"...\"",
+            ));
+        }
+
+        if attrs.revision.is_some() && attrs.default_with.is_none() && attrs.validate.is_none() {
+            let span = attrs
+                .revision
+                .as_ref()
+                .map(|(_, span)| *span)
+                .expect("checked existing revision");
+            return Err(Error::new(
+                span,
+                "revision is only supported with default_with or validate",
+            ));
         }
 
         if optional && !matches!(kind, FieldKind::Scalar { .. } | FieldKind::Choice { .. }) {
@@ -383,12 +570,37 @@ impl FieldInfo {
             optional,
             min: attrs.min.map(|(min, _)| min),
             max: attrs.max.map(|(max, _)| max),
+            active_when: attrs.active_when,
+            default_with: attrs.default_with.map(|(path, _)| path),
+            validate: attrs.validate.map(|(path, _)| path),
+            revision: attrs.revision.map(|(revision, _)| revision),
         })
     }
 
-    fn builder_tokens(&self) -> TokenStream {
+    fn builder_tokens(&self, field_ids: &[(String, String)]) -> TokenStream {
         let id = prefixed_id_tokens(&self.id);
         let prompt = &self.prompt;
+        let active_when = self.active_when.as_ref().map(|active_when| {
+            let controller = controller_id_tokens(active_when, field_ids);
+            let expected = &active_when.expected;
+            quote! { .active_when(#controller, #expected) }
+        });
+        let dynamic_default = self.default_with.as_ref().map(|path| {
+            let revision = self.revision.as_deref().unwrap_or_default();
+            quote! {
+                .with_dynamic_default(
+                    ::standout_input::questionnaire::DynamicDefault::new(#revision, #path)
+                )
+            }
+        });
+        let validator = self.validate.as_ref().map(|path| {
+            let revision = self.revision.as_deref().unwrap_or_default();
+            quote! {
+                .with_validator(
+                    ::standout_input::questionnaire::FieldValidator::new(#revision, #path)
+                )
+            }
+        });
         match &self.kind {
             FieldKind::Scalar { scalar } | FieldKind::ScalarVec { scalar } => {
                 let kind = scalar.tokens();
@@ -408,6 +620,9 @@ impl FieldInfo {
                         )
                         #optional
                         #default
+                        #dynamic_default
+                        #active_when
+                        #validator
                         .into()
                     }
                 }
@@ -434,6 +649,9 @@ impl FieldInfo {
                                 .copied()
                         )
                         #default
+                        #dynamic_default
+                        #active_when
+                        #validator
                         .into()
                     }
                 }
@@ -822,6 +1040,22 @@ fn prefixed_id_tokens(id: &str) -> TokenStream {
     }
 }
 
+fn controller_id_tokens(
+    active_when: &ActiveWhenAttr,
+    field_ids: &[(String, String)],
+) -> TokenStream {
+    let controller = field_ids
+        .iter()
+        .find_map(|(name, id)| (name == &active_when.field).then_some(id.as_str()));
+    match controller {
+        Some(id) => prefixed_id_tokens(id),
+        None => {
+            let controller = &active_when.field;
+            quote! { #controller.to_string() }
+        }
+    }
+}
+
 fn choice_kind(ty: &Type) -> Result<FieldKind> {
     if is_known_unsupported_primitive(ty) || !can_be_plain_named_type(ty) {
         return Err(Error::new(
@@ -975,6 +1209,26 @@ fn merge_question_attrs(out: &mut QuestionAttr, next: QuestionAttr, span: Span) 
     if next.max.is_some() && out.max.replace(next.max.unwrap()).is_some() {
         return Err(Error::new(span, "duplicate question max attribute"));
     }
+    if next.active_when.is_some() && out.active_when.replace(next.active_when.unwrap()).is_some() {
+        return Err(Error::new(span, "duplicate question active_when attribute"));
+    }
+    if next.default_with.is_some()
+        && out
+            .default_with
+            .replace(next.default_with.unwrap())
+            .is_some()
+    {
+        return Err(Error::new(
+            span,
+            "duplicate question default_with attribute",
+        ));
+    }
+    if next.validate.is_some() && out.validate.replace(next.validate.unwrap()).is_some() {
+        return Err(Error::new(span, "duplicate question validate attribute"));
+    }
+    if next.revision.is_some() && out.revision.replace(next.revision.unwrap()).is_some() {
+        return Err(Error::new(span, "duplicate question revision attribute"));
+    }
     Ok(())
 }
 
@@ -992,6 +1246,13 @@ fn usize_lit(expr: &Expr, message: &str) -> Result<(usize, Span)> {
         Expr::Lit(ExprLit {
             lit: Lit::Int(lit), ..
         }) => Ok((lit.base10_parse()?, lit.span())),
+        _ => Err(Error::new(expr.span(), message)),
+    }
+}
+
+fn path_expr(expr: &Expr, message: &str) -> Result<(Path, Span)> {
+    match expr {
+        Expr::Path(ExprPath { path, .. }) => Ok((path.clone(), path.span())),
         _ => Err(Error::new(expr.span(), message)),
     }
 }

--- a/crates/standout-macros/tests/questionnaire_derive.rs
+++ b/crates/standout-macros/tests/questionnaire_derive.rs
@@ -5,8 +5,9 @@ use serial_test::serial;
 use standout_input::env::MockStdin;
 use standout_input::questionnaire::QuestionnaireChoices as _;
 use standout_input::questionnaire::{
-    AnswerSheetDiagnostic, Questionnaire as RuntimeQuestionnaire, QuestionnaireError,
-    QuestionnaireInput, QuestionnaireInputError, ScalarField, ScalarKind, ValidationDiagnostic,
+    AnswerSheetDiagnostic, AnswerValue, DynamicDefault, EarlierAnswers, FieldValidator,
+    Questionnaire as RuntimeQuestionnaire, QuestionnaireError, QuestionnaireInput,
+    QuestionnaireInputError, ScalarField, ScalarKind, ValidationDiagnostic,
 };
 use standout_input::{
     reset_default_prompt_responder, set_default_prompt_responder, PromptResponse, ScriptedResponder,
@@ -702,6 +703,305 @@ fn choice_order_is_cosmetic_but_renaming_is_semantic_for_fingerprints() {
 
     assert_eq!(a.fingerprint(), b.fingerprint());
     assert_ne!(a.fingerprint(), renamed.fingerprint());
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, QuestionnaireChoices)]
+enum RuntimeMode {
+    Local,
+    Docker,
+}
+
+fn image_default(earlier: &EarlierAnswers<'_>) -> String {
+    match earlier.get_text("runtime") {
+        Some("docker") => "debian:stable".to_string(),
+        _ => "localhost".to_string(),
+    }
+}
+
+fn image_default_v2(_: &EarlierAnswers<'_>) -> String {
+    "debian:bookworm".to_string()
+}
+
+fn validate_image(value: &AnswerValue) -> Result<(), String> {
+    let Some(text) = value.as_text() else {
+        return Ok(());
+    };
+    if text.contains(':') {
+        Ok(())
+    } else {
+        Err("the image must include a tag".to_string())
+    }
+}
+
+fn validate_image_v2(_: &AnswerValue) -> Result<(), String> {
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq, Questionnaire)]
+#[question(id = "demo.hooks")]
+struct HookedProfile {
+    /// Runtime?
+    #[question(choice)]
+    runtime: RuntimeMode,
+
+    /// Container image?
+    #[question(
+        active_when(field = "runtime", is = "docker"),
+        default_with = image_default,
+        validate = validate_image,
+        revision = "image-hooks-v1"
+    )]
+    image: Option<String>,
+}
+
+fn hand_built_hooked_profile() -> RuntimeQuestionnaire {
+    RuntimeQuestionnaire::new(
+        "demo.hooks",
+        vec![
+            ScalarField::new("runtime", "Runtime?", ScalarKind::String).one_of(["local", "docker"]),
+            ScalarField::new("image", "Container image?", ScalarKind::String)
+                .optional()
+                .with_dynamic_default(DynamicDefault::new("image-hooks-v1", image_default))
+                .active_when("runtime", "docker")
+                .with_validator(FieldValidator::new("image-hooks-v1", validate_image)),
+        ],
+    )
+    .unwrap()
+}
+
+#[test]
+fn behavior_hooks_match_hand_built_definition_and_fingerprint() {
+    let derived = HookedProfile::questionnaire().unwrap();
+    let hand_built = hand_built_hooked_profile();
+
+    assert_eq!(derived, hand_built);
+    assert_eq!(derived.fingerprint(), hand_built.fingerprint());
+}
+
+#[test]
+fn behavior_hooks_round_trip_through_sheet_decode() {
+    let questionnaire = HookedProfile::questionnaire().unwrap();
+
+    let sheet = answer(&questionnaire.render_answer_sheet(), "runtime", "docker");
+    let raw = questionnaire.parse_answer_sheet(&sheet).unwrap();
+    assert_eq!(
+        HookedProfile::from_raw_answers(&raw).unwrap(),
+        HookedProfile {
+            runtime: RuntimeMode::Docker,
+            image: Some("debian:stable".to_string()),
+        }
+    );
+
+    let sheet = answer(&questionnaire.render_answer_sheet(), "runtime", "local");
+    let raw = questionnaire.parse_answer_sheet(&sheet).unwrap();
+    assert_eq!(
+        HookedProfile::from_raw_answers(&raw).unwrap(),
+        HookedProfile {
+            runtime: RuntimeMode::Local,
+            image: None,
+        }
+    );
+
+    let sheet = answer(&sheet, "image", "debian:stable");
+    let raw = questionnaire.parse_answer_sheet(&sheet).unwrap();
+    assert!(matches!(
+        HookedProfile::from_raw_answers(&raw).unwrap_err(),
+        QuestionnaireInputError::Validation(diagnostics)
+            if diagnostics.iter().any(|diagnostic| matches!(
+                diagnostic,
+                ValidationDiagnostic::InactiveAnswered { id, .. } if id == "image"
+            ))
+    ));
+
+    let sheet = answer(&questionnaire.render_answer_sheet(), "runtime", "docker");
+    let sheet = answer(&sheet, "image", "debian");
+    let raw = questionnaire.parse_answer_sheet(&sheet).unwrap();
+    assert!(matches!(
+        HookedProfile::from_raw_answers(&raw).unwrap_err(),
+        QuestionnaireInputError::Validation(diagnostics)
+            if diagnostics.iter().any(|diagnostic| matches!(
+                diagnostic,
+                ValidationDiagnostic::FieldValidation { id, message }
+                    if id == "image" && message == "the image must include a tag"
+            ))
+    ));
+}
+
+#[test]
+#[serial(prompt_responder)]
+fn behavior_hooks_round_trip_through_interactive_decode() {
+    let questionnaire = HookedProfile::questionnaire().unwrap();
+    let _guard = ResponderGuard::install([
+        PromptResponse::text("docker"),
+        PromptResponse::Skip, // image: blank -> computed default
+    ]);
+    let raw = questionnaire.collect_interactive().unwrap();
+
+    assert_eq!(
+        HookedProfile::from_raw_answers(&raw).unwrap(),
+        HookedProfile {
+            runtime: RuntimeMode::Docker,
+            image: Some("debian:stable".to_string()),
+        }
+    );
+}
+
+#[derive(Debug, Questionnaire)]
+#[question(id = "demo.hooks")]
+#[allow(dead_code)]
+struct HookedProfileRevisionV2 {
+    /// Runtime?
+    #[question(choice)]
+    runtime: RuntimeMode,
+
+    /// Container image?
+    #[question(
+        active_when(field = "runtime", is = "docker"),
+        default_with = image_default_v2,
+        validate = validate_image,
+        revision = "image-hooks-v2"
+    )]
+    image: Option<String>,
+}
+
+#[derive(Debug, Questionnaire)]
+#[question(id = "demo.hooks")]
+#[allow(dead_code)]
+struct HookedProfileValidatorRevisionV2 {
+    /// Runtime?
+    #[question(choice)]
+    runtime: RuntimeMode,
+
+    /// Container image?
+    #[question(
+        active_when(field = "runtime", is = "docker"),
+        default_with = image_default,
+        validate = validate_image_v2,
+        revision = "validator-v2"
+    )]
+    image: Option<String>,
+}
+
+#[test]
+fn hook_revisions_participate_in_the_fingerprint() {
+    let base = HookedProfile::questionnaire().unwrap();
+    let default_revision = HookedProfileRevisionV2::questionnaire().unwrap();
+    let validator_revision = HookedProfileValidatorRevisionV2::questionnaire().unwrap();
+
+    assert_ne!(base.fingerprint(), default_revision.fingerprint());
+    assert_ne!(base.fingerprint(), validator_revision.fingerprint());
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.empty-default-revision")]
+#[allow(dead_code)]
+struct EmptyDefaultRevision {
+    /// Name?
+    #[question(default_with = image_default, revision = "")]
+    name: String,
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.empty-validator-revision")]
+#[allow(dead_code)]
+struct EmptyValidatorRevision {
+    /// Name?
+    #[question(validate = validate_image, revision = "")]
+    name: String,
+}
+
+#[test]
+fn empty_hook_revisions_are_rejected_by_the_builder() {
+    assert!(matches!(
+        EmptyDefaultRevision::questionnaire().unwrap_err(),
+        QuestionnaireError::EmptyDefaultRevision { id } if id == "name"
+    ));
+    assert!(matches!(
+        EmptyValidatorRevision::questionnaire().unwrap_err(),
+        QuestionnaireError::EmptyValidatorRevision { id } if id == "name"
+    ));
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.unknown-controller")]
+#[allow(dead_code)]
+struct UnknownController {
+    /// Name?
+    #[question(active_when(field = "ghost", is = "yes"))]
+    name: String,
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.later-controller")]
+#[allow(dead_code)]
+struct LaterController {
+    /// Name?
+    #[question(active_when(field = "enabled", is = "yes"))]
+    name: String,
+
+    /// Enabled?
+    enabled: bool,
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.scope")]
+#[allow(dead_code)]
+struct ScopedController {
+    /// First?
+    first: ScopedFirst,
+
+    /// Second?
+    second: ScopedSecond,
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.scope.first")]
+#[allow(dead_code)]
+struct ScopedFirst {
+    /// Enabled?
+    enabled: bool,
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.scope.second")]
+#[allow(dead_code)]
+struct ScopedSecond {
+    /// Name?
+    #[question(active_when(field = "first.enabled", is = "yes"))]
+    name: String,
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.never")]
+#[allow(dead_code)]
+struct NeverMatchingController {
+    /// Runtime?
+    #[question(choice)]
+    runtime: RuntimeMode,
+
+    /// Image?
+    #[question(active_when(field = "runtime", is = "podman"))]
+    image: String,
+}
+
+#[test]
+fn active_when_surfaces_builder_controller_diagnostics() {
+    assert!(matches!(
+        UnknownController::questionnaire().unwrap_err(),
+        QuestionnaireError::UnknownConditionController { controller, .. } if controller == "ghost"
+    ));
+    assert!(matches!(
+        LaterController::questionnaire().unwrap_err(),
+        QuestionnaireError::ConditionOrder { controller, .. } if controller == "enabled"
+    ));
+    assert!(matches!(
+        ScopedController::questionnaire().unwrap_err(),
+        QuestionnaireError::ConditionScope { controller, .. } if controller == "first.enabled"
+    ));
+    assert!(matches!(
+        NeverMatchingController::questionnaire().unwrap_err(),
+        QuestionnaireError::InvalidCondition { id, .. } if id == "image"
+    ));
 }
 
 #[test]

--- a/crates/standout-macros/tests/ui/questionnaire/active_when_missing_is.rs
+++ b/crates/standout-macros/tests/ui/questionnaire/active_when_missing_is.rs
@@ -1,0 +1,14 @@
+use standout_macros::Questionnaire;
+
+#[derive(Questionnaire)]
+#[question(id = "demo.active")]
+struct Demo {
+    /// Enabled?
+    enabled: bool,
+
+    /// Name?
+    #[question(active_when(field = "enabled"))]
+    name: String,
+}
+
+fn main() {}

--- a/crates/standout-macros/tests/ui/questionnaire/active_when_missing_is.stderr
+++ b/crates/standout-macros/tests/ui/questionnaire/active_when_missing_is.stderr
@@ -1,0 +1,5 @@
+error: active_when requires field = "..." and is = "..."
+  --> tests/ui/questionnaire/active_when_missing_is.rs:10:45
+   |
+10 |     #[question(active_when(field = "enabled"))]
+   |                                             ^

--- a/crates/standout-macros/tests/ui/questionnaire/active_when_wrong_shape.rs
+++ b/crates/standout-macros/tests/ui/questionnaire/active_when_wrong_shape.rs
@@ -1,0 +1,14 @@
+use standout_macros::Questionnaire;
+
+#[derive(Questionnaire)]
+#[question(id = "demo.active")]
+struct Demo {
+    /// Enabled?
+    enabled: bool,
+
+    /// Name?
+    #[question(active_when = "enabled")]
+    name: String,
+}
+
+fn main() {}

--- a/crates/standout-macros/tests/ui/questionnaire/active_when_wrong_shape.stderr
+++ b/crates/standout-macros/tests/ui/questionnaire/active_when_wrong_shape.stderr
@@ -1,0 +1,5 @@
+error: unknown question attribute: expected id, default, prose, choice, repeated, min, max, active_when, default_with, validate, or revision
+  --> tests/ui/questionnaire/active_when_wrong_shape.rs:10:16
+   |
+10 |     #[question(active_when = "enabled")]
+   |                ^^^^^^^^^^^

--- a/crates/standout-macros/tests/ui/questionnaire/both_defaults.rs
+++ b/crates/standout-macros/tests/ui/questionnaire/both_defaults.rs
@@ -1,0 +1,16 @@
+use standout_input::questionnaire::EarlierAnswers;
+use standout_macros::Questionnaire;
+
+fn dynamic_default(_: &EarlierAnswers<'_>) -> String {
+    "dynamic".to_string()
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.defaults")]
+struct Demo {
+    /// Name?
+    #[question(default = "static", default_with = dynamic_default, revision = "1")]
+    name: String,
+}
+
+fn main() {}

--- a/crates/standout-macros/tests/ui/questionnaire/both_defaults.stderr
+++ b/crates/standout-macros/tests/ui/questionnaire/both_defaults.stderr
@@ -1,0 +1,5 @@
+error: default and default_with cannot be declared on the same field
+  --> tests/ui/questionnaire/both_defaults.rs:12:51
+   |
+12 |     #[question(default = "static", default_with = dynamic_default, revision = "1")]
+   |                                                   ^^^^^^^^^^^^^^^

--- a/crates/standout-macros/tests/ui/questionnaire/default_with_missing_revision.rs
+++ b/crates/standout-macros/tests/ui/questionnaire/default_with_missing_revision.rs
@@ -1,0 +1,16 @@
+use standout_input::questionnaire::EarlierAnswers;
+use standout_macros::Questionnaire;
+
+fn dynamic_default(_: &EarlierAnswers<'_>) -> String {
+    "dynamic".to_string()
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.default")]
+struct Demo {
+    /// Name?
+    #[question(default_with = dynamic_default)]
+    name: String,
+}
+
+fn main() {}

--- a/crates/standout-macros/tests/ui/questionnaire/default_with_missing_revision.stderr
+++ b/crates/standout-macros/tests/ui/questionnaire/default_with_missing_revision.stderr
@@ -1,0 +1,5 @@
+error: default_with and validate require revision = "..."
+  --> tests/ui/questionnaire/default_with_missing_revision.rs:12:31
+   |
+12 |     #[question(default_with = dynamic_default)]
+   |                               ^^^^^^^^^^^^^^^

--- a/crates/standout-macros/tests/ui/questionnaire/validate_missing_revision.rs
+++ b/crates/standout-macros/tests/ui/questionnaire/validate_missing_revision.rs
@@ -1,0 +1,16 @@
+use standout_input::questionnaire::AnswerValue;
+use standout_macros::Questionnaire;
+
+fn validate(_: &AnswerValue) -> Result<(), String> {
+    Ok(())
+}
+
+#[derive(Questionnaire)]
+#[question(id = "demo.validate")]
+struct Demo {
+    /// Name?
+    #[question(validate = validate)]
+    name: String,
+}
+
+fn main() {}

--- a/crates/standout-macros/tests/ui/questionnaire/validate_missing_revision.stderr
+++ b/crates/standout-macros/tests/ui/questionnaire/validate_missing_revision.stderr
@@ -1,0 +1,5 @@
+error: default_with and validate require revision = "..."
+  --> tests/ui/questionnaire/validate_missing_revision.rs:12:27
+   |
+12 |     #[question(validate = validate)]
+   |                           ^^^^^^^^


### PR DESCRIPTION
for #274

## Context

This PR implements only WIZ03 WS04 behavior-hook lowering for `#[derive(Questionnaire)]`: `active_when(...)`, `default_with = path` plus `revision`, and `validate = path` plus `revision`. The approach keeps the derive as a lowering layer into the existing `standout-input` builder: same-struct controller names are resolved to derived IDs, unresolved controller strings are left for the runtime builder so unknown, later-declared, out-of-scope, and never-matching controller diagnostics stay on the existing construction-time path. Dynamic defaults and validators lower to `DynamicDefault::new` and `FieldValidator::new`, so revision fingerprinting and empty-revision validation remain the runtime contract.

Self-check: this diff was checked against `docs/spec/derived-questionnaires.md`, ADR 0015, ADR 0016, and the dynamic-default / validator revision contracts in `crates/standout-input/src/questionnaire/definition.rs`.

Out of scope: command wiring, wizard migration, whole-form rules, inline closures, compile-time cross-field analysis, and any answer-sheet format or runtime semantic changes. Reviewers should not re-open the decided revision-in-fingerprint policy or replace the builder diagnostics with macro-side condition validation.

Verification:
- `cargo test -p standout-macros --test questionnaire_derive`
- `pixi run test`
- commit and push hooks: `pixi run lint`
