### PR TITLE
STANDOUT-WIZ03-WS04: Epic: Derived Questionnaires - Workstream: Behavior hooks: nested controller resolution

### DIFF
--- a/crates/standout-input/src/questionnaire/derive.rs
+++ b/crates/standout-input/src/questionnaire/derive.rs
@@ -71,9 +71,12 @@ impl std::error::Error for QuestionnaireChoiceParseError {}
 ///   field decoding, defaults, conditions, and validators on the shared
 ///   runtime path.
 ///
-/// The derive also emits hidden, prefix-aware helpers used to lower and fill
-/// nested questionnaire structs. They keep nested fields on the same stable
-/// group-prefix and occurrence-path model as the public runtime definition.
+/// The derive also emits hidden helpers used to lower and fill nested
+/// questionnaire structs. They keep nested fields on the same stable
+/// group-prefix and occurrence-path model as the public runtime definition,
+/// and carry enclosing Rust field-name mappings so `active_when` attributes
+/// in nested structs can lower to the same definition IDs a hand-built
+/// questionnaire would use.
 pub trait QuestionnaireInput: Sized {
     /// Construct the runtime questionnaire definition for this type.
     ///
@@ -110,6 +113,22 @@ pub trait QuestionnaireInput: Sized {
             .expect("manual QuestionnaireInput implementation cannot be nested unless questionnaire_items is overridden")
             .items()
             .to_vec()
+    }
+
+    /// Build this type's items under `prefix`, with controller mappings
+    /// inherited from enclosing derived structs.
+    ///
+    /// Generated implementations use `inherited_controllers` to resolve
+    /// `active_when(field = "...")` references to enclosing Rust field names
+    /// before handing the condition to the runtime builder. Manual
+    /// implementations normally keep the default behavior.
+    #[doc(hidden)]
+    fn questionnaire_items_with_context(
+        prefix: &str,
+        inherited_controllers: &[(&'static str, String)],
+    ) -> Vec<Item> {
+        let _ = inherited_controllers;
+        Self::questionnaire_items(prefix)
     }
 
     /// Fill this type from answers rooted at `prefix`.

--- a/crates/standout-macros/src/questionnaire/mod.rs
+++ b/crates/standout-macros/src/questionnaire/mod.rs
@@ -372,9 +372,9 @@ pub fn questionnaire_derive_impl(input: DeriveInput) -> Result<TokenStream> {
 
             fn questionnaire_items_with_context(
                 __prefix: &str,
-                __inherited_controllers: &[(&'static str, String)],
+                __inherited_controllers: &[(&'static str, ::std::string::String)],
             ) -> ::std::vec::Vec<::standout_input::questionnaire::Item> {
-                let mut __controller_ids: ::std::vec::Vec<(&'static str, String)> = vec![
+                let mut __controller_ids: ::std::vec::Vec<(&'static str, ::std::string::String)> = vec![
                     #(#controller_map_entries),*
                 ];
                 __controller_ids.extend_from_slice(__inherited_controllers);

--- a/crates/standout-macros/src/questionnaire/mod.rs
+++ b/crates/standout-macros/src/questionnaire/mod.rs
@@ -317,6 +317,18 @@ pub fn questionnaire_derive_impl(input: DeriveInput) -> Result<TokenStream> {
             Ok((ident.to_string(), id))
         })
         .collect::<Result<Vec<_>>>()?;
+    let controller_map_entries = field_ids.iter().map(|(name, id)| {
+        quote! {
+            (
+                #name,
+                if __prefix.is_empty() {
+                    #id.to_string()
+                } else {
+                    ::std::format!("{}.{}", __prefix, #id)
+                },
+            )
+        }
+    });
 
     for field in fields {
         let info = FieldInfo::new(field)?;
@@ -326,7 +338,7 @@ pub fn questionnaire_derive_impl(input: DeriveInput) -> Result<TokenStream> {
                 format!("duplicate question id '{}'", info.id),
             ));
         }
-        builder_fields.push(info.builder_tokens(&field_ids));
+        builder_fields.push(info.builder_tokens());
         fill_fields.push(info.fill_tokens());
     }
 
@@ -352,6 +364,20 @@ pub fn questionnaire_derive_impl(input: DeriveInput) -> Result<TokenStream> {
             }
 
             fn questionnaire_items(__prefix: &str) -> ::std::vec::Vec<::standout_input::questionnaire::Item> {
+                <Self as ::standout_input::questionnaire::QuestionnaireInput>::questionnaire_items_with_context(
+                    __prefix,
+                    &[],
+                )
+            }
+
+            fn questionnaire_items_with_context(
+                __prefix: &str,
+                __inherited_controllers: &[(&'static str, String)],
+            ) -> ::std::vec::Vec<::standout_input::questionnaire::Item> {
+                let mut __controller_ids: ::std::vec::Vec<(&'static str, String)> = vec![
+                    #(#controller_map_entries),*
+                ];
+                __controller_ids.extend_from_slice(__inherited_controllers);
                 vec![
                     #(#builder_fields),*
                 ]
@@ -607,11 +633,11 @@ impl FieldInfo {
         })
     }
 
-    fn builder_tokens(&self, field_ids: &[(String, String)]) -> TokenStream {
+    fn builder_tokens(&self) -> TokenStream {
         let id = prefixed_id_tokens(&self.id);
         let prompt = &self.prompt;
         let active_when = self.active_when.as_ref().map(|active_when| {
-            let controller = controller_id_tokens(active_when, field_ids);
+            let controller = controller_id_tokens(active_when);
             let expected = &active_when.expected;
             quote! { .active_when(#controller, #expected) }
         });
@@ -692,7 +718,10 @@ impl FieldInfo {
                     ::standout_input::questionnaire::Group::new(
                         __group_id.clone(),
                         #prompt,
-                        <#ty as ::standout_input::questionnaire::QuestionnaireInput>::questionnaire_items(&__group_id),
+                        <#ty as ::standout_input::questionnaire::QuestionnaireInput>::questionnaire_items_with_context(
+                            &__group_id,
+                            &__controller_ids,
+                        ),
                     )
                     .into()
                 }
@@ -705,7 +734,10 @@ impl FieldInfo {
                         ::standout_input::questionnaire::Group::new(
                             __group_id.clone(),
                             #prompt,
-                            <#ty as ::standout_input::questionnaire::QuestionnaireInput>::questionnaire_items(&__group_id),
+                            <#ty as ::standout_input::questionnaire::QuestionnaireInput>::questionnaire_items_with_context(
+                                &__group_id,
+                                &__controller_ids,
+                            ),
                         )
                         #repeat
                         .into()
@@ -1070,19 +1102,13 @@ fn prefixed_id_tokens(id: &str) -> TokenStream {
     }
 }
 
-fn controller_id_tokens(
-    active_when: &ActiveWhenAttr,
-    field_ids: &[(String, String)],
-) -> TokenStream {
-    let controller = field_ids
-        .iter()
-        .find_map(|(name, id)| (name == &active_when.field).then_some(id.as_str()));
-    match controller {
-        Some(id) => prefixed_id_tokens(id),
-        None => {
-            let controller = &active_when.field;
-            quote! { #controller.to_string() }
-        }
+fn controller_id_tokens(active_when: &ActiveWhenAttr) -> TokenStream {
+    let controller = &active_when.field;
+    quote! {
+        __controller_ids
+            .iter()
+            .find_map(|(__name, __id)| (*__name == #controller).then_some(__id.clone()))
+            .unwrap_or_else(|| #controller.to_string())
     }
 }
 

--- a/crates/standout-macros/tests/questionnaire_derive.rs
+++ b/crates/standout-macros/tests/questionnaire_derive.rs
@@ -939,6 +939,142 @@ fn inactive_optional_conditional_scalar_and_choice_fields_fill_as_none() {
     );
 }
 
+#[derive(Debug, PartialEq, Eq, Questionnaire)]
+#[question(id = "demo.nested.controllers")]
+struct NestedControllerPlan {
+    /// Global runtime?
+    #[question(id = "global.runtime", choice)]
+    global_runtime: RuntimeMode,
+
+    /// Services?
+    #[question(min = 2, max = 2)]
+    services: Vec<NestedControllerService>,
+}
+
+#[derive(Debug, PartialEq, Eq, Questionnaire)]
+#[question(id = "demo.nested.controllers.service")]
+struct NestedControllerService {
+    /// Service runtime?
+    #[question(id = "service.runtime", choice)]
+    runtime: RuntimeMode,
+
+    /// Details?
+    details: NestedControllerDetails,
+}
+
+#[derive(Debug, PartialEq, Eq, Questionnaire)]
+#[question(id = "demo.nested.controllers.details")]
+struct NestedControllerDetails {
+    /// Image inherited from the global runtime?
+    #[question(active_when(field = "global_runtime", is = "docker"))]
+    inherited_image: Option<String>,
+
+    /// Image inherited from the current service runtime?
+    #[question(active_when(field = "runtime", is = "docker"))]
+    service_image: Option<String>,
+}
+
+fn hand_built_nested_controller_plan() -> RuntimeQuestionnaire {
+    use standout_input::questionnaire::{Group, Item};
+
+    RuntimeQuestionnaire::new(
+        "demo.nested.controllers",
+        vec![
+            Item::from(
+                ScalarField::new("global.runtime", "Global runtime?", ScalarKind::String)
+                    .one_of(["local", "docker"]),
+            ),
+            Item::from(
+                Group::new(
+                    "services",
+                    "Services?",
+                    vec![
+                        Item::from(
+                            ScalarField::new(
+                                "services.service.runtime",
+                                "Service runtime?",
+                                ScalarKind::String,
+                            )
+                            .one_of(["local", "docker"]),
+                        ),
+                        Item::from(Group::new(
+                            "services.details",
+                            "Details?",
+                            vec![
+                                ScalarField::new(
+                                    "services.details.inherited_image",
+                                    "Image inherited from the global runtime?",
+                                    ScalarKind::String,
+                                )
+                                .optional()
+                                .active_when("global.runtime", "docker"),
+                                ScalarField::new(
+                                    "services.details.service_image",
+                                    "Image inherited from the current service runtime?",
+                                    ScalarKind::String,
+                                )
+                                .optional()
+                                .active_when("services.service.runtime", "docker"),
+                            ],
+                        )),
+                    ],
+                )
+                .repeatable(2)
+                .max_occurrences(2),
+            ),
+        ],
+    )
+    .unwrap()
+}
+
+#[test]
+fn nested_active_when_resolves_enclosing_rust_field_names_to_stable_ids() {
+    let derived = NestedControllerPlan::questionnaire().unwrap();
+    let hand_built = hand_built_nested_controller_plan();
+
+    assert_eq!(derived, hand_built);
+    assert_eq!(derived.fingerprint(), hand_built.fingerprint());
+}
+
+#[test]
+fn nested_active_when_uses_the_current_repeated_group_occurrence() {
+    let questionnaire = NestedControllerPlan::questionnaire().unwrap();
+    let sheet = answer(
+        &questionnaire.render_answer_sheet(),
+        "global.runtime",
+        "docker",
+    );
+    let sheet = answer_occurrence(&sheet, "services.service.runtime", 0, "docker");
+    let sheet = answer_occurrence(&sheet, "services.details.inherited_image", 0, "global-one");
+    let sheet = answer_occurrence(&sheet, "services.details.service_image", 0, "service-one");
+    let sheet = answer_occurrence(&sheet, "services.service.runtime", 1, "local");
+    let sheet = answer_occurrence(&sheet, "services.details.inherited_image", 1, "global-two");
+    let raw = questionnaire.parse_answer_sheet(&sheet).unwrap();
+
+    assert_eq!(
+        NestedControllerPlan::from_raw_answers(&raw).unwrap(),
+        NestedControllerPlan {
+            global_runtime: RuntimeMode::Docker,
+            services: vec![
+                NestedControllerService {
+                    runtime: RuntimeMode::Docker,
+                    details: NestedControllerDetails {
+                        inherited_image: Some("global-one".to_string()),
+                        service_image: Some("service-one".to_string()),
+                    },
+                },
+                NestedControllerService {
+                    runtime: RuntimeMode::Local,
+                    details: NestedControllerDetails {
+                        inherited_image: Some("global-two".to_string()),
+                        service_image: None,
+                    },
+                },
+            ],
+        }
+    );
+}
+
 #[derive(Questionnaire)]
 #[question(id = "demo.empty-default-revision")]
 #[allow(dead_code)]

--- a/crates/standout-macros/tests/questionnaire_derive.rs
+++ b/crates/standout-macros/tests/questionnaire_derive.rs
@@ -1075,6 +1075,40 @@ fn nested_active_when_uses_the_current_repeated_group_occurrence() {
     );
 }
 
+mod shadowed_string_hygiene {
+    use super::*;
+
+    #[allow(dead_code)]
+    type String = PathBuf;
+
+    #[derive(Questionnaire)]
+    #[question(id = "demo.shadowed-string")]
+    #[allow(dead_code)]
+    struct ShadowedRoot {
+        /// Enabled?
+        enabled: bool,
+
+        /// Child?
+        child: ShadowedChild,
+    }
+
+    #[derive(Questionnaire)]
+    #[question(id = "demo.shadowed-string.child")]
+    #[allow(dead_code)]
+    struct ShadowedChild {
+        /// Visible?
+        #[question(active_when(field = "enabled", is = "yes"))]
+        visible: Option<bool>,
+    }
+
+    #[test]
+    fn generated_context_uses_std_string_when_string_is_shadowed() {
+        let questionnaire = ShadowedRoot::questionnaire().unwrap();
+
+        assert_eq!(questionnaire.id(), "demo.shadowed-string");
+    }
+}
+
 #[derive(Questionnaire)]
 #[question(id = "demo.empty-default-revision")]
 #[allow(dead_code)]


### PR DESCRIPTION
for #274

## Context

This is the WIZ03 WS04 convergence follow-up requested on issue #274 after the initial behavior-hook PR merged. The fix keeps `#[derive(Questionnaire)]` as a lowering layer into the existing `standout-input` builder, but generated nested lowering now carries an inherited Rust field-name to definition-ID map. That lets `active_when(field = "...")` in nested and repeated derived structs resolve enclosing Rust field names to the stable IDs the hand-built builder definition would use, including renamed ancestors and controllers in the current repeated-group occurrence. Unresolved names still flow to the runtime builder as literals, so unknown, later-declared, out-of-scope, and never-matching controller diagnostics stay on the existing construction-time path.

Self-check: this diff was checked against `docs/spec/derived-questionnaires.md`, ADR 0015, ADR 0016, and the dynamic-default / validator revision contracts in `crates/standout-input/src/questionnaire/definition.rs`. The implementer brief slots were present in issue #274; this PR also follows the issue comment requesting inherited controller context after WS02 integration.

Out of scope: command wiring, wizard changes, whole-form rules, inline closures, compile-time cross-field analysis, and any runtime condition semantic changes. Reviewers should not re-open the decided builder-diagnostic boundary or replace inherited name lowering with macro-side condition validation.

Verification:
- `cargo test -p standout-macros --test questionnaire_derive`
- `pixi run lint --fix` after the first commit hook reported rustfmt-only drift
- `pixi run test` passed after formatting: 2,090 tests
- commit and push hooks: `pixi run lint` passed with 31 checks

Note: one intermediate full `pixi run test` attempt hit a transient `standout::process_outcomes real_process_status_and_stream_matrix` example-binary lookup failure; the test passed when rerun directly, and the final full `pixi run test` passed afterward.