### PR TITLE
STANDOUT-WIZ03-WS06: Epic: Derived Questionnaires - Workstream: Wizard rewrite as reference client

### DIFF
--- a/crates/standout/src/bin/standout.rs
+++ b/crates/standout/src/bin/standout.rs
@@ -2155,8 +2155,29 @@ cargo test --workspace
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+    use standout_input::{
+        reset_default_prompt_responder, set_default_prompt_responder, PromptResponse,
+        ScriptedResponder,
+    };
     use std::process::Command;
+    use std::sync::Arc;
     use tempfile::TempDir;
+
+    struct PromptResponderGuard;
+
+    impl PromptResponderGuard {
+        fn install(responses: impl IntoIterator<Item = PromptResponse>) -> Self {
+            set_default_prompt_responder(Arc::new(ScriptedResponder::new(responses)));
+            Self
+        }
+    }
+
+    impl Drop for PromptResponderGuard {
+        fn drop(&mut self) {
+            reset_default_prompt_responder();
+        }
+    }
 
     fn required_string(name: impl Into<String>) -> CommandInput {
         CommandInput {
@@ -3417,6 +3438,57 @@ mod tests {
         assert_eq!(
             ProjectSpec::from_answers(from_file).unwrap(),
             ProjectSpec::from_answers(from_stdin).unwrap()
+        );
+    }
+
+    #[test]
+    #[serial(prompt_responder)]
+    fn interactive_file_and_stdin_decode_to_identical_answers_and_specs() {
+        use standout_input::questionnaire::QuestionnaireInput;
+
+        let sheet = minimal_sheet();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("answers.txt");
+        fs::write(&path, &sheet).unwrap();
+        let questionnaire = questionnaire();
+
+        let _guard = PromptResponderGuard::install([
+            PromptResponse::text("hello-tool"),
+            PromptResponse::Skip,
+            PromptResponse::text("greet"),
+            PromptResponse::text("Greet one value"),
+            PromptResponse::text("name"),
+            PromptResponse::Skip,
+            PromptResponse::Skip,
+            PromptResponse::Skip,
+            PromptResponse::Skip,
+            PromptResponse::Skip,
+            PromptResponse::Skip,
+        ]);
+        let interactive_raw = questionnaire.collect_interactive().unwrap();
+        let from_file_raw = questionnaire.read_answer_sheet_file(&path).unwrap();
+        let from_stdin_raw = questionnaire
+            .read_answer_sheet_stdin_with(&standout_input::MockStdin::piped(&sheet))
+            .unwrap();
+
+        let from_interactive =
+            NewProjectAnswers::from_raw_answers_with(&interactive_raw, new_project_form_rules)
+                .unwrap();
+        let from_file =
+            NewProjectAnswers::from_raw_answers_with(&from_file_raw, new_project_form_rules)
+                .unwrap();
+        let from_stdin =
+            NewProjectAnswers::from_raw_answers_with(&from_stdin_raw, new_project_form_rules)
+                .unwrap();
+
+        assert_eq!(from_interactive, from_file);
+        assert_eq!(from_interactive, from_stdin);
+        let spec = ProjectSpec::from_answers(from_interactive).unwrap();
+        assert_eq!(spec, ProjectSpec::from_answers(from_file).unwrap());
+        assert_eq!(spec, ProjectSpec::from_answers(from_stdin).unwrap());
+        assert_eq!(
+            spec.inputs[0].sources,
+            vec![InputSource::Argument, InputSource::File, InputSource::Stdin,]
         );
     }
 }

--- a/crates/standout/src/bin/standout.rs
+++ b/crates/standout/src/bin/standout.rs
@@ -39,16 +39,19 @@ fn build_app() -> Result<App> {
         .command_with("new-project", run_new_project, |config| {
             config
                 .template("{{ transcript }}")
-                .questionnaire_with_form::<NewProjectAnswers, _>(new_project_form_rules)
+                .questionnaire_with_form_and_review::<NewProjectAnswers, _, _>(
+                    new_project_form_rules,
+                    write_new_project_review,
+                )
         })?
         .build()?)
 }
 
 /// Generate a project from the typed questionnaire value collected by the
 /// framework-injected `new-project` surface. The framework owns collection,
