### PR TITLE
WIZ03/WS05: Route questionnaire inputs and stabilize captures

### DIFF
--- a/crates/standout-render/src/warnings.rs
+++ b/crates/standout-render/src/warnings.rs
@@ -48,6 +48,14 @@ thread_local! {
     /// warnings come from the main-thread setup path), so a thread-local
     /// is sufficient and avoids the overhead of a mutex.
     static WARNINGS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+
+    /// Warnings drained by the most recent capture-oriented run.
+    ///
+    /// `App::run_to_string` cannot print the warning block, but it still owns
+    /// the run boundary. Stashing the drained batch here makes warnings
+    /// observable to test/capture APIs without letting them leak into the next
+    /// run on the same thread.
+    static CAPTURED_WARNINGS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
 }
 
 /// Appends a framework warning to the thread-local collector.
@@ -65,6 +73,25 @@ pub fn push_warning(message: impl Into<String>) {
 /// at the end of `App::run` to render the batch.
 pub fn drain_warnings() -> Vec<String> {
     WARNINGS.with(|w| std::mem::take(&mut *w.borrow_mut()))
+}
+
+/// Drains pending framework warnings into the captured-run buffer.
+///
+/// This is the capture-mode counterpart to [`flush_to_stderr`]: it ends the
+/// current run's warning batch without writing to stderr. The next call
+/// replaces the previous captured batch, so stale warnings cannot bleed across
+/// consecutive in-process runs.
+pub fn capture_warnings_for_run() {
+    let warnings = drain_warnings();
+    CAPTURED_WARNINGS.with(|captured| {
+        *captured.borrow_mut() = warnings;
+    });
+}
+
+/// Returns and clears the warning batch captured by the most recent
+/// capture-oriented run on this thread.
+pub fn take_captured_warnings() -> Vec<String> {
+    CAPTURED_WARNINGS.with(|captured| std::mem::take(&mut *captured.borrow_mut()))
 }
 
 /// Returns `true` if any warnings are currently buffered for this thread.
@@ -195,6 +222,22 @@ mod tests {
         assert!(!has_warnings());
 
         // Draining again yields nothing.
+        assert!(drain_warnings().is_empty());
+    }
+
+    #[test]
+    fn capture_replaces_previous_batch_and_drains_pending_warnings() {
+        reset();
+        push_warning("first");
+        capture_warnings_for_run();
+        assert_eq!(take_captured_warnings(), vec!["first".to_string()]);
+        assert!(drain_warnings().is_empty());
+
+        push_warning("second");
+        capture_warnings_for_run();
+        push_warning("pending");
+        capture_warnings_for_run();
+        assert_eq!(take_captured_warnings(), vec!["pending".to_string()]);
         assert!(drain_warnings().is_empty());
     }
 

--- a/crates/standout-test/src/lib.rs
+++ b/crates/standout-test/src/lib.rs
@@ -467,11 +467,13 @@ impl TestHarness {
         }
 
         let outcome = app.run_to_string(cmd, argv);
+        let warnings = standout_render::warnings::take_captured_warnings();
 
         // `self` (and its tempdir) move into TestResult so the fixture dir
         // survives until the test is finished with the result.
         TestResult {
             outcome,
+            warnings,
             _tempdir: self.tempdir.take(),
             _restore: restore,
         }
@@ -570,6 +572,7 @@ impl Drop for RestoreState {
 /// accessors and assertion helpers oriented at text output.
 pub struct TestResult {
     outcome: RunResult,
+    warnings: Vec<String>,
     // Kept alive so fixture files remain readable while the test inspects
     // the result; dropped after restore state is torn down.
     _tempdir: Option<TempDir>,
@@ -581,6 +584,16 @@ impl TestResult {
     /// accessors aren't enough.
     pub fn outcome(&self) -> &RunResult {
         &self.outcome
+    }
+
+    /// Returns framework warnings captured during the run.
+    ///
+    /// These are warnings that `App::run` would render to stderr after the
+    /// primary output. The harness drains and stores them per run so warning
+    /// assertions are deterministic and cannot leak into a later test on the
+    /// same thread.
+    pub fn warnings(&self) -> &[String] {
+        &self.warnings
     }
 
     /// Returns the completed run's typed shell status.
@@ -853,6 +866,19 @@ impl TestResult {
                 expected, out
             );
         }
+    }
+
+    /// Panics unless the captured framework warnings contain `needle`.
+    #[track_caller]
+    pub fn assert_warning_contains(&self, needle: &str) {
+        if self.warnings.iter().any(|warning| warning.contains(needle)) {
+            return;
+        }
+        panic!(
+            "warnings did not contain {:?}\n--- warnings ---\n{}\n----------------",
+            needle,
+            self.warnings.join("\n")
+        );
     }
 }
 

--- a/crates/standout-test/tests/questionnaire_command_surface.rs
+++ b/crates/standout-test/tests/questionnaire_command_surface.rs
@@ -156,6 +156,37 @@ fn stdin_answers_decode_through_shared_pipeline() {
 
 #[test]
 #[serial(questionnaire)]
+fn answer_sheet_warnings_are_captured_and_do_not_leak() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let app = derived_app(calls);
+
+    let warned = TestHarness::new()
+        .fixture(
+            "answers.txt",
+            answered_sheet("name with <id:fragment> suffix"),
+        )
+        .run(
+            &app,
+            command(),
+            ["fixture", "collect", "--answers", "answers.txt", "--yes"],
+        );
+
+    warned.assert_success();
+    warned.assert_warning_contains("answer sheet answers.txt");
+    warned.assert_warning_contains("name");
+
+    let clean = TestHarness::new()
+        .prompts(Arc::new(ScriptedResponder::new([PromptResponse::text(
+            "interactive",
+        )])))
+        .run(&app, command(), ["fixture", "collect", "--yes"]);
+
+    clean.assert_success();
+    assert!(clean.warnings().is_empty(), "{:?}", clean.warnings());
+}
+
+#[test]
+#[serial(questionnaire)]
 fn terminal_stdin_is_rejected_for_explicit_answers_dash() {
     let calls = Arc::new(AtomicUsize::new(0));
     let app = derived_app(calls.clone());

--- a/crates/standout/src/cli/builder/execution.rs
+++ b/crates/standout/src/cli/builder/execution.rs
@@ -421,10 +421,11 @@ impl AppBuilder {
     /// and exits with its typed status: Clap usage errors use 2, runtime
     /// failures use 1, and an application-declared `ExternalFailure` preserves
     /// its exact nonzero status and verbatim diagnostic. Final text and binary
-    /// writes are framework-owned; a write failure is diagnosed on stderr and exits 1.
-    /// Callers needing fine-grained control over exit codes should use
-    /// [`Self::run_to_string`] or [`Self::dispatch_from`] and match on
-    /// `RunResult` themselves.
+    /// writes are framework-owned; a write failure is diagnosed on stderr and exits 1,
+    /// except that a text stdout `BrokenPipe` is treated as successful early
+    /// consumer termination. Callers needing fine-grained control over exit
+    /// codes should use [`Self::run_to_string`] or [`Self::dispatch_from`] and
+    /// match on `RunResult` themselves.
     ///
     /// # Example
     ///
@@ -479,6 +480,10 @@ impl AppBuilder {
     ///
     /// Similar to `run()`, but returns the output instead of printing it.
     /// Useful for testing or when you need to capture and process the output.
+    /// Framework warnings queued during the run are drained into
+    /// [`standout_render::warnings::take_captured_warnings`] instead of
+    /// printing to stderr, so consecutive in-process runs do not leak warnings
+    /// into each other.
     ///
     /// # Returns
     ///
@@ -515,7 +520,9 @@ impl AppBuilder {
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
     {
-        self.dispatch_from(cmd, args)
+        let result = self.dispatch_from(cmd, args);
+        standout_render::warnings::capture_warnings_for_run();
+        result
     }
 
     /// Augments a command for dispatch (adds --output flag without help subcommand).
@@ -776,12 +783,7 @@ fn emit_run_result<W: Write, E: Write>(
         RunResult::Handled(output) => writeln!(stdout, "{}", output)
             .and_then(|()| stdout.flush())
             .err()
-            .map(|error| {
-                RunError::new(
-                    format!("Error writing stdout: {}", error),
-                    RunErrorKind::FinalWrite(OutputKind::Text),
-                )
-            }),
+            .and_then(|error| final_write_error_unless_broken_pipe(error, OutputKind::Text)),
         RunResult::Binary(bytes, _) => stdout
             .write_all(bytes)
             .and_then(|()| stdout.flush())
@@ -818,6 +820,20 @@ fn emit_run_result<W: Write, E: Write>(
         let _ = writeln!(stderr, "{}", error).and_then(|()| stderr.flush());
     }
     (true, failure)
+}
+
+fn final_write_error_unless_broken_pipe(
+    error: std::io::Error,
+    kind: OutputKind,
+) -> Option<RunError> {
+    if kind == OutputKind::Text && error.kind() == std::io::ErrorKind::BrokenPipe {
+        None
+    } else {
+        Some(RunError::new(
+            format!("Error writing stdout: {}", error),
+            RunErrorKind::FinalWrite(kind),
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -2754,21 +2770,20 @@ header:
     }
 
     #[test]
-    fn final_text_and_binary_write_failures_keep_payload_kind() {
+    fn final_text_broken_pipe_is_successful_early_termination() {
         let mut stderr = Vec::new();
         let (_, text_failure) = emit_run_result(
             &RunResult::Handled(RunOutput::command("hello")),
             &mut FailingWriter,
             &mut stderr,
         );
-        let text_failure = text_failure.unwrap();
-        assert_eq!(
-            text_failure.kind(),
-            RunErrorKind::FinalWrite(OutputKind::Text)
-        );
-        assert_eq!(text_failure.exit_status(), crate::cli::ExitStatus::FAILURE);
+        assert!(text_failure.is_none());
+        assert!(stderr.is_empty());
+    }
 
-        stderr.clear();
+    #[test]
+    fn final_binary_write_failures_keep_payload_kind() {
+        let mut stderr = Vec::new();
         let (_, binary_failure) = emit_run_result(
             &RunResult::Binary(vec![0, 1], "data.bin".into()),
             &mut FailingWriter,
@@ -2786,7 +2801,7 @@ header:
     }
 
     #[test]
-    fn final_text_and_binary_flush_failures_keep_payload_kind() {
+    fn final_text_broken_pipe_flush_is_successful_early_termination() {
         let mut text_stdout = FlushFailingWriter::default();
         let (_, text_failure) = emit_run_result(
             &RunResult::Handled(RunOutput::command("hello")),
@@ -2794,11 +2809,11 @@ header:
             &mut Vec::new(),
         );
         assert_eq!(text_stdout.bytes, b"hello\n");
-        assert_eq!(
-            text_failure.unwrap().kind(),
-            RunErrorKind::FinalWrite(OutputKind::Text)
-        );
+        assert!(text_failure.is_none());
+    }
 
+    #[test]
+    fn final_binary_flush_failures_keep_payload_kind() {
         let mut binary_stdout = FlushFailingWriter::default();
         let (_, binary_failure) = emit_run_result(
             &RunResult::Binary(vec![0, 1], "data.bin".into()),

--- a/crates/standout/src/cli/builder/execution.rs
+++ b/crates/standout/src/cli/builder/execution.rs
@@ -422,10 +422,10 @@ impl AppBuilder {
     /// failures use 1, and an application-declared `ExternalFailure` preserves
     /// its exact nonzero status and verbatim diagnostic. Final text and binary
     /// writes are framework-owned; a write failure is diagnosed on stderr and exits 1,
-    /// except that a text stdout `BrokenPipe` is treated as successful early
-    /// consumer termination. Callers needing fine-grained control over exit
-    /// codes should use [`Self::run_to_string`] or [`Self::dispatch_from`] and
-    /// match on `RunResult` themselves.
+    /// except that `BrokenPipe` while writing final rendered command text to stdout
+    /// is treated as successful early consumer termination. Callers needing
+    /// fine-grained control over exit codes should use [`Self::run_to_string`] or
+    /// [`Self::dispatch_from`] and match on `RunResult` themselves.
     ///
     /// # Example
     ///

--- a/crates/standout/src/cli/questionnaire.rs
+++ b/crates/standout/src/cli/questionnaire.rs
@@ -17,7 +17,9 @@ use standout_input::questionnaire::{
     AnswerSheetDiagnostic, FormError, Questionnaire, QuestionnaireInput, QuestionnaireInputError,
     RawAnswers,
 };
-use standout_input::{InputError, InputSourceKind, Inputs, ResolvedInput};
+use standout_input::{
+    InputChain, InputCollector, InputError, InputSourceKind, Inputs, ResolvedInput,
+};
 
 use crate::cli::dispatch::get_deepest_matches;
 use crate::cli::handler::{CommandContext, RunError, RunErrorKind};
@@ -132,59 +134,142 @@ where
     let questionnaire = T::questionnaire()
         .map_err(|error| InputError::validation(format!("definition is invalid: {error}")))?;
 
-    if let Some(path) = matches.get_one::<String>(ANSWERS_ARG_ID) {
-        let source = if path == "-" {
-            AnswerSource::Stdin
-        } else {
-            AnswerSource::File(PathBuf::from(path))
-        };
-        let raw = source.raw_answers(&questionnaire).map_err(|diagnostics| {
-            InputError::validation(format_diagnostics(source.label(), &diagnostics))
-        })?;
-        push_raw_answer_warnings(source.label(), raw.warnings());
-        let value = T::from_raw_answers_with(&raw, form).map_err(questionnaire_input_error)?;
-        return Ok(ResolvedInput {
-            value,
-            source: source.kind(),
-        });
-    }
+    let submission = InputChain::new()
+        .try_source_with_kind(
+            QuestionnaireFileSource::new(questionnaire.clone()),
+            InputSourceKind::Flag,
+        )
+        .try_source(QuestionnaireStdinSource::new(questionnaire.clone()))
+        .try_source(InteractiveQuestionnaireSource::new(questionnaire))
+        .resolve_with_source(matches)?;
 
-    let raw = questionnaire.collect_interactive()?;
-    let value = T::from_raw_answers_with(&raw, form).map_err(questionnaire_input_error)?;
+    if let Some(label) = &submission.value.warning_label {
+        push_raw_answer_warnings(label.clone(), submission.value.raw.warnings());
+    }
+    let value =
+        T::from_raw_answers_with(&submission.value.raw, form).map_err(questionnaire_input_error)?;
     Ok(ResolvedInput {
         value,
-        source: InputSourceKind::Prompt,
+        source: submission.source,
     })
 }
 
-enum AnswerSource {
-    File(PathBuf),
-    Stdin,
+#[derive(Clone)]
+struct QuestionnaireSubmission {
+    raw: RawAnswers,
+    warning_label: Option<String>,
 }
 
-impl AnswerSource {
-    fn label(&self) -> String {
-        match self {
-            Self::File(path) => path.display().to_string(),
-            Self::Stdin => "from stdin".to_string(),
-        }
+struct QuestionnaireFileSource {
+    questionnaire: Questionnaire,
+}
+
+impl QuestionnaireFileSource {
+    fn new(questionnaire: Questionnaire) -> Self {
+        Self { questionnaire }
+    }
+}
+
+impl InputCollector<QuestionnaireSubmission> for QuestionnaireFileSource {
+    fn name(&self) -> &'static str {
+        "flag"
     }
 
-    fn kind(&self) -> InputSourceKind {
-        match self {
-            Self::File(_) => InputSourceKind::Flag,
-            Self::Stdin => InputSourceKind::Stdin,
-        }
+    fn is_available(&self, matches: &ArgMatches) -> bool {
+        matches
+            .get_one::<String>(ANSWERS_ARG_ID)
+            .is_some_and(|path| path != "-")
     }
 
-    fn raw_answers(
-        &self,
-        questionnaire: &Questionnaire,
-    ) -> Result<RawAnswers, Vec<AnswerSheetDiagnostic>> {
-        match self {
-            Self::File(path) => questionnaire.read_answer_sheet_file(path),
-            Self::Stdin => questionnaire.read_answer_sheet_stdin_with(&DefaultStdin),
+    fn collect(&self, matches: &ArgMatches) -> Result<Option<QuestionnaireSubmission>, InputError> {
+        let Some(path) = matches.get_one::<String>(ANSWERS_ARG_ID) else {
+            return Ok(None);
+        };
+        if path == "-" {
+            return Ok(None);
         }
+        let path = PathBuf::from(path);
+        let label = path.display().to_string();
+        let raw = self
+            .questionnaire
+            .read_answer_sheet_file(&path)
+            .map_err(|diagnostics| {
+                InputError::validation(format_diagnostics(label.clone(), &diagnostics))
+            })?;
+        Ok(Some(QuestionnaireSubmission {
+            raw,
+            warning_label: Some(label),
+        }))
+    }
+}
+
+struct QuestionnaireStdinSource {
+    questionnaire: Questionnaire,
+}
+
+impl QuestionnaireStdinSource {
+    fn new(questionnaire: Questionnaire) -> Self {
+        Self { questionnaire }
+    }
+}
+
+impl InputCollector<QuestionnaireSubmission> for QuestionnaireStdinSource {
+    fn name(&self) -> &'static str {
+        "stdin"
+    }
+
+    fn is_available(&self, matches: &ArgMatches) -> bool {
+        matches
+            .get_one::<String>(ANSWERS_ARG_ID)
+            .is_some_and(|path| path == "-")
+    }
+
+    fn collect(&self, matches: &ArgMatches) -> Result<Option<QuestionnaireSubmission>, InputError> {
+        if !self.is_available(matches) {
+            return Ok(None);
+        }
+        let label = "from stdin".to_string();
+        let raw = self
+            .questionnaire
+            .read_answer_sheet_stdin_with(&DefaultStdin)
+            .map_err(|diagnostics| {
+                InputError::validation(format_diagnostics(label.clone(), &diagnostics))
+            })?;
+        Ok(Some(QuestionnaireSubmission {
+            raw,
+            warning_label: Some(label),
+        }))
+    }
+}
+
+struct InteractiveQuestionnaireSource {
+    questionnaire: Questionnaire,
+}
+
+impl InteractiveQuestionnaireSource {
+    fn new(questionnaire: Questionnaire) -> Self {
+        Self { questionnaire }
+    }
+}
+
+impl InputCollector<QuestionnaireSubmission> for InteractiveQuestionnaireSource {
+    fn name(&self) -> &'static str {
+        "prompt"
+    }
+
+    fn is_available(&self, matches: &ArgMatches) -> bool {
+        matches.get_one::<String>(ANSWERS_ARG_ID).is_none()
+    }
+
+    fn collect(&self, matches: &ArgMatches) -> Result<Option<QuestionnaireSubmission>, InputError> {
+        if !self.is_available(matches) {
+            return Ok(None);
+        }
+        let raw = self.questionnaire.collect_interactive()?;
+        Ok(Some(QuestionnaireSubmission {
+            raw,
+            warning_label: None,
+        }))
     }
 }
 

--- a/crates/standout/tests/new_project_answer_sheets.rs
+++ b/crates/standout/tests/new_project_answer_sheets.rs
@@ -162,6 +162,26 @@ fn questions_renders_a_deterministic_sheet_and_generates_nothing() {
 }
 
 #[test]
+fn questions_stdout_broken_pipe_is_successful_early_termination() {
+    let dir = TempDir::new().unwrap();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_standout"))
+        .current_dir(dir.path())
+        .arg("new-project")
+        .arg("questions")
+        .env(TERMINAL_SEAM_VAR, "absent")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    drop(child.stdout.take());
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    assert!(stderr(&output).is_empty());
+    assert!(dir_entries(dir.path()).is_empty());
+}
+
+#[test]
 fn questions_writes_the_same_sheet_to_a_named_file() {
     let dir = TempDir::new().unwrap();
 

--- a/crates/standout/tests/process_outcomes.rs
+++ b/crates/standout/tests/process_outcomes.rs
@@ -211,22 +211,31 @@ fn real_process_status_and_stream_matrix() {
 }
 
 #[test]
-fn real_process_reports_broken_text_and_binary_stdout() {
+fn real_process_accepts_broken_text_stdout_but_reports_binary_stdout() {
     let binary = fixture_binary();
-    for command in ["huge", "binary-huge"] {
-        let mut child = Command::new(&binary)
-            .arg(command)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
-        drop(child.stdout.take());
-        let output = child.wait_with_output().unwrap();
-        assert_eq!(output.status.code(), Some(1), "command: {command}");
-        assert!(
-            String::from_utf8_lossy(&output.stderr).contains("Error writing"),
-            "command: {command}, stderr: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    let mut text_child = Command::new(&binary)
+        .arg("huge")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    drop(text_child.stdout.take());
+    let text_output = text_child.wait_with_output().unwrap();
+    assert_eq!(text_output.status.code(), Some(0));
+    assert!(text_output.stderr.is_empty());
+
+    let mut binary_child = Command::new(&binary)
+        .arg("binary-huge")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    drop(binary_child.stdout.take());
+    let binary_output = binary_child.wait_with_output().unwrap();
+    assert_eq!(binary_output.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&binary_output.stderr).contains("Error writing"),
+        "stderr: {}",
+        String::from_utf8_lossy(&binary_output.stderr)
+    );
 }

--- a/docs/topics/execution-outcomes.md
+++ b/docs/topics/execution-outcomes.md
@@ -22,8 +22,8 @@ runtime failure.
 
 Warning flushing happens after the primary output and does not replace its
 status. A final text or binary write failure does replace a successful status
-with `1`, except that `BrokenPipe` while writing text stdout is successful early
-consumer termination.
+with `1`, except that `BrokenPipe` while writing final rendered command text to
+stdout is successful early consumer termination.
 
 ## Capturing typed metadata
 
@@ -72,10 +72,12 @@ command and its eventual status.
 
 `run()` writes successful text and binary bytes to stdout, diagnostics to
 stderr, and exits with the typed non-zero status when execution fails. A closed
-downstream text pipe is not an error: `BrokenPipe` while writing rendered text
-means the consumer stopped reading early. The suggested filename on binary
-output remains available to capture callers; use `--output-file-path` when the
-framework should write either text or binary to a file instead of stdout.
+downstream pipe is not an error only for final rendered command text:
+`BrokenPipe` there means the consumer stopped reading early. Binary stdout
+writes and artifact report writes keep their typed final-write failures. The
+suggested filename on binary output remains available to capture callers; use
+`--output-file-path` when the framework should write either text or binary to a
+file instead of stdout.
 
 Capture APIs do not perform the final stdout/stderr write, but file redirection
 is part of dispatch and therefore reports typed `FinalWrite` failures directly.

--- a/docs/topics/execution-outcomes.md
+++ b/docs/topics/execution-outcomes.md
@@ -22,7 +22,8 @@ runtime failure.
 
 Warning flushing happens after the primary output and does not replace its
 status. A final text or binary write failure does replace a successful status
-with `1`.
+with `1`, except that `BrokenPipe` while writing text stdout is successful early
+consumer termination.
 
 ## Capturing typed metadata
 
@@ -70,10 +71,11 @@ command and its eventual status.
 ## Framework-owned final writes
 
 `run()` writes successful text and binary bytes to stdout, diagnostics to
-stderr, and exits with the typed non-zero status when execution fails. The
-suggested filename on binary output remains available to capture callers; use
-`--output-file-path` when the framework should write either text or binary to a
-file instead of stdout.
+stderr, and exits with the typed non-zero status when execution fails. A closed
+downstream text pipe is not an error: `BrokenPipe` while writing rendered text
+means the consumer stopped reading early. The suggested filename on binary
+output remains available to capture callers; use `--output-file-path` when the
+framework should write either text or binary to a file instead of stdout.
 
 Capture APIs do not perform the final stdout/stderr write, but file redirection
 is part of dispatch and therefore reports typed `FinalWrite` failures directly.


### PR DESCRIPTION
for #275

## Context

This follow-up closes the three WIZ03 convergence gaps from issue #275. Questionnaire answer resolution now flows through small `InputCollector` sources composed by `InputChain`, preserving the existing framework-injected command surface while avoiding a bespoke file/stdin/interactive switch in the pre-dispatch helper. Text stdout `BrokenPipe` is treated as successful early consumer termination so generated question output can be piped to consumers like `head`/`jq`; binary stdout keeps the existing typed final-write failure. `run_to_string` now drains framework warnings into a captured warning batch, and `TestHarness` exposes those warnings per run so they cannot leak into later in-process runs.

Self-check: I checked `docs/spec/questionnaire-answer-sheets.md`, `docs/spec/derived-questionnaires.md`, ADR-0014, ADR-0015, and ADR-0017 before opening this PR. I also updated `docs/topics/execution-outcomes.md` for the BrokenPipe contract change.

Brief gap: the spawned brief named issue #275 and the verification target, but it did not explicitly name governing docs or decision boundaries. I treated the WIZ02/WIZ03 questionnaire specs and ADRs above as governing docs.

Out of scope: no answer-sheet format, fingerprint, confirmation-gate policy, generated-project input wiring, or questionnaire derive semantics are changed. Review should not reopen those WIZ03 decisions here.

Verification:
- `cargo test -p standout-test --test questionnaire_command_surface answer_sheet_warnings_are_captured_and_do_not_leak`
- `cargo test -p standout --test process_outcomes real_process_accepts_broken_text_stdout_but_reports_binary_stdout`
- `cargo test -p standout --test new_project_answer_sheets questions_stdout_broken_pipe_is_successful_early_termination`
- `cargo test -p standout --lib final_text_broken_pipe`
- `pixi run lint --fix`
- `pixi run test`
- commit and push hooks: `pixi run lint`