-/// `--answers`/`questions`, dynamic defaults, and the attended confirmation
-/// gate before this handler runs; the binary owns review text, final
-/// publication, and project-specific validation.
+/// `--answers`/`questions`, dynamic defaults, the binary's pre-confirmation
+/// review callback, and the attended confirmation gate before this handler
+/// runs; the handler owns final publication.
 fn run_new_project(
     _matches: &clap::ArgMatches,
     ctx: &CommandContext,
@@ -56,13 +59,20 @@ fn run_new_project(
     let answers: &NewProjectAnswers = ctx.questionnaire()?;
     let spec = ProjectSpec::from_answers(answers.clone())?;
     let mut transcript = Vec::new();
-    write_review(&spec, &mut transcript)?;
     publish_project(&spec)?;
     writeln!(transcript, "Created {}", spec.destination.display())?;
     Ok(HandlerOutput::Render(json!({
         "transcript": String::from_utf8(transcript)
             .expect("wizard transcript is generated from UTF-8 literals and paths"),
     })))
+}
+
+fn write_new_project_review(
+    answers: &NewProjectAnswers,
+    output: &mut dyn Write,
+) -> anyhow::Result<()> {
+    let spec = ProjectSpec::from_answers(answers.clone())?;
+    write_review(&spec, output)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, standout::Questionnaire)]
@@ -2157,8 +2167,8 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use standout_input::{
-        reset_default_prompt_responder, set_default_prompt_responder, PromptResponse,
-        ScriptedResponder,
+        questionnaire::QuestionnaireInput, reset_default_prompt_responder,
+        set_default_prompt_responder, PromptResponse, ScriptedResponder,
     };
     use std::process::Command;
     use std::sync::Arc;
@@ -3244,13 +3254,147 @@ mod tests {
     }
 
     fn questionnaire() -> standout_input::questionnaire::Questionnaire {
-        use standout_input::questionnaire::QuestionnaireInput;
         NewProjectAnswers::questionnaire().unwrap()
     }
 
-    fn decode_sheet(sheet: &str) -> Result<NewProjectAnswers, Vec<String>> {
-        use standout_input::questionnaire::QuestionnaireInput;
+    fn hand_built_questionnaire() -> standout_input::questionnaire::Questionnaire {
+        use standout_input::questionnaire::{
+            DynamicDefault, FieldValidator, Group, Item, QuestionnaireChoices as _, ScalarField,
+            ScalarKind,
+        };
 
+        standout_input::questionnaire::Questionnaire::new(
+            "standout.new-project",
+            vec![
+                Item::from(Group::new(
+                    "project",
+                    "Project identity.",
+                    vec![
+                        ScalarField::new(
+                            "project.name",
+                            "What is the project name? It is also the destination directory.",
+                            ScalarKind::String,
+                        )
+                        .with_validator(FieldValidator::new(
+                            "crate-name.v1",
+                            validate_project_name,
+                        )),
+                        ScalarField::new(
+                            "project.executable",
+                            "What is the executable name? Leave blank to reuse the project name.",
+                            ScalarKind::String,
+                        )
+                        .with_dynamic_default(DynamicDefault::new(
+                            "crate-name.v2",
+                            executable_default,
+                        ))
+                        .with_validator(FieldValidator::new(
+                            "crate-name.v2",
+                            validate_executable_name,
+                        )),
+                    ],
+                )),
+                Item::from(Group::new(
+                    "command",
+                    "Initial command.",
+                    vec![
+                        Item::from(
+                            ScalarField::new(
+                                "command.name",
+                                "What is the command name?",
+                                ScalarKind::String,
+                            )
+                            .with_validator(FieldValidator::new(
+                                "command-name.v1",
+                                validate_command_answer,
+                            )),
+                        ),
+                        Item::from(ScalarField::new(
+                            "command.description",
+                            "Describe the command in a sentence or two.",
+                            ScalarKind::Text,
+                        )),
+                        Item::from(
+                            Group::new(
+                                "command.inputs",
+                                "Describe a command input.",
+                                vec![
+                                    ScalarField::new(
+                                        "command.inputs.name",
+                                        "What is its name?",
+                                        ScalarKind::String,
+                                    )
+                                    .with_validator(FieldValidator::new(
+                                        "input-name.v1",
+                                        validate_input_name,
+                                    )),
+                                    ScalarField::new(
+                                        "command.inputs.value_type",
+                                        "What type of value is it?",
+                                        ScalarKind::String,
+                                    )
+                                    .one_of(InputValueType::choices().iter().copied())
+                                    .with_default("string"),
+                                    ScalarField::new(
+                                        "command.inputs.cardinality",
+                                        "How many values does it take?",
+                                        ScalarKind::String,
+                                    )
+                                    .one_of(InputCardinality::choices().iter().copied())
+                                    .with_dynamic_default(DynamicDefault::new(
+                                        "input-cardinality-default.v1",
+                                        cardinality_default,
+                                    )),
+                                    ScalarField::new(
+                                        "command.inputs.sources",
+                                        "Where can its value come from, in precedence order (comma-separated: argument, file, stdin)?",
+                                        ScalarKind::String,
+                                    )
+                                    .with_dynamic_default(DynamicDefault::new(
+                                        "input-sources.v2",
+                                        sources_default,
+                                    ))
+                                    .with_validator(FieldValidator::new(
+                                        "input-sources.v2",
+                                        validate_sources_answer,
+                                    )),
+                                ],
+                            )
+                            .repeatable(1),
+                        ),
+                    ],
+                )),
+                Item::from(Group::new(
+                    "result",
+                    "Result shape.",
+                    vec![
+                        ScalarField::new(
+                            "result.shape",
+                            "Should the result be a message or a record?",
+                            ScalarKind::String,
+                        )
+                        .one_of(ResultShape::choices().iter().copied())
+                        .with_default("record"),
+                        ScalarField::new(
+                            "result.fields",
+                            "Which fields should the record carry (comma-separated)?",
+                            ScalarKind::String,
+                        )
+                        .optional()
+                        .with_default("summary,count")
+                        .active_when("result.shape", "record")
+                        .with_validator(FieldValidator::new(
+                            "record-fields.v1",
+                            validate_record_fields_answer,
+                        )),
+                    ],
+                )),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn decode_sheet(sheet: &str) -> Result<NewProjectAnswers, Vec<String>> {
         let questionnaire = questionnaire();
         let raw = questionnaire
             .parse_answer_sheet(sheet)
@@ -3295,6 +3439,15 @@ mod tests {
         assert!(sheet.contains("string, bool, or path"));
         assert!(sheet.contains("required, optional, repeated, or boolean"));
         assert!(sheet.contains("message or record"));
+    }
+
+    #[test]
+    fn derived_wizard_schema_matches_hand_built_definition_and_fingerprint() {
+        let derived = questionnaire();
+        let hand_built = hand_built_questionnaire();
+
+        assert_eq!(derived, hand_built);
+        assert_eq!(derived.fingerprint(), hand_built.fingerprint());
     }
 
     #[test]
@@ -3415,8 +3568,6 @@ mod tests {
 
     #[test]
     fn file_and_stdin_sheets_decode_to_identical_answers_and_specs() {
-        use standout_input::questionnaire::QuestionnaireInput;
-
         let sheet = minimal_sheet();
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("answers.txt");
@@ -3444,8 +3595,6 @@ mod tests {
     #[test]
     #[serial(prompt_responder)]
     fn interactive_file_and_stdin_decode_to_identical_answers_and_specs() {
-        use standout_input::questionnaire::QuestionnaireInput;
-
         let sheet = minimal_sheet();
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("answers.txt");

--- a/crates/standout/src/cli/group.rs
+++ b/crates/standout/src/cli/group.rs
@@ -15,7 +15,8 @@ use super::dispatch::{render_handler_output, DispatchFn};
 use crate::cli::handler::{CommandContext, FnHandler, Handler, HandlerResult};
 use crate::cli::hooks::{Hooks, RenderedOutput, TextOutput};
 use crate::cli::questionnaire::{
-    questionnaire_pre_dispatch, questionnaire_pre_dispatch_with, QuestionnaireCommand,
+    questionnaire_pre_dispatch, questionnaire_pre_dispatch_with,
+    questionnaire_pre_dispatch_with_review, QuestionnaireCommand,
 };
 use crate::StructuredOutputProjection;
 use standout_dispatch::verify::ExpectedArg;
@@ -497,10 +498,12 @@ impl<H> CommandConfig<H> {
     /// command at parse time: `--answers FILE|-`, `--yes`, and the
     /// side-effect-free `questions` subcommand. Before the handler runs, the
     /// framework resolves exactly one answer source (answer sheet file,
-    /// explicit stdin, or interactive prompts), decodes it through the shared
-    /// questionnaire pipeline, runs the attended confirmation gate unless
-    /// `--yes` was supplied, and stores the typed value in the command
-    /// context. Handlers read it with
+    /// explicit stdin, or interactive prompts), decodes it through the
+    /// shared questionnaire pipeline, optionally renders an application
+    /// review configured with
+    /// [`questionnaire_with_form_and_review`](Self::questionnaire_with_form_and_review),
+    /// runs the attended confirmation gate unless `--yes` was supplied, and
+    /// stores the typed value in the command context. Handlers read it with
     /// [`CommandContextInput::questionnaire`](crate::cli::CommandContextInput::questionnaire).
     pub fn questionnaire<T>(mut self) -> Self
     where
@@ -524,6 +527,31 @@ impl<H> CommandConfig<H> {
         self.questionnaire = Some(QuestionnaireCommand::new::<T>());
         self.pre_dispatch(move |matches, ctx| {
             questionnaire_pre_dispatch_with::<T, _>(matches, ctx, form.clone())
+        })
+    }
+
+    /// Attaches a derived questionnaire with whole-form rules and a
+    /// pre-confirmation application review.
+    ///
+    /// The framework first resolves and decodes the questionnaire, then calls
+    /// `review` with the typed answers and stdout before it asks for attended
+    /// confirmation. A declined or missing confirmation prevents the handler
+    /// from running, so applications can show the exact operation that would
+    /// happen while keeping side effects behind the confirmation gate.
+    pub fn questionnaire_with_form_and_review<T, F, R>(mut self, form: F, review: R) -> Self
+    where
+        T: QuestionnaireInput + Clone + Send + Sync + 'static,
+        F: Fn(&T) -> Vec<FormError> + Clone + 'static,
+        R: Fn(&T, &mut dyn std::io::Write) -> anyhow::Result<()> + Clone + 'static,
+    {
+        self.questionnaire = Some(QuestionnaireCommand::new::<T>());
+        self.pre_dispatch(move |matches, ctx| {
+            questionnaire_pre_dispatch_with_review::<T, _, _>(
+                matches,
+                ctx,
+                form.clone(),
+                review.clone(),
+            )
         })
     }
 

--- a/crates/standout/src/cli/questionnaire.rs
+++ b/crates/standout/src/cli/questionnaire.rs
@@ -2,7 +2,9 @@
 //!
 //! A command configured with a questionnaire gets reserved clap surface from
 //! the app builder (`--answers`, `--yes`, and a `questions` subcommand). The
-//! handler then reads the filled application type from
+//! framework resolves and validates the filled application type before
+//! dispatch, optionally lets the application render a review, runs the
+//! attended confirmation gate, and then the handler reads the filled type from
 //! [`CommandContextInput::questionnaire`](crate::cli::CommandContextInput::questionnaire).
 //! File and stdin sheets keep non-fatal parse diagnostics visible by queuing
 //! their `RawAnswers` warnings for the framework warning flush.
@@ -90,6 +92,20 @@ where
     T: QuestionnaireInput + Clone + Send + Sync + 'static,
     F: FnOnce(&T) -> Vec<FormError>,
 {
+    questionnaire_pre_dispatch_with_review::<T, F, _>(matches, ctx, form, |_, _| Ok(()))
+}
+
+pub(crate) fn questionnaire_pre_dispatch_with_review<T, F, R>(
+    matches: &ArgMatches,
+    ctx: &mut CommandContext,
+    form: F,
+    review: R,
+) -> Result<(), HookError>
+where
+    T: QuestionnaireInput + Clone + Send + Sync + 'static,
+    F: FnOnce(&T) -> Vec<FormError>,
+    R: FnOnce(&T, &mut dyn Write) -> anyhow::Result<()>,
+{
     let sub_matches = get_deepest_matches(matches);
     let resolved = collect_questionnaire_with::<T, F>(sub_matches, form).map_err(|error| {
         HookError::pre_dispatch(format!(
@@ -98,6 +114,15 @@ where
     })?;
 
     let assume_yes = sub_matches.get_flag(YES_ARG_ID);
+    {
+        let stdout = io::stdout();
+        let mut stdout = stdout.lock();
+        review(&resolved.value, &mut stdout)
+            .map_err(|error| HookError::pre_dispatch(error.to_string()))?;
+        stdout
+            .flush()
+            .map_err(|error| HookError::pre_dispatch(error.to_string()))?;
+    }
     if !assume_yes
         && !confirm_attended_from_env()
             .map_err(|error| HookError::pre_dispatch(error.to_string()))?

--- a/crates/standout/tests/new_project_answer_sheets.rs
+++ b/crates/standout/tests/new_project_answer_sheets.rs
@@ -81,6 +81,19 @@ fn stderr(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
 }
 
+fn assert_in_order(text: &str, earlier: &str, later: &str) {
+    let earlier_at = text
+        .find(earlier)
+        .unwrap_or_else(|| panic!("missing {earlier:?} in:\n{text}"));
+    let later_at = text
+        .find(later)
+        .unwrap_or_else(|| panic!("missing {later:?} in:\n{text}"));
+    assert!(
+        earlier_at < later_at,
+        "expected {earlier:?} before {later:?} in:\n{text}"
+    );
+}
+
 /// The entries of `dir`, sorted, for whole-directory no-partial-write
 /// assertions (a failed run must leave nothing behind — no destination and
 /// no staging leftovers).
@@ -218,6 +231,12 @@ fn answers_file_generates_after_review_and_attended_confirmation() {
     assert!(transcript.contains("Continue? Type 'yes' to continue:"));
     assert!(transcript.contains("Review"));
     assert!(transcript.contains("Created hello-tool"));
+    assert_in_order(&transcript, "Review", "Continue? Type 'yes' to continue:");
+    assert_in_order(
+        &transcript,
+        "Continue? Type 'yes' to continue:",
+        "Created hello-tool",
+    );
     let destination = dir.path().join("hello-tool");
     assert!(destination.join("Cargo.toml").is_file());
     assert!(destination.join("crates/hello-tool/src/main.rs").is_file());
@@ -237,6 +256,11 @@ fn rejected_confirmation_leaves_the_destination_unwritten() {
     );
 
     assert!(!output.status.success());
+    let transcript = stdout(&output);
+    assert!(transcript.contains("Review"));
+    assert!(transcript.contains("Continue? Type 'yes' to continue:"));
+    assert!(!transcript.contains("Created hello-tool"));
+    assert_in_order(&transcript, "Review", "Continue? Type 'yes' to continue:");
     assert!(stderr(&output).contains("confirmation declined; nothing was run"));
     assert_eq!(dir_entries(dir.path()), ["answers.txt"]);
 }
@@ -258,6 +282,12 @@ fn stdin_sheet_generates_after_review_and_attended_confirmation() {
     assert!(transcript.contains("Continue? Type 'yes' to continue:"));
     assert!(transcript.contains("Review"));
     assert!(transcript.contains("Created hello-tool"));
+    assert_in_order(&transcript, "Review", "Continue? Type 'yes' to continue:");
+    assert_in_order(
+        &transcript,
+        "Continue? Type 'yes' to continue:",
+        "Created hello-tool",
+    );
     assert!(dir.path().join("hello-tool/Cargo.toml").is_file());
     assert_eq!(dir_entries(dir.path()), ["hello-tool"]);
 }
@@ -275,6 +305,11 @@ fn stdin_sheet_rejected_on_the_terminal_writes_nothing() {
     );
 
     assert!(!output.status.success());
+    let transcript = stdout(&output);
+    assert!(transcript.contains("Review"));
+    assert!(transcript.contains("Continue? Type 'yes' to continue:"));
+    assert!(!transcript.contains("Created hello-tool"));
+    assert_in_order(&transcript, "Review", "Continue? Type 'yes' to continue:");
     assert!(stderr(&output).contains("confirmation declined; nothing was run"));
     assert!(dir_entries(dir.path()).is_empty());
 }
@@ -287,6 +322,7 @@ fn stdin_sheet_without_a_terminal_fails_before_publication_with_guidance() {
     let output = run_standout(dir.path(), &["new-project", "--answers", "-"], &sheet);
 
     assert!(!output.status.success());
+    assert!(stdout(&output).contains("Review"));
     let errors = stderr(&output);
     assert!(errors.contains("attended terminal"));
     assert!(errors.contains("--yes"));


### PR DESCRIPTION
for #276

## Context

This follow-up pins the final WS06 acceptance property that the already-rewritten `standout new-project` wizard decodes equivalent interactive prompts, `--answers FILE`, and `--answers -` submissions into the same typed `NewProjectAnswers` and equal `ProjectSpec` values. The production implementation remains the derived questionnaire client: one derived answer struct plus choice enums, framework-injected `--answers`/`questions`/`--yes`, and app-side whole-form rules.

Self-check: read and checked this against `docs/spec/derived-questionnaires.md`, ADRs 0015-0017, and `docs/guides/bootstrap-a-project.md`. No guide update is needed because the final injected CLI surface and dynamic-default behavior were already documented.

Out of scope: new wizard features, local questionnaire plumbing, binary-local prompt loops/parsers, or changes to the framework collection surface. Do not reintroduce a local wizard workaround for collection parity; this test verifies the framework path.

Verification:

- `cargo test -p standout interactive_file_and_stdin_decode_to_identical_answers_and_specs --bin standout`
- `pixi run lint --fix`
- `pixi run test`
- commit and push hooks: `pixi run lint`
